### PR TITLE
ci(docker): publish images only from releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish Image
 
 on:
-  push:
-    branches:
-      - main
   release:
     types:
       - published
@@ -40,7 +37,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=nightly,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=sha-

--- a/README.md
+++ b/README.md
@@ -115,14 +115,10 @@ docker compose --env-file .compose.env down
 
 ## GitHub Actions Publishing
 
-This repo publishes `ghcr.io/samaluk/fintual-api` in two channels:
-
-- pushes to `main` publish a rolling `nightly` image plus `sha-<commit>`
-- GitHub Releases publish stable release images
+This repo publishes `ghcr.io/samaluk/fintual-api` from GitHub Releases.
 
 Published tags:
 
-- `nightly` from `main`
 - `sha-<commit>`
 - `latest` from GitHub Releases
 - the GitHub Release tag itself, such as `v1.0.0`


### PR DESCRIPTION
## What
- remove image publishing on pushes to `main`
- keep image publishing for GitHub Releases and manual workflow dispatches
- update the README to match the release-only publishing model

## Why
- avoid publishing new images for every merge to `main`
- keep stable image publication tied to explicit GitHub Releases

## Verify
- pushing to `main` no longer triggers `Publish Image`
- creating a GitHub Release still publishes `latest`, `sha-<commit>`, and the release tag