### PR TITLE
chore(renovate): add repo update policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:recommended",
+		":disableRateLimiting"
+	],
+	"packageRules": [
+		{
+			"minimumReleaseAge": "3 days"
+		},
+		{
+			"matchPackageNames": [
+				"@actual-app/api"
+			],
+			"minimumReleaseAge": null
+		}
+	]
+}


### PR DESCRIPTION
## What
- add a repo-level `renovate.json`
- require a 3 day minimum release age by default
- allow `@actual-app/api` updates immediately

## Why
- keep dependency updates visible without automerging anything
- let most releases settle for a few days
- surface `@actual-app/api` updates quickly because it is central to the sync reliability issues

## Verify
- Renovate detects the new config
- non-Actual dependency updates respect the 3 day minimum release age
- `@actual-app/api` updates are not delayed by minimum release age