### PR TITLE
fix(renovate): use a valid minimum release age override

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,13 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"config:recommended",
-		":disableRateLimiting"
-	],
+	"extends": ["config:recommended", ":disableRateLimiting"],
 	"packageRules": [
 		{
 			"minimumReleaseAge": "3 days"
 		},
 		{
-			"matchPackageNames": [
-				"@actual-app/api"
-			],
-			"minimumReleaseAge": null
+			"matchPackageNames": ["@actual-app/api"],
+			"minimumReleaseAge": "0 days"
 		}
 	]
 }


### PR DESCRIPTION
## What
- replace the invalid `null` `minimumReleaseAge` override with `"0 days"` for `@actual-app/api`

## Why
- Renovate rejects the repo config when `minimumReleaseAge` is `null`
- `"0 days"` preserves the intended behavior of allowing immediate `@actual-app/api` updates

## Verify
- Renovate accepts the repository config again
- `@actual-app/api` updates are not delayed by the default 3 day minimum release age