### PR TITLE
ci: PR workflow for Docker build

### DIFF
--- a/.github/workflows/pr-docker.yml
+++ b/.github/workflows/pr-docker.yml
@@ -1,0 +1,32 @@
+name: PR Docker
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: pr-docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          tags: fintual-api:pr
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add `.github/workflows/pr-docker.yml` to build the Docker image on pull requests to `main` (no push to a registry).

## Test plan
- [x] Workflow validates `docker build` with Buildx and GHA cache.

Made with [Cursor](https://cursor.com)