### PR TITLE
fix: fail Actual sync on upload errors

### DIFF
--- a/src/actual.ts
+++ b/src/actual.ts
@@ -187,6 +187,11 @@ function syncDailyVariationTransactions(): Effect.Effect<SyncCounts, Error> {
       )
     }
 
+    yield* tryPromise({
+      try: () => api.sync(),
+      catch: "Failed to sync Actual budget",
+    })
+
     return syncCounts
   })
 }


### PR DESCRIPTION
## Summary
- Add an explicit Actual sync after transaction writes so upload failures are surfaced before success is reported.
- Let transient Actual network failures use the existing retry/backoff path instead of being swallowed by shutdown.

## Checks
- pnpm typecheck
- pnpm lint
- pnpm format:check