### PR TITLE
fix: dispatch publish workflow after renovate release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to publish
+        required: true
+        type: string
 
 env:
   REGISTRY: docker.io
@@ -19,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -36,8 +43,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' || inputs.release_tag != '' }}
+            type=raw,value=${{ github.event.release.tag_name || inputs.release_tag }},enable=${{ github.event_name == 'release' || inputs.release_tag != '' }}
             type=sha,prefix=sha-
           labels: |
             org.opencontainers.image.title=fintual-api

--- a/.github/workflows/renovate-actual-api-release.yml
+++ b/.github/workflows/renovate-actual-api-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   create-release:
@@ -75,3 +76,9 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger publish workflow
+        if: steps.detect.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish.yml --ref ${{ github.event.repository.default_branch }} -f release_tag=${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## Issues relacionados

N/A

## Summary

- Dispatch `publish.yml` after the Renovate Actual API release workflow creates a GitHub release.
- Allow `publish.yml` to run manually with a `release_tag` input.
- Checkout and tag the Docker image using the release tag from either the release event or manual dispatch input.

## Testing

- Parsed the updated workflow YAML with Ruby.
- `actionlint` was not available locally.