### PR TITLE
fix: publish version tag for tag dispatches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       release_tag:
         description: Release tag to publish
-        required: true
+        required: false
         type: string
 
 env:
@@ -20,12 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag || (github.ref_type == 'tag' && github.ref_name) || '' }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
+          ref: ${{ env.RELEASE_TAG || github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -43,8 +45,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable=${{ github.event_name == 'release' || inputs.release_tag != '' }}
-            type=raw,value=${{ github.event.release.tag_name || inputs.release_tag }},enable=${{ github.event_name == 'release' || inputs.release_tag != '' }}
+            type=raw,value=latest,enable=${{ env.RELEASE_TAG != '' }}
+            type=raw,value=${{ env.RELEASE_TAG }},enable=${{ env.RELEASE_TAG != '' }}
             type=sha,prefix=sha-
           labels: |
             org.opencontainers.image.title=fintual-api


### PR DESCRIPTION
## Summary
- Derive the Docker release tag from the release event, workflow input, or tag ref.
- Make manual publish runs against a tag produce `latest` and the version-specific Docker tag, not only `sha-*`.

## Testing
- Parsed updated workflow YAML with Ruby.