### PR TITLE
chore(renovate): ignore bogus mcuadros/ofelia v3.0.8 tag

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
 	"packageRules": [
 		{
 			"matchPackageNames": [
+				"mcuadros/ofelia"
+			],
+			"allowedVersions": "!/^v3\\.0\\.8$/"
+		},
+		{
+			"matchPackageNames": [
 				"@actual-app/api"
 			],
 			"minimumReleaseAge": "0 days",


### PR DESCRIPTION
## Summary

- Exclude Docker tag `v3.0.8` from Renovate updates for `mcuadros/ofelia`
- Workaround for [mcuadros/ofelia#399](https://github.com/mcuadros/ofelia/issues/399): a stale `v3.0.8` tag on Docker Hub is semver-sorted above `v0.3.x` and triggers incorrect upgrade PRs

## Test plan

- [ ] Confirm Renovate no longer proposes `mcuadros/ofelia` `v3.0.8`
- [ ] Confirm legitimate `v0.3.x` updates are still offered