### PR TITLE
fix(ci): Renovate auto-merge workflow permissions

### DIFF
--- a/.github/workflows/renovate-actual-api-auto-merge.yml
+++ b/.github/workflows/renovate-actual-api-auto-merge.yml
@@ -1,14 +1,14 @@
 name: Renovate Actual API Auto-Merge
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
       - reopened
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

- Switch Renovate auto-merge workflow from `pull_request_target` to `pull_request` so permission updates apply from the PR branch
- Grant `contents: write` so `enablePullRequestAutoMerge` is allowed for the integration token

## Context

PR #141 CI fails on `enablePullRequestAutoMerge` with "Resource not accessible by integration". The workflow on `main` only has `contents: read`, and `pull_request_target` always runs the workflow definition from the base branch.

Merge this before (or alongside) the Renovate dependency PR so auto-merge can be enabled.

## Test plan

- [ ] Merge this PR
- [ ] Re-run Renovate Actual API Auto-Merge on PR #141