### PR TITLE
chore(deps): update pnpm to v11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fintual-api",
-	"packageManager": "pnpm@11.11.0",
+	"packageManager": "pnpm@11.13.0",
 	"type": "module",
 	"devDependencies": {
 		"@types/mailparser": "3.4.6",


### PR DESCRIPTION
## Summary
- Bump `packageManager` from `pnpm@11.11.0` to `pnpm@11.13.0`
- Skips broken `11.12.0`, which fails in `pnpm/action-setup` with `Cannot use 'in' operator to search for 'integrity'`

Leaves Renovate's [#210](https://github.com/samaluk/fintual-api/pull/210) (`11.12.0`) alone so Renovate can manage that update independently.

## Test plan
- [x] CI `lint-and-typecheck` / `docker-build` pass on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package management tooling version used by the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->