### PR TITLE
chore(pnpm): enable minimum release age strict mode

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 allowBuilds:
   better-sqlite3: true
   fallow: true
+minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:
   - '@actual-app/api'
   - '@actual-app/core'


### PR DESCRIPTION
Enables `minimumReleaseAgeStrict: true` in pnpm-workspace.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added stricter minimum release-age enforcement for package updates to improve dependency stability and reduce exposure to newly published issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->