### PR TITLE
Replace pnpm action setup

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.10
+        uses: pnpm/setup@v2.0.2
         with:
-          run_install: false
+          install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v7.0.0


### PR DESCRIPTION
## Summary

- replace `pnpm/action-setup@v6.0.10` with `pnpm/setup@v2.0.2` in the PR Check workflow
- replace the legacy `run_install` input with the new action's `install` input

## Why

Use the new pnpm setup action and its current release while preserving the workflow's existing explicit dependency installation step.

## Impact

The workflow continues to set up pnpm without automatically installing dependencies; the existing `pnpm install --frozen-lockfile` step remains responsible for installation.

## Validation

- `actionlint .github/workflows/pr-check.yml`
- `git diff --check`