### PR TITLE
ci: pin GitHub Actions digests with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
 		"config:recommended",
-		":disableRateLimiting"
+		":disableRateLimiting",
+		"helpers:pinGitHubActionDigests"
 	],
 	"rangeStrategy": "pin",
 	"minimumReleaseAge": "3 days",


### PR DESCRIPTION
Adds `helpers:pinGitHubActionDigests` to the Renovate extends list so GitHub Actions are pinned to commit SHA digests.