### PR TITLE
chore: baseline TypeScript escape-hatch lint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,33 @@
+{
+	"plugins": [
+		"typescript"
+	],
+	"options": {
+		"typeAware": true
+	},
+	"rules": {
+		"typescript/ban-ts-comment": [
+			"error",
+			{
+				"ts-ignore": true,
+				"ts-nocheck": true,
+				"ts-expect-error": "allow-with-description"
+			}
+		],
+		"typescript/consistent-type-assertions": [
+			"error",
+			{
+				"assertionStyle": "never"
+			}
+		],
+		"typescript/no-explicit-any": "error",
+		"typescript/no-non-null-assertion": "error",
+		"typescript/no-unsafe-argument": "error",
+		"typescript/no-unsafe-assignment": "error",
+		"typescript/no-unsafe-call": "error",
+		"typescript/no-unsafe-member-access": "error",
+		"typescript/no-unsafe-return": "error",
+		"typescript/no-unsafe-type-assertion": "error",
+		"typescript/no-unnecessary-type-assertion": "error"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"fallow": "3.14.0",
 		"oxfmt": "0.62.0",
 		"oxlint": "1.77.0",
+		"oxlint-tsgolint": "7.0.2001",
 		"typescript": "7.0.2"
 	},
 	"dependencies": {
@@ -22,7 +23,7 @@
 		"typecheck": "tsc -p tsconfig.json",
 		"format": "oxfmt --write src",
 		"format:check": "oxfmt --check src",
-		"lint": "oxlint src",
+		"lint": "oxlint --report-unused-disable-directives src",
 		"lint:fix": "oxlint --fix src",
 		"fallow": "fallow",
 		"fallow:status": "fallow type-aware status",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,10 @@ importers:
         version: 0.62.0
       oxlint:
         specifier: 1.77.0
-        version: 1.77.0
+        version: 1.77.0(oxlint-tsgolint@7.0.2001)
+      oxlint-tsgolint:
+        specifier: 7.0.2001
+        version: 7.0.2001
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -223,6 +226,36 @@ packages:
   '@oxfmt/binding-win32-x64-msvc@0.62.0':
     resolution: {integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    resolution: {integrity: sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    resolution: {integrity: sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    resolution: {integrity: sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    resolution: {integrity: sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    resolution: {integrity: sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
+    resolution: {integrity: sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog==}
     cpu: [x64]
     os: [win32]
 
@@ -736,6 +769,10 @@ packages:
       vite-plus:
         optional: true
 
+  oxlint-tsgolint@7.0.2001:
+    resolution: {integrity: sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==}
+    hasBin: true
+
   oxlint@1.77.0:
     resolution: {integrity: sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1047,6 +1084,24 @@ snapshots:
     optional: true
 
   '@oxfmt/binding-win32-x64-msvc@0.62.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.77.0':
@@ -1459,7 +1514,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.62.0
       '@oxfmt/binding-win32-x64-msvc': 0.62.0
 
-  oxlint@1.77.0:
+  oxlint-tsgolint@7.0.2001:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 7.0.2001
+      '@oxlint-tsgolint/darwin-x64': 7.0.2001
+      '@oxlint-tsgolint/linux-arm64': 7.0.2001
+      '@oxlint-tsgolint/linux-x64': 7.0.2001
+      '@oxlint-tsgolint/win32-arm64': 7.0.2001
+      '@oxlint-tsgolint/win32-x64': 7.0.2001
+
+  oxlint@1.77.0(oxlint-tsgolint@7.0.2001):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.77.0
       '@oxlint/binding-android-arm64': 1.77.0
@@ -1480,6 +1544,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.77.0
       '@oxlint/binding-win32-ia32-msvc': 1.77.0
       '@oxlint/binding-win32-x64-msvc': 1.77.0
+      oxlint-tsgolint: 7.0.2001
 
   parseley@0.13.1:
     dependencies:

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -209,6 +209,7 @@ function resetDataDirectory(): Effect.Effect<void, Error> {
 function loadBalanceEntries(): Effect.Effect<BalanceEntry[], Error> {
   return Effect.gen(function* () {
     const parsedFile = yield* trySync({
+      // oxlint-disable-next-line typescript/consistent-type-assertions
       try: () => JSON.parse(fs.readFileSync(BALANCE_FILE_PATH, "utf-8")) as unknown,
       catch: "Failed to load Fintual balance file",
     })

--- a/src/fintual/email-2fa.ts
+++ b/src/fintual/email-2fa.ts
@@ -218,6 +218,7 @@ function runMailboxSearch(
           catch: "Failed to search Gmail IMAP mailbox",
         }),
         (cause) => {
+          // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
           const originalError = cause.cause as { code?: string } | undefined
           if (originalError?.code === "MissingServerExtension") {
             return Effect.succeed(false as const)
@@ -336,9 +337,12 @@ function collectMessageSources(
 }
 
 function decodeQuotedPrintable(value: string): string {
-  return value
-    .replaceAll(/=\r?\n/g, "")
-    .replaceAll(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+  return (
+    value
+      .replaceAll(/=\r?\n/g, "")
+      // oxlint-disable-next-line typescript/no-unsafe-argument
+      .replaceAll(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+  )
 }
 
 function extractCodeFromText(rawContent: string): string | null {

--- a/src/fintual/new-performance.ts
+++ b/src/fintual/new-performance.ts
@@ -41,6 +41,7 @@ function parseGoalPerformanceJsonText(body: string): Effect.Effect<GoalPerforman
   return Effect.gen(function* () {
     const parsedJson = yield* Effect.catchAll(
       trySync({
+        // oxlint-disable-next-line typescript/consistent-type-assertions
         try: () => JSON.parse(body) as unknown,
         catch: "Failed to parse goal performance response body",
       }),


### PR DESCRIPTION
## Summary

Enables strict Oxlint enforcement against TypeScript escape hatches and baselines all pre-existing violations with narrow inline suppressions. No underlying TypeScript debt was fixed in this change.

### Rules enabled (all at `error`)

| Rule | Notes |
| --- | --- |
| `typescript/consistent-type-assertions` | `assertionStyle: "never"`; `as const` remains allowed |
| `typescript/no-unsafe-type-assertion` | type-aware |
| `typescript/no-unnecessary-type-assertion` | type-aware |
| `typescript/no-explicit-any` | |
| `typescript/no-non-null-assertion` | |
| `typescript/no-unsafe-assignment` | type-aware |
| `typescript/no-unsafe-argument` | type-aware |
| `typescript/no-unsafe-call` | type-aware |
| `typescript/no-unsafe-member-access` | type-aware |
| `typescript/no-unsafe-return` | type-aware |
| `typescript/ban-ts-comment` | `ts-ignore: true` (banned), `ts-nocheck: true` (banned), `ts-expect-error: "allow-with-description"` |

### Type-aware linting

Newly enabled: installed `oxlint-tsgolint@7.0.2001` (peer dep of oxlint 1.77.0, matches repo's exact-pin convention) and set `options.typeAware: true` in the new root `.oxlintrc.json`. Type-aware rules now run in the normal `pnpm lint` / CI path. The separate `pnpm run typecheck` (tsc) is kept unchanged.

### Baseline

4 inline suppressions cover 5 pre-existing violations, all `oxlint-disable-next-line`:

| Rule | Suppressions |
| --- | --- |
| `typescript/consistent-type-assertions` | 3 |
| `typescript/no-unsafe-type-assertion` | 1 |
| `typescript/no-unsafe-argument` | 1 |

(`src/fintual/email-2fa.ts:221` needed both `consistent-type-assertions` and `no-unsafe-type-assertion` on one line.)

Also added `--report-unused-disable-directives` to the lint script so stale suppressions fail CI once the underlying debt is fixed.

### Generated/vendor exclusions

None — no generated or vendored TypeScript files exist in the repo.

### Unsupported requested rules

None — all 11 requested rules are supported by oxlint 1.77.0.

### Validation

- `pnpm lint` (incl. type-aware) — pass
- `pnpm run format:check` — pass
- `pnpm run typecheck` — pass
- `pnpm fallow:ci` — pass
