### PR TITLE
Adopt hk for pre-commit and pre-push hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The repo intentionally supports only two flows:
 
 - Node.js 24+
 - pnpm
+- [hk](https://hk.jdx.dev/) 1.54+
 - Fintual credentials
 - Actual Budget server credentials
 - Gmail app password for unattended 2FA
@@ -22,6 +23,14 @@ The repo intentionally supports only two flows:
 ```bash
 pnpm install
 ```
+
+1. Enable the repository's Git hooks. With Git 2.54+, the recommended one-time setup is:
+
+```bash
+hk install --global
+```
+
+   For an installation scoped to this clone instead, run `hk install`.
 
 1. Create a local env file:
 
@@ -108,6 +117,21 @@ Details and observed endpoints are in [`docs/fintual-http-capture.md`](docs/fint
 ## Quality ratchet
 
 Fallow 3.14 runs type-aware dead-code, duplication, and health gates in CI. See [`docs/fallow.md`](docs/fallow.md).
+
+## Git hooks
+
+[`hk`](https://hk.jdx.dev/) keeps local commits and pushes aligned with CI:
+
+- `pre-commit` checks staged TypeScript with Oxfmt and Oxlint in parallel. Safe fixes are applied and re-staged while unstaged changes are temporarily stashed.
+- `pre-push` checks the files being pushed with Oxfmt and Oxlint while running the full TypeScript and Fallow gates in parallel.
+
+Run the hooks explicitly when needed:
+
+```bash
+hk run pre-commit
+hk run pre-push
+hk check --all
+```
 
 ## Docker Image
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,53 @@
+amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+
+local sourceGlobs = List("src/**/*.ts")
+
+local sourceChecks = new Mapping<String, Step> {
+    ["oxfmt"] = (Builtins.oxfmt) {
+        glob = sourceGlobs
+        prefix = "pnpm exec"
+        check_first = true
+        // These built-in fixtures cannot resolve repo-local pnpm binaries from their temp dirs.
+        tests = new Mapping<String, StepTest> {}
+    }
+    ["oxlint"] = (Builtins.ox_lint) {
+        glob = sourceGlobs
+        prefix = "pnpm exec"
+        check_first = true
+        // These built-in fixtures cannot resolve repo-local pnpm binaries from their temp dirs.
+        tests = new Mapping<String, StepTest> {}
+    }
+}
+
+local projectChecks = new Mapping<String, Step> {
+    ...sourceChecks
+    ["typecheck"] {
+        check = new Command {
+            argv = List("pnpm", "run", "typecheck")
+        }
+    }
+    ["fallow"] {
+        check = new Command {
+            argv = List("pnpm", "run", "fallow:ci")
+        }
+    }
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = sourceChecks
+    }
+    ["pre-push"] {
+        steps = projectChecks
+    }
+    ["fix"] {
+        fix = true
+        steps = sourceChecks
+    }
+    ["check"] {
+        steps = projectChecks
+    }
+}


### PR DESCRIPTION
## What changed

- add a version-pinned `hk.pkl` using hk's built-in Oxfmt and Oxlint steps
- run safe, parallel auto-fixes against staged TypeScript in `pre-commit`, with unstaged changes stashed and modified files re-staged
- run Oxfmt, Oxlint, TypeScript, and the full Fallow CI ratchet in parallel in `pre-push`
- expose matching `hk check` and `hk fix` workflows
- document global and per-clone hook installation plus manual commands

## Why

Move the existing quality checks earlier in the development loop while keeping pre-commit fast and reserving whole-project checks for pre-push.

## Validation

- `hk config dump`
- `hk run pre-commit --all --check --no-progress`
- installed local hooks with `hk install`
- `git push` exercised the installed pre-push hook
- `pnpm run typecheck` passed through pre-push
- `pnpm run fallow:ci` passed through pre-push