### PR TITLE
Enforce Conventional Commits with hk

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,14 @@ Fallow 3.14 runs type-aware dead-code, duplication, and health gates in CI. See 
 
 [`hk`](https://hk.jdx.dev/) keeps local commits and pushes aligned with CI:
 
+- `commit-msg` requires commit subjects to follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
 - `pre-commit` checks staged TypeScript with Oxfmt and Oxlint in parallel. Safe fixes are applied and re-staged while unstaged changes are temporarily stashed.
 - `pre-push` checks the files being pushed with Oxfmt and Oxlint while running the full TypeScript and Fallow gates in parallel.
 
 Run the hooks explicitly when needed:
 
 ```bash
+hk run commit-msg .git/COMMIT_EDITMSG
 hk run pre-commit
 hk run pre-push
 hk check --all

--- a/hk.pkl
+++ b/hk.pkl
@@ -35,6 +35,11 @@ local projectChecks = new Mapping<String, Step> {
 }
 
 hooks {
+    ["commit-msg"] {
+        steps = new Mapping<String, Step> {
+            ["conventional-commit"] = Builtins.check_conventional_commit
+        }
+    }
     ["pre-commit"] {
         fix = true
         stash = "git"


### PR DESCRIPTION
## What changed

- add hk's native `check_conventional_commit` validator to the `commit-msg` hook
- document the Conventional Commits policy and manual hook invocation

## Why

The repository already relies on hk for pre-commit and pre-push checks, but commit messages were not validated. This keeps commit history consistent without adding another dependency.

## Impact

New commits must use a Conventional Commit subject such as `feat: add sync option`. Autosquash commit prefixes supported by hk remain exempt.

## Validation

- `hk validate`
- accepted a valid Conventional Commit message through `hk run commit-msg`
- rejected an invalid commit message through `hk run commit-msg`
- hk pre-push checks: TypeScript and Fallow