### PR TITLE
docs(domain): define goal performance data

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# Investment Sync
+
+This context covers the investment performance information transferred from Fintual into Actual Budget.
+
+## Language
+
+**Goal Performance Data**:
+Validated valuation and cost-basis observations for a Fintual goal over a requested time interval. The sync uses two datasets with different time intervals to calculate recent balance and deposit changes.
+_Avoid_: Raw GraphQL response, performance payload
+
+**Reference Goal Performance Data**:
+Goal Performance Data that supplies the observation immediately before the recent calculation period. Its Fintual time interval is an implementation detail.
+_Avoid_: Six-month data, baseline data
+
+**Recent Goal Performance Data**:
+Goal Performance Data that supplies the observations used to calculate recent balance and deposit changes. Its Fintual time interval is an implementation detail.
+_Avoid_: Last-month data, current data


### PR DESCRIPTION
## Summary

- define Goal Performance Data as the validated observations used by the investment sync
- distinguish Reference and Recent Goal Performance Data by purpose
- keep Fintual time-interval names out of the domain language

## Testing

- documentation-only change

## Stack

- base PR in stack #272
- followed by #271

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>