### PR TITLE
Compose validated runtime configuration once

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -52,7 +52,7 @@
         "backend_family": "typescript-go",
         "completeness": "complete"
       },
-      "totalIssues": 1,
+      "totalIssues": 0,
       "unusedFiles": 0,
       "unusedExports": 0,
       "unusedTypes": 0,

--- a/fallow-baselines/dead-code.json
+++ b/fallow-baselines/dead-code.json
@@ -13,9 +13,7 @@
   "unused_files": [],
   "unused_exports": [],
   "unused_types": [],
-  "private_type_leaks": [
-    "src/fintual/email-2fa.ts:get2FACodeFromEmail->Email2FAOptions"
-  ],
+  "private_type_leaks": [],
   "unused_dependencies": [],
   "unused_dev_dependencies": [],
   "circular_dependencies": [],

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -3,15 +3,8 @@ import * as api from "@actual-app/api"
 import { Effect } from "effect"
 import * as v from "valibot"
 import { log, sleep, tryPromise, trySync, warn } from "./effect.ts"
-import { getEnv } from "./env.ts"
+import type { ActualConfig } from "./env.ts"
 import { getErrorMessage } from "./log.ts"
-
-const SERVER_URL = getEnv("ACTUAL_SERVER_URL")
-const PASSWORD = getEnv("ACTUAL_PASSWORD")
-const SYNC_ID = getEnv("ACTUAL_SYNC_ID")
-const FINTUAL_ACCOUNT = getEnv("ACTUAL_FINTUAL_ACCOUNT")
-const STARTING_DATE = getEnv("ACTUAL_STARTING_DATE", getEnv("STARTING_DATE", "2024-03-01"))
-const PAYEE = getEnv("ACTUAL_PAYEE", "Fintual")
 
 const ACTUAL_DATA_DIR = "./tmp/actual-data"
 const BALANCE_FILE_PATH = "./tmp/fintual-data/balance-2.json"
@@ -59,24 +52,20 @@ interface SyncCounts {
   deletedDuplicates: number
 }
 
-export const main: Effect.Effect<void, Error> = Effect.gen(function* () {
-  yield* assertActualEnvConfigured()
-  const syncCounts = yield* runActualSyncWithRetry(1)
-  yield* log(
-    `Actual sync finished. Created ${syncCounts.created} transactions, updated ${syncCounts.updated}, and deleted ${syncCounts.deletedDuplicates} duplicates.`,
-  )
-})
-
-function assertActualEnvConfigured(): Effect.Effect<void, Error> {
-  if (SERVER_URL && PASSWORD && SYNC_ID && FINTUAL_ACCOUNT && STARTING_DATE && PAYEE) {
-    return Effect.void
-  }
-
-  return Effect.fail(new Error("Missing Actual configuration environment variables"))
+export function main(config: ActualConfig): Effect.Effect<void, Error> {
+  return Effect.gen(function* () {
+    const syncCounts = yield* runActualSyncWithRetry(config, 1)
+    yield* log(
+      `Actual sync finished. Created ${syncCounts.created} transactions, updated ${syncCounts.updated}, and deleted ${syncCounts.deletedDuplicates} duplicates.`,
+    )
+  })
 }
 
-function runActualSyncWithRetry(attempt: number): Effect.Effect<SyncCounts, Error> {
-  return Effect.catchAll(runActualSyncAttempt(), (cause) => {
+function runActualSyncWithRetry(
+  config: ActualConfig,
+  attempt: number,
+): Effect.Effect<SyncCounts, Error> {
+  return Effect.catchAll(runActualSyncAttempt(config), (cause) => {
     const shouldRetry = isRetryableActualError(cause) && attempt < MAX_SYNC_ATTEMPTS
 
     if (!shouldRetry) {
@@ -89,22 +78,22 @@ function runActualSyncWithRetry(attempt: number): Effect.Effect<SyncCounts, Erro
         `Actual sync attempt ${attempt} failed with a retryable error: ${getErrorMessage(cause)}. Retrying in ${Math.round(retryDelayMs / 1000)}s.`,
       )
       yield* sleep(retryDelayMs)
-      return yield* runActualSyncWithRetry(attempt + 1)
+      return yield* runActualSyncWithRetry(config, attempt + 1)
     })
   })
 }
 
-function runActualSyncAttempt(): Effect.Effect<SyncCounts, Error> {
+function runActualSyncAttempt(config: ActualConfig): Effect.Effect<SyncCounts, Error> {
   return Effect.gen(function* () {
     yield* resetDataDirectory()
-    yield* assertActualServerReachable()
+    yield* assertActualServerReachable(config)
 
     yield* tryPromise({
       try: () =>
         api.init({
           dataDir: ACTUAL_DATA_DIR,
-          serverURL: SERVER_URL,
-          password: PASSWORD,
+          serverURL: config.serverUrl,
+          password: config.password,
         } satisfies ActualInitConfig),
       catch: "Failed to initialize Actual API",
     })
@@ -112,10 +101,10 @@ function runActualSyncAttempt(): Effect.Effect<SyncCounts, Error> {
     return yield* Effect.ensuring(
       Effect.gen(function* () {
         yield* tryPromise({
-          try: () => api.downloadBudget(SYNC_ID),
+          try: () => api.downloadBudget(config.syncId),
           catch: "Failed to download Actual budget",
         })
-        return yield* syncDailyVariationTransactions()
+        return yield* syncDailyVariationTransactions(config)
       }),
       Effect.ignore(
         tryPromise({
@@ -127,16 +116,16 @@ function runActualSyncAttempt(): Effect.Effect<SyncCounts, Error> {
   })
 }
 
-function syncDailyVariationTransactions(): Effect.Effect<SyncCounts, Error> {
+function syncDailyVariationTransactions(config: ActualConfig): Effect.Effect<SyncCounts, Error> {
   return Effect.gen(function* () {
     const endingDate = getTodayIsoDate()
     const transactions = yield* tryPromise({
-      try: () => api.getTransactions(FINTUAL_ACCOUNT, STARTING_DATE, endingDate),
+      try: () => api.getTransactions(config.fintualAccount, config.startingDate, endingDate),
       catch: "Failed to fetch Actual transactions",
     })
 
-    const balanceEntries = yield* normalizeBalanceEntries(yield* loadBalanceEntries())
-    const payeeId = yield* getPayeeId()
+    const balanceEntries = yield* normalizeBalanceEntries(yield* loadBalanceEntries(config))
+    const payeeId = yield* getPayeeId(config)
     const variationTransactionsByDate = groupVariationTransactionsByDate(transactions, payeeId)
     const processedDates = new Set<string>()
     const syncCounts: SyncCounts = {
@@ -152,7 +141,7 @@ function syncDailyVariationTransactions(): Effect.Effect<SyncCounts, Error> {
 
       if (existingTransactions.length === 0) {
         yield* tryPromise({
-          try: () => api.addTransactions(FINTUAL_ACCOUNT, [transaction]),
+          try: () => api.addTransactions(config.fintualAccount, [transaction]),
           catch: "Failed to add Actual transaction",
         })
         syncCounts.created += 1
@@ -206,7 +195,7 @@ function resetDataDirectory(): Effect.Effect<void, Error> {
   })
 }
 
-function loadBalanceEntries(): Effect.Effect<BalanceEntry[], Error> {
+function loadBalanceEntries(config: ActualConfig): Effect.Effect<BalanceEntry[], Error> {
   return Effect.gen(function* () {
     const parsedFile = yield* trySync({
       // oxlint-disable-next-line typescript/consistent-type-assertions
@@ -220,7 +209,7 @@ function loadBalanceEntries(): Effect.Effect<BalanceEntry[], Error> {
       return []
     }
 
-    const startingTimestamp = Date.parse(STARTING_DATE)
+    const startingTimestamp = Date.parse(config.startingDate)
     return validation.output.balance.filter((entry) => entry.date >= startingTimestamp)
   })
 }
@@ -358,13 +347,13 @@ function deleteDuplicateVariationTransactions(
   })
 }
 
-function getPayeeId(): Effect.Effect<string | undefined, Error> {
+function getPayeeId(config: ActualConfig): Effect.Effect<string | undefined, Error> {
   return Effect.gen(function* () {
     const payees = yield* tryPromise({
       try: () => api.getPayees(),
       catch: "Failed to fetch Actual payees",
     })
-    const payee = payees.find((candidate) => candidate.name === PAYEE)
+    const payee = payees.find((candidate) => candidate.name === config.payee)
 
     if (!payee) {
       yield* log("Configured payee not found")
@@ -412,8 +401,10 @@ function isRetryableActualError(error: unknown): boolean {
   return error.type === "PostError" && error.reason === "network-failure"
 }
 
-function assertActualServerReachable(): Effect.Effect<void, Error> {
-  const normalizedBaseUrl = SERVER_URL.endsWith("/") ? SERVER_URL.slice(0, -1) : SERVER_URL
+function assertActualServerReachable(config: ActualConfig): Effect.Effect<void, Error> {
+  const normalizedBaseUrl = config.serverUrl.endsWith("/")
+    ? config.serverUrl.slice(0, -1)
+    : config.serverUrl
   const healthUrl = `${normalizedBaseUrl}/health`
 
   return Effect.gen(function* () {

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,0 +1,117 @@
+import { Effect } from "effect"
+import { expect, test } from "vitest"
+import { resolveRuntimeConfig } from "./env.ts"
+
+function requiredEnvironment(): Record<string, string> {
+  return {
+    ACTUAL_SERVER_URL: " https://actual.example.test ",
+    ACTUAL_PASSWORD: " 'actual password' ",
+    ACTUAL_SYNC_ID: "sync-id",
+    ACTUAL_FINTUAL_ACCOUNT: "account-id",
+    FINTUAL_USER_EMAIL: '"investor@example.com"',
+    FINTUAL_USER_PASSWORD: "fintual password",
+    FINTUAL_GOAL_ID: "goal-id",
+  }
+}
+
+test("normalizes runtime values and applies defaults once for every domain", async () => {
+  const configuration = await Effect.runPromise(resolveRuntimeConfig(requiredEnvironment()))
+
+  expect(configuration).toEqual({
+    actual: {
+      serverUrl: "https://actual.example.test",
+      password: "actual password",
+      syncId: "sync-id",
+      fintualAccount: "account-id",
+      startingDate: "2024-03-01",
+      payee: "Fintual",
+    },
+    fintual: {
+      email: "investor@example.com",
+      password: "fintual password",
+      goalId: "goal-id",
+      email2FA: null,
+    },
+  })
+})
+
+test("uses legacy starting date and enables email 2FA when both credentials are present", async () => {
+  const configuration = await Effect.runPromise(
+    resolveRuntimeConfig({
+      ...requiredEnvironment(),
+      STARTING_DATE: "2025-01-02",
+      ACTUAL_PAYEE: "Investments",
+      GMAIL_USER_EMAIL: "mailbox@example.com",
+      GMAIL_APP_PASSWORD: "app password",
+      GMAIL_IMAP_HOST: "mail.example.com",
+      GMAIL_IMAP_PORT: "1993",
+      GMAIL_IMAP_DEBUG: "TRUE",
+      FINTUAL_2FA_SENDER: "security@example.com",
+    }),
+  )
+
+  expect(configuration.actual.startingDate).toBe("2025-01-02")
+  expect(configuration.actual.payee).toBe("Investments")
+  expect(configuration.fintual.email2FA).toEqual({
+    userEmail: "mailbox@example.com",
+    appPassword: "app password",
+    host: "mail.example.com",
+    port: 1993,
+    debug: true,
+    sender: "security@example.com",
+  })
+})
+
+test("reports all missing required runtime values", async () => {
+  const result = await Effect.runPromise(Effect.either(resolveRuntimeConfig({})))
+
+  expect(result._tag).toBe("Left")
+  if (result._tag === "Left") {
+    expect(result.left.message).toContain("ACTUAL_SERVER_URL")
+  }
+})
+
+test("rejects partially configured email 2FA credentials", async () => {
+  const result = await Effect.runPromise(
+    Effect.either(
+      resolveRuntimeConfig({
+        ...requiredEnvironment(),
+        GMAIL_USER_EMAIL: "mailbox@example.com",
+      }),
+    ),
+  )
+
+  expect(result._tag).toBe("Left")
+  if (result._tag === "Left") {
+    expect(result.left.message).toBe("Missing environment variables: GMAIL_APP_PASSWORD")
+  }
+})
+
+test("rejects an invalid email 2FA port", async () => {
+  const result = await Effect.runPromise(
+    Effect.either(
+      resolveRuntimeConfig({
+        ...requiredEnvironment(),
+        GMAIL_USER_EMAIL: "mailbox@example.com",
+        GMAIL_APP_PASSWORD: "app password",
+        GMAIL_IMAP_PORT: "not-a-port",
+      }),
+    ),
+  )
+
+  expect(result._tag).toBe("Left")
+  if (result._tag === "Left") {
+    expect(result.left.message).toBe('Expected a network port value but received "not-a-port"')
+  }
+})
+
+test("ignores email 2FA settings when automatic retrieval is disabled", async () => {
+  const configuration = await Effect.runPromise(
+    resolveRuntimeConfig({
+      ...requiredEnvironment(),
+      GMAIL_IMAP_PORT: "not-a-port",
+    }),
+  )
+
+  expect(configuration.fintual.email2FA).toBeNull()
+})

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,28 +1,131 @@
-import { config } from "dotenv"
-import { Effect } from "effect"
+import { Config, ConfigProvider, Effect, Option } from "effect"
 
-config()
-
-export function assertRequiredEnv(names: string[]): Effect.Effect<void, Error> {
-  const missingNames = names.filter((name) => !getEnv(name))
-
-  if (missingNames.length === 0) {
-    return Effect.void
-  }
-
-  return Effect.fail(new Error(`Missing environment variables: ${missingNames.join(", ")}`))
+export interface ActualConfig {
+  serverUrl: string
+  password: string
+  syncId: string
+  fintualAccount: string
+  startingDate: string
+  payee: string
 }
 
-export function getEnv(name: string, fallback = ""): string {
-  const value = process.env[name]
-  if (!value) {
-    return fallback
-  }
-
-  return normalizeEnvValue(value)
+export interface Email2FAConfig {
+  userEmail: string
+  appPassword: string
+  host: string
+  port: number
+  debug: boolean
+  sender: string
 }
 
-export function normalizeEnvValue(value: string): string {
+export interface FintualConfig {
+  email: string
+  password: string
+  goalId: string
+  email2FA: Email2FAConfig | null
+}
+
+export interface RuntimeConfig {
+  actual: ActualConfig
+  fintual: FintualConfig
+}
+
+export type Environment = Readonly<Record<string, string | undefined>>
+
+export function resolveRuntimeConfig(
+  environment: Environment,
+): Effect.Effect<RuntimeConfig, Error> {
+  return Effect.gen(function* () {
+    const provider = ConfigProvider.fromMap(
+      new Map(
+        Object.entries(environment).flatMap(([name, value]) =>
+          value ? [[name, normalizeEnvValue(value)] as const] : [],
+        ),
+      ),
+    )
+    const values = yield* Effect.withConfigProvider(provider)(runtimeValueConfig).pipe(
+      Effect.mapError((cause) => new Error(cause.message)),
+    )
+    const gmailUserEmail = Option.getOrElse(values.gmailUserEmail, () => "")
+    const gmailAppPassword = Option.getOrElse(values.gmailAppPassword, () => "")
+    const email2FA = yield* resolveEmail2FAConfig(provider, gmailUserEmail, gmailAppPassword)
+
+    return {
+      actual: {
+        serverUrl: values.actualServerUrl,
+        password: values.actualPassword,
+        syncId: values.actualSyncId,
+        fintualAccount: values.actualFintualAccount,
+        startingDate: values.actualStartingDate,
+        payee: values.actualPayee,
+      },
+      fintual: {
+        email: values.fintualUserEmail,
+        password: values.fintualUserPassword,
+        goalId: values.fintualGoalId,
+        email2FA,
+      },
+    }
+  })
+}
+
+const runtimeValueConfig = Config.all({
+  actualServerUrl: Config.string("ACTUAL_SERVER_URL"),
+  actualPassword: Config.string("ACTUAL_PASSWORD"),
+  actualSyncId: Config.string("ACTUAL_SYNC_ID"),
+  actualFintualAccount: Config.string("ACTUAL_FINTUAL_ACCOUNT"),
+  actualStartingDate: Config.string("ACTUAL_STARTING_DATE").pipe(
+    Config.orElse(() => Config.string("STARTING_DATE")),
+    Config.withDefault("2024-03-01"),
+  ),
+  actualPayee: Config.string("ACTUAL_PAYEE").pipe(Config.withDefault("Fintual")),
+  fintualUserEmail: Config.string("FINTUAL_USER_EMAIL"),
+  fintualUserPassword: Config.string("FINTUAL_USER_PASSWORD"),
+  fintualGoalId: Config.string("FINTUAL_GOAL_ID"),
+  gmailUserEmail: Config.option(Config.string("GMAIL_USER_EMAIL")),
+  gmailAppPassword: Config.option(Config.string("GMAIL_APP_PASSWORD")),
+})
+
+const email2FAValueConfig = Config.all({
+  gmailImapHost: Config.string("GMAIL_IMAP_HOST").pipe(Config.withDefault("imap.gmail.com")),
+  gmailImapPort: Config.port("GMAIL_IMAP_PORT").pipe(Config.withDefault(993)),
+  gmailImapDebug: Config.string("GMAIL_IMAP_DEBUG").pipe(
+    Config.withDefault(""),
+    Config.map((value) => ["1", "true"].includes(value.toLowerCase())),
+  ),
+  fintual2FASender: Config.string("FINTUAL_2FA_SENDER").pipe(
+    Config.withDefault("notificaciones@fintual.com"),
+  ),
+})
+
+function resolveEmail2FAConfig(
+  provider: ConfigProvider.ConfigProvider,
+  userEmail: string,
+  appPassword: string,
+): Effect.Effect<Email2FAConfig | null, Error> {
+  if (!userEmail && !appPassword) {
+    return Effect.succeed(null)
+  }
+
+  const missingName = userEmail ? "GMAIL_APP_PASSWORD" : "GMAIL_USER_EMAIL"
+  if (!userEmail || !appPassword) {
+    return Effect.fail(new Error(`Missing environment variables: ${missingName}`))
+  }
+
+  return Effect.withConfigProvider(provider)(email2FAValueConfig).pipe(
+    Effect.mapError((cause) => new Error(cause.message)),
+    Effect.map((values) => ({
+      userEmail,
+      appPassword,
+      host: values.gmailImapHost,
+      port: values.gmailImapPort,
+      debug: values.gmailImapDebug,
+      sender: values.fintual2FASender,
+    })),
+  )
+}
+
+function normalizeEnvValue(value: string): string {
   const trimmedValue = value.trim()
   const startsWithQuote = trimmedValue.startsWith('"') || trimmedValue.startsWith("'")
   const endsWithQuote = trimmedValue.endsWith('"') || trimmedValue.endsWith("'")

--- a/src/fintual/authenticated-ingestion.ts
+++ b/src/fintual/authenticated-ingestion.ts
@@ -1,6 +1,5 @@
 import { Effect } from "effect"
 import { tryPromise, trySync } from "../effect.ts"
-import { get2FACodeFromEmail } from "./email-2fa.ts"
 import {
   createGoalPerformanceRequest,
   type GoalPerformanceData,
@@ -16,7 +15,11 @@ const BROWSER_USER_AGENT =
 
 export interface AuthenticatedIngestionDependencies {
   fetch: typeof globalThis.fetch
-  get2FACode: typeof get2FACodeFromEmail
+  get2FACode: (options: {
+    afterTimestamp: Date
+    timeoutMs?: number
+    pollIntervalMs?: number
+  }) => Effect.Effect<string | null, Error>
 }
 
 export interface AuthenticatedIngestionOptions {
@@ -61,11 +64,6 @@ export function createAuthenticatedFintualIngestion(
     })
   }
 }
-
-export const fetchAuthenticatedGoalPerformance = createAuthenticatedFintualIngestion({
-  fetch: globalThis.fetch,
-  get2FACode: get2FACodeFromEmail,
-})
 
 class FintualHttpSession {
   private readonly cookies = new Map<string, string>()
@@ -120,7 +118,7 @@ function loadSignInPage(session: FintualHttpSession): Effect.Effect<void, Error>
 
 function authenticate(
   session: FintualHttpSession,
-  get2FACode: typeof get2FACodeFromEmail,
+  get2FACode: AuthenticatedIngestionDependencies["get2FACode"],
   email: string,
   password: string,
 ): Effect.Effect<void, Error> {

--- a/src/fintual/email-2fa.ts
+++ b/src/fintual/email-2fa.ts
@@ -2,37 +2,33 @@ import { Effect } from "effect"
 import { ImapFlow, type SearchObject } from "imapflow"
 import { simpleParser } from "mailparser"
 import { error, log, sleep, tryPromise, warn } from "../effect.ts"
-import { getEnv } from "../env.ts"
+import type { Email2FAConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 
 const DEFAULT_TIMEOUT_MS = 10000
 const DEFAULT_POLL_INTERVAL_MS = 2000
 const MAX_RESULTS = 10
 
-const GMAIL_IMAP_HOST = getEnv("GMAIL_IMAP_HOST", "imap.gmail.com")
-const GMAIL_IMAP_PORT = Number.parseInt(getEnv("GMAIL_IMAP_PORT", "993"), 10)
-const GMAIL_IMAP_DEBUG = ["1", "true"].includes(getEnv("GMAIL_IMAP_DEBUG", "").toLowerCase())
-const GMAIL_USER_EMAIL = getEnv("GMAIL_USER_EMAIL")
-const GMAIL_APP_PASSWORD = getEnv("GMAIL_APP_PASSWORD")
-const FINTUAL_2FA_SENDER = getEnv("FINTUAL_2FA_SENDER", "notificaciones@fintual.com")
-
 /** Gmail can file 2FA under categories; IMAP search is per-folder. */
 const GMAIL_IMAP_SEARCH_PATHS = ["INBOX", "[Gmail]/All Mail", "[Gmail]/Spam"] as const
 
-interface Email2FAOptions {
+export interface Email2FAOptions {
   afterTimestamp: Date
   timeoutMs?: number
   pollIntervalMs?: number
 }
 
-export function get2FACodeFromEmail(options: Email2FAOptions): Effect.Effect<string | null, Error> {
+export function get2FACodeFromEmail(
+  config: Email2FAConfig | null,
+  options: Email2FAOptions,
+): Effect.Effect<string | null, Error> {
   const {
     afterTimestamp,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
   } = options
 
-  if (!GMAIL_USER_EMAIL || !GMAIL_APP_PASSWORD) {
+  if (!config) {
     return Effect.as(
       log("Gmail IMAP credentials not configured, skipping automatic 2FA retrieval"),
       null,
@@ -41,7 +37,7 @@ export function get2FACodeFromEmail(options: Email2FAOptions): Effect.Effect<str
 
   return Effect.gen(function* () {
     yield* log("Connecting to Gmail IMAP for automatic 2FA retrieval...")
-    const imapClient = createImapClient()
+    const imapClient = createImapClient(config)
     const startedAt = Date.now()
     const seenMessageKeys = new Set<string>()
 
@@ -52,7 +48,7 @@ export function get2FACodeFromEmail(options: Email2FAOptions): Effect.Effect<str
       })
 
       while (Date.now() - startedAt < timeoutMs) {
-        const code = yield* searchForCode(imapClient, afterTimestamp, seenMessageKeys)
+        const code = yield* searchForCode(config, imapClient, afterTimestamp, seenMessageKeys)
         if (code) {
           yield* log("2FA code retrieved from Gmail.")
           return code
@@ -73,25 +69,26 @@ export function get2FACodeFromEmail(options: Email2FAOptions): Effect.Effect<str
   })
 }
 
-function createImapClient(): ImapFlow {
+function createImapClient(config: Email2FAConfig): ImapFlow {
   return new ImapFlow({
-    host: GMAIL_IMAP_HOST,
-    port: GMAIL_IMAP_PORT,
+    host: config.host,
+    port: config.port,
     secure: true,
     auth: {
-      user: GMAIL_USER_EMAIL,
-      pass: GMAIL_APP_PASSWORD,
+      user: config.userEmail,
+      pass: config.appPassword,
     },
     logger: false,
   })
 }
 
 function searchForCode(
+  config: Email2FAConfig,
   imapClient: ImapFlow,
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
 ): Effect.Effect<string | null, Error> {
-  const paths = imapSearchMailboxes()
+  const paths = imapSearchMailboxes(config)
 
   return Effect.gen(function* () {
     for (const mailboxPath of paths) {
@@ -101,7 +98,7 @@ function searchForCode(
           catch: `Failed to lock Gmail IMAP mailbox ${mailboxPath}`,
         }),
         () =>
-          GMAIL_IMAP_DEBUG
+          config.debug
             ? Effect.as(log(`Gmail IMAP: skip missing mailbox ${mailboxPath}`), undefined)
             : Effect.succeed(undefined),
       )
@@ -111,8 +108,8 @@ function searchForCode(
 
       const code = yield* Effect.ensuring(
         Effect.gen(function* () {
-          const messageUids = yield* runMailboxSearch(imapClient, afterTimestamp)
-          if (GMAIL_IMAP_DEBUG) {
+          const messageUids = yield* runMailboxSearch(config, imapClient, afterTimestamp)
+          if (config.debug) {
             yield* log(
               `Gmail IMAP: ${mailboxPath} search -> ${messageUids === false ? "no match" : `${messageUids.length} uid(s)`}`,
             )
@@ -140,8 +137,8 @@ function searchForCode(
   })
 }
 
-function imapSearchMailboxes(): string[] {
-  if (isGmailImapHost(GMAIL_IMAP_HOST)) {
+function imapSearchMailboxes(config: Email2FAConfig): string[] {
+  if (isGmailImapHost(config.host)) {
     return [...GMAIL_IMAP_SEARCH_PATHS]
   }
   return ["INBOX"]
@@ -205,10 +202,11 @@ function extractCodeFromMailboxUids(
 }
 
 function runMailboxSearch(
+  config: Email2FAConfig,
   imapClient: ImapFlow,
   afterTimestamp: Date,
 ): Effect.Effect<number[] | false, Error> {
-  const queries = buildSearchQueries(afterTimestamp)
+  const queries = buildSearchQueries(config, afterTimestamp)
 
   return Effect.gen(function* () {
     for (const query of queries) {
@@ -248,20 +246,20 @@ function formatGmailAfterDate(d: Date): string {
   return `${yyyy}/${mm}/${dd}`
 }
 
-function buildSearchQueries(afterTimestamp: Date): SearchObject[] {
+function buildSearchQueries(config: Email2FAConfig, afterTimestamp: Date): SearchObject[] {
   const queries: SearchObject[] = []
 
-  if (isGmailImapHost(GMAIL_IMAP_HOST)) {
+  if (isGmailImapHost(config.host)) {
     const after = formatGmailAfterDate(afterTimestamp)
     queries.push({
-      gmraw: `from:${FINTUAL_2FA_SENDER} after:${after}`,
+      gmraw: `from:${config.sender} after:${after}`,
     })
     queries.push({
       gmraw: `from:fintual.com after:${after}`,
     })
     // Relative window avoids rare date/TZ mismatches between container and Gmail account settings.
     queries.push({
-      gmraw: `from:${FINTUAL_2FA_SENDER} newer_than:1d`,
+      gmraw: `from:${config.sender} newer_than:1d`,
     })
     queries.push({
       gmraw: `from:fintual.com newer_than:1d`,
@@ -269,7 +267,7 @@ function buildSearchQueries(afterTimestamp: Date): SearchObject[] {
   }
 
   queries.push({
-    from: FINTUAL_2FA_SENDER,
+    from: config.sender,
     since: afterTimestamp,
   })
 

--- a/src/fintual/http-sync.ts
+++ b/src/fintual/http-sync.ts
@@ -1,25 +1,25 @@
 import { Effect } from "effect"
 import { error, log, trySync } from "../effect.ts"
-import { getEnv } from "../env.ts"
+import type { FintualConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
-import { fetchAuthenticatedGoalPerformance } from "./authenticated-ingestion.ts"
+import { createAuthenticatedFintualIngestion } from "./authenticated-ingestion.ts"
+import { get2FACodeFromEmail } from "./email-2fa.ts"
 import { BALANCE_FILE_PATH, foldGoalPerformanceData, writePerformanceFile } from "./scraper.ts"
-
-const GOAL_ID = getEnv("FINTUAL_GOAL_ID")
 
 /**
  * Fetches performance via `initiate_login` → (e-mail 2FA) `finalize_login_web` → GraphQL.
  * Requires Gmail IMAP env vars for accounts with e-mail 2FA.
  */
-function fetchFintualPerformanceHttp(): Effect.Effect<void, Error> {
-  const email = getEnv("FINTUAL_USER_EMAIL")
-  const password = getEnv("FINTUAL_USER_PASSWORD")
-
+function fetchFintualPerformanceHttp(config: FintualConfig): Effect.Effect<void, Error> {
+  const fetchAuthenticatedGoalPerformance = createAuthenticatedFintualIngestion({
+    fetch: globalThis.fetch,
+    get2FACode: (options) => get2FACodeFromEmail(config.email2FA, options),
+  })
   return Effect.gen(function* () {
     const { reference, recent } = yield* fetchAuthenticatedGoalPerformance({
-      email,
-      password,
-      goalId: GOAL_ID,
+      email: config.email,
+      password: config.password,
+      goalId: config.goalId,
     })
 
     const performanceData = yield* trySync({
@@ -35,7 +35,8 @@ function fetchFintualPerformanceHttp(): Effect.Effect<void, Error> {
   })
 }
 
-export const runFintualSync: Effect.Effect<void, Error> = Effect.catchAll(
-  fetchFintualPerformanceHttp(),
-  (cause) => Effect.zipRight(error(`Error: ${getErrorMessage(cause)}`), Effect.fail(cause)),
-)
+export function runFintualSync(config: FintualConfig): Effect.Effect<void, Error> {
+  return Effect.catchAll(fetchFintualPerformanceHttp(config), (cause) =>
+    Effect.zipRight(error(`Error: ${getErrorMessage(cause)}`), Effect.fail(cause)),
+  )
+}

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,26 +1,14 @@
 import { Effect } from "effect"
 import { main as mainActual } from "./actual.ts"
 import { log } from "./effect.ts"
-import { assertRequiredEnv } from "./env.ts"
+import type { RuntimeConfig } from "./env.ts"
 import { runFintualSync } from "./fintual/http-sync.ts"
-import "./env.ts"
 
-const REQUIRED_SYNC_ENV_NAMES = [
-  "ACTUAL_SERVER_URL",
-  "ACTUAL_PASSWORD",
-  "ACTUAL_SYNC_ID",
-  "ACTUAL_FINTUAL_ACCOUNT",
-  "FINTUAL_USER_EMAIL",
-  "FINTUAL_USER_PASSWORD",
-  "FINTUAL_GOAL_ID",
-  "GMAIL_USER_EMAIL",
-  "GMAIL_APP_PASSWORD",
-] satisfies string[]
-
-export const runJob: Effect.Effect<void, Error> = Effect.gen(function* () {
-  yield* assertRequiredEnv(REQUIRED_SYNC_ENV_NAMES)
-  yield* log("Running job...")
-  yield* runFintualSync
-  yield* mainActual
-  yield* log("Job finished.")
-})
+export function runJob(config: RuntimeConfig): Effect.Effect<void, Error> {
+  return Effect.gen(function* () {
+    yield* log("Running job...")
+    yield* runFintualSync(config.fintual)
+    yield* mainActual(config.actual)
+    yield* log("Job finished.")
+  })
+}

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,21 +1,21 @@
 import { inspect } from "node:util"
-import { normalizeEnvValue } from "./env.ts"
+import type { RuntimeConfig } from "./env.ts"
 
-const SENSITIVE_ENV_NAMES = [
-  "ACTUAL_PASSWORD",
-  "ACTUAL_SERVER_URL",
-  "ACTUAL_SYNC_ID",
-  "ACTUAL_FINTUAL_ACCOUNT",
-  "FINTUAL_USER_EMAIL",
-  "FINTUAL_USER_PASSWORD",
-  "FINTUAL_GOAL_ID",
-  "GMAIL_USER_EMAIL",
-  "GMAIL_APP_PASSWORD",
-  "GMAIL_IMAP_HOST",
-  "GMAIL_IMAP_PORT",
-  "FINTUAL_2FA_SENDER",
-  "FINTUAL_2FA_SUBJECT",
-] as const
+let configuredRedactionSecrets: string[] = []
+
+export function configureSensitiveValues(config: RuntimeConfig): void {
+  configuredRedactionSecrets = [
+    config.actual.password,
+    config.actual.serverUrl,
+    config.actual.syncId,
+    config.actual.fintualAccount,
+    config.fintual.email,
+    config.fintual.password,
+    config.fintual.goalId,
+    config.fintual.email2FA?.userEmail,
+    config.fintual.email2FA?.appPassword,
+  ].filter((value): value is string => Boolean(value))
+}
 
 export function getErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message) {
@@ -41,13 +41,8 @@ export function getErrorMessage(error: unknown): string {
 function redactSensitiveText(value: string): string {
   let redactedValue = value
 
-  for (const envName of SENSITIVE_ENV_NAMES) {
-    const envValue = getNormalizedEnvValue(envName)
-    if (!envValue) {
-      continue
-    }
-
-    redactedValue = redactedValue.split(envValue).join(`[redacted ${envName}]`)
+  for (const sensitiveValue of configuredRedactionSecrets) {
+    redactedValue = redactedValue.split(sensitiveValue).join("[redacted]")
   }
 
   redactedValue = redactedValue.replaceAll(
@@ -74,15 +69,6 @@ function getStructuredErrorMessage(error: Record<string, unknown>): string {
   }
 
   return parts.join(": ")
-}
-
-function getNormalizedEnvValue(name: string): string {
-  const value = process.env[name]
-  if (!value) {
-    return ""
-  }
-
-  return normalizeEnvValue(value)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/once.ts
+++ b/src/once.ts
@@ -1,13 +1,18 @@
 import { pathToFileURL } from "node:url"
+import { config as loadDotEnv } from "dotenv"
 import { Effect } from "effect"
 import { log } from "./effect.ts"
+import { resolveRuntimeConfig } from "./env.ts"
 import { runJob } from "./job.ts"
-import { getErrorMessage } from "./log.ts"
-import "./env.ts"
+import { configureSensitiveValues, getErrorMessage } from "./log.ts"
+
+loadDotEnv()
 
 const main: Effect.Effect<void, Error> = Effect.gen(function* () {
+  const runtimeConfig = yield* resolveRuntimeConfig(process.env)
+  configureSensitiveValues(runtimeConfig)
   yield* log("Running task once...")
-  yield* runJob
+  yield* runJob(runtimeConfig)
   yield* log("Task completed.")
 })
 


### PR DESCRIPTION
Closes #269

## Summary

- resolve and validate runtime configuration once at the composition root using Effect Config
- inject typed Actual, Fintual, and optional Gmail 2FA configuration into domain modules
- keep Gmail credentials optional while rejecting partial configuration
- remove import-time environment capture and centralize defaults and requiredness
- add focused tests for normalization, defaults, missing values, Gmail policy, and port validation

## Impact

Runtime configuration policy now has one source of truth, domain modules have smaller explicit interfaces, and isolated configuration tests no longer depend on process environment state.

## Validation

- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm fallow:ci