### PR TITLE
Test email 2FA selection policy

### DIFF
--- a/src/fintual/email-2fa-policy.test.ts
+++ b/src/fintual/email-2fa-policy.test.ts
@@ -1,0 +1,72 @@
+import { readFile } from "node:fs/promises"
+import { Effect } from "effect"
+import { expect, test } from "vitest"
+import {
+  buildEmail2FASearchQueries,
+  selectEmail2FACode,
+  type Email2FACandidate,
+} from "./email-2fa-policy.ts"
+
+const AFTER_TIMESTAMP = new Date(2026, 6, 14, 10, 30)
+
+test("builds Gmail sender, domain, relative-window, and portable fallback queries", () => {
+  const queries = buildEmail2FASearchQueries(
+    { host: "IMAP.GMAIL.COM", sender: "security@fintual.com" },
+    AFTER_TIMESTAMP,
+  )
+
+  expect(queries).toEqual([
+    { gmraw: "from:security@fintual.com after:2026/07/14" },
+    { gmraw: "from:fintual.com after:2026/07/14" },
+    { gmraw: "from:security@fintual.com newer_than:1d" },
+    { gmraw: "from:fintual.com newer_than:1d" },
+    { from: "security@fintual.com", since: AFTER_TIMESTAMP },
+  ])
+})
+
+test("uses only the portable IMAP query outside Gmail", () => {
+  expect(
+    buildEmail2FASearchQueries(
+      { host: "imap.example.com", sender: "security@example.com" },
+      AFTER_TIMESTAMP,
+    ),
+  ).toEqual([{ from: "security@example.com", since: AFTER_TIMESTAMP }])
+})
+
+test.each([
+  ["plain text", "2fa-plain.eml", "123456"],
+  ["HTML", "2fa-html.eml", "234567"],
+  ["quoted-printable", "2fa-quoted-printable.eml", "345678"],
+])("selects a code from a captured %s message", async (_, fixtureName, expectedCode) => {
+  const candidate = await loadFixture(fixtureName)
+
+  const code = await Effect.runPromise(selectEmail2FACode([candidate], AFTER_TIMESTAMP))
+
+  expect(code).toBe(expectedCode)
+})
+
+test("rejects stale and invalid candidates before selecting a fresh code", async () => {
+  const candidates: Email2FACandidate[] = [
+    {
+      source: Buffer.from("Subject: Codigo 456789\n\nCodigo: 456789"),
+      receivedAt: new Date(2026, 6, 14, 10, 29),
+    },
+    {
+      source: Buffer.from("Subject: Codigo 000000\n\nCodigo: 000000"),
+      receivedAt: new Date(2026, 6, 14, 10, 31),
+    },
+    {
+      source: Buffer.from("Subject: Codigo 567890\n\nCodigo: 567890"),
+      receivedAt: new Date(2026, 6, 14, 10, 32),
+    },
+  ]
+
+  const code = await Effect.runPromise(selectEmail2FACode(candidates, AFTER_TIMESTAMP))
+
+  expect(code).toBe("567890")
+})
+
+async function loadFixture(name: string): Promise<Email2FACandidate> {
+  const source = await readFile(new URL(`./fixtures/${name}`, import.meta.url))
+  return { source, receivedAt: new Date(2026, 6, 14, 10, 31) }
+}

--- a/src/fintual/email-2fa-policy.ts
+++ b/src/fintual/email-2fa-policy.ts
@@ -1,0 +1,138 @@
+import { Effect } from "effect"
+import type { SearchObject } from "imapflow"
+import { simpleParser } from "mailparser"
+import { tryPromise } from "../effect.ts"
+
+export interface Email2FASearchPolicy {
+  host: string
+  sender: string
+}
+
+export interface Email2FACandidate {
+  source: Buffer | Uint8Array
+  envelopeSubject?: string
+  receivedAt?: Date
+}
+
+export function buildEmail2FASearchQueries(
+  policy: Email2FASearchPolicy,
+  afterTimestamp: Date,
+): SearchObject[] {
+  const queries: SearchObject[] = []
+
+  if (isGmailImapHost(policy.host)) {
+    const after = formatGmailAfterDate(afterTimestamp)
+    queries.push({ gmraw: `from:${policy.sender} after:${after}` })
+    queries.push({ gmraw: `from:fintual.com after:${after}` })
+    // Relative queries cover date and timezone disagreement between Gmail and the caller.
+    queries.push({ gmraw: `from:${policy.sender} newer_than:1d` })
+    queries.push({ gmraw: "from:fintual.com newer_than:1d" })
+  }
+
+  queries.push({ from: policy.sender, since: afterTimestamp })
+  return queries
+}
+
+export function selectEmail2FACode(
+  candidates: Iterable<Email2FACandidate>,
+  afterTimestamp: Date,
+): Effect.Effect<string | null, Error> {
+  return Effect.gen(function* () {
+    for (const candidate of candidates) {
+      if (candidate.receivedAt && candidate.receivedAt < afterTimestamp) {
+        continue
+      }
+
+      const sources = yield* collectMessageSources(candidate)
+      for (const source of sources) {
+        const code = extractCodeFromText(source)
+        if (code) {
+          return code
+        }
+      }
+    }
+
+    return null
+  })
+}
+
+export function isGmailImapHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase()
+  return normalized === "imap.gmail.com" || normalized === "imap.googlemail.com"
+}
+
+/** Gmail web-style search; avoids broken IMAP SUBJECT matching for UTF-8 (e.g. "Código"). */
+function formatGmailAfterDate(date: Date): string {
+  const yyyy = date.getFullYear()
+  const mm = String(date.getMonth() + 1).padStart(2, "0")
+  const dd = String(date.getDate()).padStart(2, "0")
+  return `${yyyy}/${mm}/${dd}`
+}
+
+function collectMessageSources(candidate: Email2FACandidate): Effect.Effect<string[], Error> {
+  return Effect.gen(function* () {
+    const sources: string[] = []
+    if (candidate.envelopeSubject) {
+      sources.push(candidate.envelopeSubject)
+    }
+
+    const parsedMessage = yield* tryPromise({
+      try: () => simpleParser(Buffer.from(candidate.source)),
+      catch: "Failed to parse Gmail IMAP message",
+    })
+    if (parsedMessage.subject) {
+      sources.push(parsedMessage.subject)
+    }
+    if (parsedMessage.text) {
+      sources.push(parsedMessage.text)
+    }
+    if (parsedMessage.html) {
+      sources.push(String(parsedMessage.html))
+    }
+
+    return sources
+  })
+}
+
+function decodeQuotedPrintable(value: string): string {
+  return (
+    value
+      .replaceAll(/=\r?\n/g, "")
+      // oxlint-disable-next-line typescript/no-unsafe-argument
+      .replaceAll(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+  )
+}
+
+function extractCodeFromText(rawContent: string): string | null {
+  const decodedContent = decodeQuotedPrintable(rawContent)
+  const htmlAsText = decodedContent.replaceAll(/<[^>]*>/g, " ")
+  const collapsedText = htmlAsText.replaceAll(/\s+/g, " ")
+  const candidates = collectCandidateCodes(collapsedText)
+
+  return candidates.find((candidate) => candidate !== "000000") ?? null
+}
+
+function collectCandidateCodes(text: string): string[] {
+  const orderedCandidates: string[] = []
+  const preferredPatterns = [
+    /(?:codigo|c\u00f3digo)\D{0,20}(\d{6})/gi,
+    /(?:entrar(?:\s+a)?\s+tu\s+cuenta)\D{0,20}(\d{6})/gi,
+    /(?:cuenta)\D{0,20}(\d{6})/gi,
+  ]
+
+  for (const pattern of preferredPatterns) {
+    for (const match of text.matchAll(pattern)) {
+      if (match[1]) {
+        orderedCandidates.push(match[1])
+      }
+    }
+  }
+
+  for (const match of text.matchAll(/\b(\d{6})\b/g)) {
+    if (match[1]) {
+      orderedCandidates.push(match[1])
+    }
+  }
+
+  return [...new Set(orderedCandidates)]
+}

--- a/src/fintual/email-2fa.ts
+++ b/src/fintual/email-2fa.ts
@@ -1,9 +1,14 @@
-import { Effect } from "effect"
-import { ImapFlow, type SearchObject } from "imapflow"
-import { simpleParser } from "mailparser"
+import { Clock, Effect } from "effect"
+import { ImapFlow } from "imapflow"
 import { error, log, sleep, tryPromise, warn } from "../effect.ts"
 import type { Email2FAConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
+import {
+  buildEmail2FASearchQueries,
+  isGmailImapHost,
+  selectEmail2FACode,
+  type Email2FACandidate,
+} from "./email-2fa-policy.ts"
 
 const DEFAULT_TIMEOUT_MS = 10000
 const DEFAULT_POLL_INTERVAL_MS = 2000
@@ -38,7 +43,7 @@ export function get2FACodeFromEmail(
   return Effect.gen(function* () {
     yield* log("Connecting to Gmail IMAP for automatic 2FA retrieval...")
     const imapClient = createImapClient(config)
-    const startedAt = Date.now()
+    const startedAt = yield* Clock.currentTimeMillis
     const seenMessageKeys = new Set<string>()
 
     const program = Effect.gen(function* () {
@@ -47,14 +52,15 @@ export function get2FACodeFromEmail(
         catch: "Failed to connect to Gmail IMAP",
       })
 
-      while (Date.now() - startedAt < timeoutMs) {
+      while ((yield* Clock.currentTimeMillis) - startedAt < timeoutMs) {
         const code = yield* searchForCode(config, imapClient, afterTimestamp, seenMessageKeys)
         if (code) {
           yield* log("2FA code retrieved from Gmail.")
           return code
         }
 
-        const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000)
+        const now = yield* Clock.currentTimeMillis
+        const elapsedSeconds = Math.round((now - startedAt) / 1000)
         yield* log(`Waiting for 2FA email... (${elapsedSeconds}s elapsed)`)
         yield* sleep(pollIntervalMs)
       }
@@ -158,6 +164,7 @@ function extractCodeFromMailboxUids(
   const recentUids = messageUids.slice(-MAX_RESULTS).reverse()
 
   return Effect.gen(function* () {
+    const candidates: Email2FACandidate[] = []
     for (const uid of recentUids) {
       const key = messageSeenKey(mailboxPath, uid)
       if (seenMessageKeys.has(key)) {
@@ -186,18 +193,14 @@ function extractCodeFromMailboxUids(
         typeof message.internalDate === "string"
           ? new Date(message.internalDate)
           : message.internalDate
-      const deliveredAt = internalDate?.getTime() ?? 0
-      if (deliveredAt > 0 && deliveredAt < afterTimestamp.getTime()) {
-        continue
-      }
-
-      const code = yield* extractCodeFromMessage(message.source, message.envelope?.subject ?? "")
-      if (code) {
-        return code
-      }
+      candidates.push({
+        source: message.source,
+        envelopeSubject: message.envelope?.subject,
+        receivedAt: internalDate,
+      })
     }
 
-    return null
+    return yield* selectEmail2FACode(candidates, afterTimestamp)
   })
 }
 
@@ -206,7 +209,7 @@ function runMailboxSearch(
   imapClient: ImapFlow,
   afterTimestamp: Date,
 ): Effect.Effect<number[] | false, Error> {
-  const queries = buildSearchQueries(config, afterTimestamp)
+  const queries = buildEmail2FASearchQueries(config, afterTimestamp)
 
   return Effect.gen(function* () {
     for (const query of queries) {
@@ -233,47 +236,6 @@ function runMailboxSearch(
   })
 }
 
-function isGmailImapHost(host: string): boolean {
-  const normalized = host.trim().toLowerCase()
-  return normalized === "imap.gmail.com" || normalized === "imap.googlemail.com"
-}
-
-/** Gmail web-style search; avoids broken IMAP SUBJECT matching for UTF-8 (e.g. "Código"). */
-function formatGmailAfterDate(d: Date): string {
-  const yyyy = d.getFullYear()
-  const mm = String(d.getMonth() + 1).padStart(2, "0")
-  const dd = String(d.getDate()).padStart(2, "0")
-  return `${yyyy}/${mm}/${dd}`
-}
-
-function buildSearchQueries(config: Email2FAConfig, afterTimestamp: Date): SearchObject[] {
-  const queries: SearchObject[] = []
-
-  if (isGmailImapHost(config.host)) {
-    const after = formatGmailAfterDate(afterTimestamp)
-    queries.push({
-      gmraw: `from:${config.sender} after:${after}`,
-    })
-    queries.push({
-      gmraw: `from:fintual.com after:${after}`,
-    })
-    // Relative window avoids rare date/TZ mismatches between container and Gmail account settings.
-    queries.push({
-      gmraw: `from:${config.sender} newer_than:1d`,
-    })
-    queries.push({
-      gmraw: `from:fintual.com newer_than:1d`,
-    })
-  }
-
-  queries.push({
-    from: config.sender,
-    since: afterTimestamp,
-  })
-
-  return queries
-}
-
 function closeImapClient(imapClient: ImapFlow): Effect.Effect<void> {
   if (!imapClient.usable) {
     return Effect.void
@@ -286,99 +248,4 @@ function closeImapClient(imapClient: ImapFlow): Effect.Effect<void> {
     }),
     (cause) => warn(`Failed to close IMAP connection cleanly: ${getErrorMessage(cause)}`),
   )
-}
-
-function extractCodeFromMessage(
-  rawSource: Buffer | Uint8Array,
-  envelopeSubject: string,
-): Effect.Effect<string | null, Error> {
-  return Effect.gen(function* () {
-    const sources = yield* collectMessageSources(rawSource, envelopeSubject)
-
-    for (const source of sources) {
-      const code = extractCodeFromText(source)
-      if (code) {
-        return code
-      }
-    }
-
-    return null
-  })
-}
-
-function collectMessageSources(
-  rawSource: Buffer | Uint8Array,
-  envelopeSubject: string,
-): Effect.Effect<string[], Error> {
-  return Effect.gen(function* () {
-    const sources: string[] = []
-    if (envelopeSubject) {
-      sources.push(envelopeSubject)
-    }
-
-    const parsedMessage = yield* tryPromise({
-      try: () => simpleParser(Buffer.from(rawSource)),
-      catch: "Failed to parse Gmail IMAP message",
-    })
-    if (parsedMessage.subject) {
-      sources.push(parsedMessage.subject)
-    }
-    if (parsedMessage.text) {
-      sources.push(parsedMessage.text)
-    }
-    if (parsedMessage.html) {
-      sources.push(String(parsedMessage.html))
-    }
-
-    return sources
-  })
-}
-
-function decodeQuotedPrintable(value: string): string {
-  return (
-    value
-      .replaceAll(/=\r?\n/g, "")
-      // oxlint-disable-next-line typescript/no-unsafe-argument
-      .replaceAll(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
-  )
-}
-
-function extractCodeFromText(rawContent: string): string | null {
-  const decodedContent = decodeQuotedPrintable(rawContent)
-  const htmlAsText = decodedContent.replaceAll(/<[^>]*>/g, " ")
-  const collapsedText = htmlAsText.replaceAll(/\s+/g, " ")
-  const candidates = collectCandidateCodes(collapsedText)
-
-  for (const candidate of candidates) {
-    if (candidate !== "000000") {
-      return candidate
-    }
-  }
-
-  return null
-}
-
-function collectCandidateCodes(text: string): string[] {
-  const orderedCandidates: string[] = []
-  const preferredPatterns = [
-    /(?:codigo|c\u00f3digo)\D{0,20}(\d{6})/gi,
-    /(?:entrar(?:\s+a)?\s+tu\s+cuenta)\D{0,20}(\d{6})/gi,
-    /(?:cuenta)\D{0,20}(\d{6})/gi,
-  ]
-
-  for (const pattern of preferredPatterns) {
-    for (const match of text.matchAll(pattern)) {
-      if (match[1]) {
-        orderedCandidates.push(match[1])
-      }
-    }
-  }
-
-  for (const match of text.matchAll(/\b(\d{6})\b/g)) {
-    if (match[1]) {
-      orderedCandidates.push(match[1])
-    }
-  }
-
-  return [...new Set(orderedCandidates)]
 }

--- a/src/fintual/fixtures/2fa-html.eml
+++ b/src/fintual/fixtures/2fa-html.eml
@@ -1,0 +1,7 @@
+From: Fintual <no-responder@fintual.com>
+To: investor@example.com
+Subject: Acceso a Fintual
+MIME-Version: 1.0
+Content-Type: text/html; charset=utf-8
+
+<html><body><p>Usa este código para entrar a tu cuenta:</p><strong>234567</strong></body></html>

--- a/src/fintual/fixtures/2fa-plain.eml
+++ b/src/fintual/fixtures/2fa-plain.eml
@@ -1,0 +1,6 @@
+From: Fintual <no-responder@fintual.com>
+To: investor@example.com
+Subject: Tu codigo para entrar a tu cuenta
+Content-Type: text/plain; charset=utf-8
+
+Tu codigo para entrar a tu cuenta es 123456.

--- a/src/fintual/fixtures/2fa-quoted-printable.eml
+++ b/src/fintual/fixtures/2fa-quoted-printable.eml
@@ -1,0 +1,9 @@
+From: Fintual <no-responder@fintual.com>
+To: investor@example.com
+Subject: =?UTF-8?Q?C=C3=B3digo_de_seguridad?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Tu c=C3=B3digo para entrar a tu cuenta es=
+ 345678.


### PR DESCRIPTION
Closes #268

## Summary

- extract Gmail query construction and MIME/code-selection policy into a locally testable module
- cover plain-text, HTML, and quoted-printable messages with captured fixtures
- reject stale and invalid candidates while preserving the private IMAP facade
- use Effect Clock for polling deadline measurements

## Why

The Gmail IMAP adapter previously mixed mailbox resource management with failure-prone query and parsing policy. Isolating that policy keeps the caller interface small while making email variants and fallback behavior deterministic to verify.

## Validation

- `pnpm test` (25 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm fallow:ci`