### PR TITLE
fix(env): preserve quoted-empty values after Effect v4 migration

### DIFF
--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -62,6 +62,19 @@ test("uses legacy starting date and enables email 2FA when both credentials are 
   })
 })
 
+test("preserves quoted-empty values instead of falling back to defaults", async () => {
+  const configuration = await Effect.runPromise(
+    resolveRuntimeConfig({
+      ...requiredEnvironment(),
+      ACTUAL_PAYEE: "''",
+      STARTING_DATE: "''",
+    }),
+  )
+
+  expect(configuration.actual.payee).toBe("")
+  expect(configuration.actual.startingDate).toBe("")
+})
+
 test("reports all missing required runtime values", async () => {
   const result = await Effect.runPromise(Effect.result(resolveRuntimeConfig({})))
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -42,6 +42,7 @@ export function resolveRuntimeConfig(
           value ? [[name, normalizeEnvValue(value)]] : [],
         ),
       ),
+      { preserveEmptyStrings: true },
     )
     const values = yield* runtimeValueConfig.pipe(
       Effect.provideService(ConfigProvider.ConfigProvider, provider),


### PR DESCRIPTION
## What changed

- add `preserveEmptyStrings: true` to the `ConfigProvider.fromUnknown` call in `src/env.ts`
- add a regression test asserting `ACTUAL_PAYEE=''` and `STARTING_DATE=''` resolve to `""` instead of their defaults

## Why

Follow-up to #278 (discussion_r3754394224). Effect v4's `ConfigProvider.fromUnknown` treats a present-but-empty string value as missing (`emptyStringAsMissing`), where v3's `fromMap` returned it as-is. Since the provider is fed `normalizeEnvValue` output, a quoted-empty env var like `ACTUAL_PAYEE=''` silently fell back to the `withDefault("Fintual")` — that key is what disables the Actual payee filter, so the migration changed sync behavior.

## Validation

- `pnpm test` — 26 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`