### PR TITLE
refactor(actual): separate reconciliation policy from the SDK implementation

### DIFF
--- a/src/actual.ts
+++ b/src/actual.ts
@@ -5,6 +5,7 @@ import * as v from "valibot"
 import { log, sleep, tryPromise, trySync, warn } from "./effect.ts"
 import type { ActualConfig } from "./env.ts"
 import { getErrorMessage } from "./log.ts"
+import { planReconciliation } from "./actual/reconciliation-policy.ts"
 
 const ACTUAL_DATA_DIR = "./tmp/actual-data"
 const BALANCE_FILE_PATH = "./tmp/fintual-data/balance-2.json"
@@ -12,8 +13,6 @@ const MAX_SYNC_ATTEMPTS = 5
 const INITIAL_RETRY_DELAY_MS = 5000
 const MAX_RETRY_DELAY_MS = 60000
 const RETRY_JITTER_RATIO = 0.2
-const VARIATION_NOTES = "Variation"
-const VARIATION_IMPORTED_ID_PREFIX = "fintual-variation:"
 
 const balanceFileSchema = v.object({
   balance: v.array(
@@ -35,16 +34,6 @@ const balanceFileSchema = v.object({
 
 type BalanceEntry = v.InferOutput<typeof balanceFileSchema>["balance"][number]
 type ActualInitConfig = Parameters<typeof api.init>[0]
-type ActualTransaction = Awaited<ReturnType<typeof api.getTransactions>>[number]
-
-interface VariationTransactionFields {
-  date: string
-  amount: number
-  payee: string | undefined
-  notes: string
-  imported_id: string
-  cleared: boolean
-}
 
 interface SyncCounts {
   created: number
@@ -124,56 +113,51 @@ function syncDailyVariationTransactions(config: ActualConfig): Effect.Effect<Syn
       catch: "Failed to fetch Actual transactions",
     })
 
-    const balanceEntries = yield* normalizeBalanceEntries(yield* loadBalanceEntries(config))
+    const balanceEntries = yield* loadBalanceEntries(config)
     const payeeId = yield* getPayeeId(config)
-    const variationTransactionsByDate = groupVariationTransactionsByDate(transactions, payeeId)
-    const processedDates = new Set<string>()
+    const plan = planReconciliation({
+      balanceEntries,
+      existingTransactions: transactions,
+      payeeId,
+    })
+
+    for (const warning of plan.warnings) {
+      yield* warn(warning)
+    }
+
     const syncCounts: SyncCounts = {
       created: 0,
       updated: 0,
       deletedDuplicates: 0,
     }
 
-    for (const balanceEntry of balanceEntries) {
-      const transaction = createVariationTransaction(balanceEntry, payeeId)
-      const existingTransactions = variationTransactionsByDate.get(transaction.date) ?? []
-      processedDates.add(transaction.date)
-
-      if (existingTransactions.length === 0) {
-        yield* tryPromise({
-          try: () => api.addTransactions(config.fintualAccount, [transaction]),
-          catch: "Failed to add Actual transaction",
-        })
-        syncCounts.created += 1
-        continue
+    for (const action of plan.actions) {
+      switch (action.type) {
+        case "create": {
+          yield* tryPromise({
+            try: () => api.addTransactions(config.fintualAccount, [action.transaction]),
+            catch: "Failed to add Actual transaction",
+          })
+          syncCounts.created += 1
+          break
+        }
+        case "update": {
+          yield* tryPromise({
+            try: () => api.updateTransaction(action.id, action.transaction),
+            catch: "Failed to update Actual transaction",
+          })
+          syncCounts.updated += 1
+          break
+        }
+        case "delete": {
+          yield* tryPromise({
+            try: () => api.deleteTransaction(action.id),
+            catch: "Failed to delete duplicate Actual transaction",
+          })
+          syncCounts.deletedDuplicates += 1
+          break
+        }
       }
-
-      const canonicalTransaction = getCanonicalVariationTransaction(
-        existingTransactions,
-        transaction.date,
-      )
-      yield* tryPromise({
-        try: () => api.updateTransaction(canonicalTransaction.id, transaction),
-        catch: "Failed to update Actual transaction",
-      })
-      syncCounts.updated += 1
-
-      syncCounts.deletedDuplicates += yield* deleteDuplicateVariationTransactions(
-        existingTransactions,
-        canonicalTransaction.id,
-      )
-    }
-
-    for (const [date, existingTransactions] of variationTransactionsByDate.entries()) {
-      if (processedDates.has(date) || existingTransactions.length < 2) {
-        continue
-      }
-
-      const canonicalTransaction = getCanonicalVariationTransaction(existingTransactions, date)
-      syncCounts.deletedDuplicates += yield* deleteDuplicateVariationTransactions(
-        existingTransactions,
-        canonicalTransaction.id,
-      )
     }
 
     yield* tryPromise({
@@ -214,139 +198,6 @@ function loadBalanceEntries(config: ActualConfig): Effect.Effect<BalanceEntry[],
   })
 }
 
-function normalizeBalanceEntries(
-  balanceEntries: BalanceEntry[],
-): Effect.Effect<BalanceEntry[], Error> {
-  return Effect.gen(function* () {
-    const entriesByDate = new Map<string, BalanceEntry[]>()
-
-    for (const balanceEntry of balanceEntries) {
-      const date = toIsoDate(balanceEntry.date)
-      const entries = entriesByDate.get(date) ?? []
-      entries.push(balanceEntry)
-      entriesByDate.set(date, entries)
-    }
-
-    const normalizedEntries: BalanceEntry[] = []
-
-    for (const [date, entries] of entriesByDate.entries()) {
-      const latestEntry = entries.sort((left, right) => right.date - left.date)[0]
-      normalizedEntries.push(latestEntry)
-
-      if (entries.length > 1) {
-        yield* warn(
-          `Fintual balance data contains ${entries.length} entries for ${date}. Keeping latest timestamp ${latestEntry.date}.`,
-        )
-      }
-    }
-
-    return normalizedEntries.sort((left, right) => left.date - right.date)
-  })
-}
-
-function createVariationTransaction(
-  balanceEntry: BalanceEntry,
-  payeeId: string | undefined,
-): VariationTransactionFields {
-  const date = toIsoDate(balanceEntry.date)
-
-  return {
-    date,
-    amount: Math.round(Math.round(balanceEntry.real_difference) * 100),
-    payee: payeeId,
-    notes: VARIATION_NOTES,
-    imported_id: getVariationImportedId(date),
-    cleared: true,
-  }
-}
-
-function getVariationImportedId(date: string): string {
-  return `${VARIATION_IMPORTED_ID_PREFIX}${date}`
-}
-
-function groupVariationTransactionsByDate(
-  transactions: ActualTransaction[],
-  payeeId: string | undefined,
-): Map<string, ActualTransaction[]> {
-  const transactionsByDate = new Map<string, ActualTransaction[]>()
-
-  for (const transaction of transactions) {
-    if (!isManagedVariationTransaction(transaction, payeeId)) {
-      continue
-    }
-
-    const date = getVariationTransactionDate(transaction)
-    if (!date) {
-      continue
-    }
-
-    const dateTransactions = transactionsByDate.get(date) ?? []
-    dateTransactions.push(transaction)
-    transactionsByDate.set(date, dateTransactions)
-  }
-
-  return transactionsByDate
-}
-
-function isManagedVariationTransaction(
-  transaction: ActualTransaction,
-  payeeId: string | undefined,
-): boolean {
-  return transaction.notes === VARIATION_NOTES && (!payeeId || transaction.payee === payeeId)
-}
-
-function getVariationTransactionDate(transaction: ActualTransaction): string | null {
-  if (transaction.imported_id?.startsWith(VARIATION_IMPORTED_ID_PREFIX)) {
-    const date = transaction.imported_id.slice(VARIATION_IMPORTED_ID_PREFIX.length)
-    if (isIsoDate(date)) {
-      return date
-    }
-  }
-
-  if (transaction.imported_id && isNumericTimestamp(transaction.imported_id)) {
-    return toIsoDate(Number(transaction.imported_id))
-  }
-
-  if (transaction.date && isIsoDate(transaction.date)) {
-    return transaction.date
-  }
-
-  return null
-}
-
-function getCanonicalVariationTransaction(
-  transactions: ActualTransaction[],
-  date: string,
-): ActualTransaction {
-  return (
-    transactions.find((transaction) => transaction.imported_id === getVariationImportedId(date)) ??
-    transactions[0]
-  )
-}
-
-function deleteDuplicateVariationTransactions(
-  transactions: ActualTransaction[],
-  canonicalTransactionId: string,
-): Effect.Effect<number, Error> {
-  return Effect.gen(function* () {
-    let deletedDuplicates = 0
-
-    for (const transaction of transactions) {
-      if (transaction.id === canonicalTransactionId) {
-        continue
-      }
-
-      yield* tryPromise({
-        try: () => api.deleteTransaction(transaction.id),
-        catch: "Failed to delete duplicate Actual transaction",
-      })
-      deletedDuplicates += 1
-    }
-
-    return deletedDuplicates
-  })
-}
-
 function getPayeeId(config: ActualConfig): Effect.Effect<string | undefined, Error> {
   return Effect.gen(function* () {
     const payees = yield* tryPromise({
@@ -366,18 +217,6 @@ function getPayeeId(config: ActualConfig): Effect.Effect<string | undefined, Err
 
 function getTodayIsoDate(): string {
   return new Date().toISOString().split("T")[0]
-}
-
-function toIsoDate(timestamp: number): string {
-  return new Date(timestamp).toISOString().split("T")[0]
-}
-
-function isIsoDate(value: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}$/.test(value)
-}
-
-function isNumericTimestamp(value: string): boolean {
-  return /^\d+$/.test(value)
 }
 
 function isRetryableActualError(error: unknown): boolean {

--- a/src/actual/reconciliation-policy.test.ts
+++ b/src/actual/reconciliation-policy.test.ts
@@ -1,0 +1,202 @@
+import { expect, test } from "vitest"
+import {
+  VARIATION_IMPORTED_ID_PREFIX,
+  VARIATION_NOTES,
+  planReconciliation,
+  type BalanceEntry,
+  type ExistingVariationTransaction,
+} from "./reconciliation-policy.ts"
+
+function balanceEntry(date: string, realDifference: number, timestampOffsetMs = 0): BalanceEntry {
+  return {
+    date: Date.parse(`${date}T00:00:00Z`) + timestampOffsetMs,
+    real_difference: realDifference,
+  }
+}
+
+function existingTransaction(
+  id: string,
+  date: string,
+  options: { notes?: string; payee?: string; importedId?: string } = {},
+): ExistingVariationTransaction {
+  return {
+    id,
+    date,
+    notes: options.notes ?? VARIATION_NOTES,
+    payee: options.payee,
+    imported_id: options.importedId,
+  }
+}
+
+function variationTransaction(date: string, amount: number, payeeId?: string) {
+  return {
+    date,
+    amount,
+    payee: payeeId,
+    notes: VARIATION_NOTES,
+    imported_id: `${VARIATION_IMPORTED_ID_PREFIX}${date}`,
+    cleared: true,
+  }
+}
+
+const create = (transaction: ReturnType<typeof variationTransaction>) =>
+  ({ type: "create", transaction }) as const
+const update = (id: string, transaction: ReturnType<typeof variationTransaction>) =>
+  ({ type: "update", id, transaction }) as const
+const deleteTransaction = (id: string) => ({ type: "delete", id }) as const
+
+test.each([
+  {
+    name: "creates a transaction when no managed transaction exists for the date",
+    balanceEntries: [balanceEntry("2026-01-05", 12.49)],
+    existingTransactions: [],
+    payeeId: "payee-1",
+    expectedActions: [create(variationTransaction("2026-01-05", 1200, "payee-1"))],
+  },
+  {
+    name: "updates the canonical transaction and deletes legacy duplicates",
+    balanceEntries: [balanceEntry("2026-01-05", -4.75)],
+    existingTransactions: [
+      existingTransaction("legacy-1", "2026-01-05", {
+        importedId: String(Date.parse("2026-01-05T00:00:00Z")),
+      }),
+      existingTransaction("canon", "2026-01-05", {
+        importedId: `${VARIATION_IMPORTED_ID_PREFIX}2026-01-05`,
+      }),
+    ],
+    expectedActions: [
+      update("canon", variationTransaction("2026-01-05", -500)),
+      deleteTransaction("legacy-1"),
+    ],
+  },
+  {
+    name: "updates the first legacy transaction when no canonical id exists",
+    balanceEntries: [balanceEntry("2026-01-05", 3)],
+    existingTransactions: [
+      existingTransaction("legacy-1", "2026-01-05", {
+        importedId: String(Date.parse("2026-01-05T00:00:00Z")),
+      }),
+      existingTransaction("legacy-2", "2026-01-05", {
+        importedId: String(Date.parse("2026-01-05T00:00:00Z") + 1000),
+      }),
+    ],
+    expectedActions: [
+      update("legacy-1", variationTransaction("2026-01-05", 300)),
+      deleteTransaction("legacy-2"),
+    ],
+  },
+  {
+    name: "manages every variation transaction when no payee is configured",
+    balanceEntries: [balanceEntry("2026-01-05", 6)],
+    existingTransactions: [
+      existingTransaction("foreign-payee", "2026-01-05", { payee: "someone-else" }),
+    ],
+    expectedActions: [update("foreign-payee", variationTransaction("2026-01-05", 600))],
+  },
+  {
+    name: "ignores transactions with different notes or payee and creates a new one",
+    balanceEntries: [balanceEntry("2026-01-05", 8.49)],
+    existingTransactions: [
+      existingTransaction("other-1", "2026-01-05", { notes: "Salary" }),
+      existingTransaction("other-2", "2026-01-05", { payee: "someone-else" }),
+      existingTransaction("other-3", "2026-01-05", { notes: "Salary", payee: "someone-else" }),
+    ],
+    payeeId: "payee-1",
+    expectedActions: [create(variationTransaction("2026-01-05", 800, "payee-1"))],
+  },
+  {
+    name: "reconciles multiple dates in balance entry order",
+    balanceEntries: [balanceEntry("2026-01-06", 5), balanceEntry("2026-01-05", 10)],
+    existingTransactions: [
+      existingTransaction("jan-5", "2026-01-05", {
+        importedId: `${VARIATION_IMPORTED_ID_PREFIX}2026-01-05`,
+      }),
+      existingTransaction("jan-6", "2026-01-06", {
+        importedId: `${VARIATION_IMPORTED_ID_PREFIX}2026-01-06`,
+      }),
+      existingTransaction("jan-6-dup", "2026-01-06", {
+        importedId: `${VARIATION_IMPORTED_ID_PREFIX}2026-01-06`,
+      }),
+    ],
+    expectedActions: [
+      update("jan-5", variationTransaction("2026-01-05", 1000)),
+      update("jan-6", variationTransaction("2026-01-06", 500)),
+      deleteTransaction("jan-6-dup"),
+    ],
+  },
+  {
+    name: "deletes duplicates for dates with no balance entry",
+    balanceEntries: [balanceEntry("2026-01-05", 1)],
+    existingTransactions: [
+      existingTransaction("jan-5", "2026-01-05", {
+        importedId: `${VARIATION_IMPORTED_ID_PREFIX}2026-01-05`,
+      }),
+      existingTransaction("orphan-1", "2026-01-07", {
+        importedId: String(Date.parse("2026-01-07T00:00:00Z")),
+      }),
+      existingTransaction("orphan-2", "2026-01-07", {
+        importedId: `${VARIATION_IMPORTED_ID_PREFIX}2026-01-07`,
+      }),
+    ],
+    expectedActions: [
+      update("jan-5", variationTransaction("2026-01-05", 100)),
+      deleteTransaction("orphan-1"),
+    ],
+  },
+  {
+    name: "leaves a single orphaned transaction untouched",
+    balanceEntries: [],
+    existingTransactions: [
+      existingTransaction("orphan-1", "2026-01-07", {
+        importedId: `${VARIATION_IMPORTED_ID_PREFIX}2026-01-07`,
+      }),
+    ],
+    expectedActions: [],
+  },
+])("$name", ({ balanceEntries, existingTransactions, payeeId, expectedActions }) => {
+  const plan = planReconciliation({ balanceEntries, existingTransactions, payeeId })
+
+  expect(plan.actions).toEqual(expectedActions)
+})
+
+test("keeps the latest timestamp when the balance file has duplicate dates", () => {
+  const plan = planReconciliation({
+    balanceEntries: [
+      balanceEntry("2026-01-05", 10, 0),
+      balanceEntry("2026-01-05", 11.49, 3600_000),
+    ],
+    existingTransactions: [],
+  })
+
+  expect(plan.actions).toEqual([create(variationTransaction("2026-01-05", 1100))])
+  expect(plan.warnings).toEqual([
+    "Fintual balance data contains 2 entries for 2026-01-05. Keeping latest timestamp " +
+      `${Date.parse("2026-01-05T00:00:00Z") + 3600_000}.`,
+  ])
+})
+
+test("groups a legacy numeric imported id under its date even when the date field is stale", () => {
+  const plan = planReconciliation({
+    balanceEntries: [balanceEntry("2026-01-05", 2.49)],
+    existingTransactions: [
+      existingTransaction("legacy-1", "2020-01-01", {
+        importedId: String(Date.parse("2026-01-05T00:00:00Z")),
+      }),
+    ],
+  })
+
+  expect(plan.actions).toEqual([update("legacy-1", variationTransaction("2026-01-05", 200))])
+})
+
+test("skips managed-looking transactions whose date cannot be derived", () => {
+  const plan = planReconciliation({
+    balanceEntries: [balanceEntry("2026-01-05", 2.49)],
+    existingTransactions: [
+      existingTransaction("undated-1", "not-a-date", {
+        importedId: "not-a-date",
+      }),
+    ],
+  })
+
+  expect(plan.actions).toEqual([create(variationTransaction("2026-01-05", 200))])
+})

--- a/src/actual/reconciliation-policy.ts
+++ b/src/actual/reconciliation-policy.ts
@@ -1,0 +1,209 @@
+export const VARIATION_NOTES = "Variation"
+export const VARIATION_IMPORTED_ID_PREFIX = "fintual-variation:"
+
+export interface BalanceEntry {
+  date: number
+  real_difference: number
+}
+
+export interface ExistingVariationTransaction {
+  id: string
+  date?: string
+  notes?: string
+  payee?: string | null
+  imported_id?: string
+}
+
+export interface VariationTransactionInput {
+  date: string
+  amount: number
+  payee?: string
+  notes: string
+  imported_id: string
+  cleared: boolean
+}
+
+export type ReconciliationAction =
+  | { type: "create"; transaction: VariationTransactionInput }
+  | { type: "update"; id: string; transaction: VariationTransactionInput }
+  | { type: "delete"; id: string }
+
+export interface ReconciliationPlan {
+  actions: ReconciliationAction[]
+  warnings: string[]
+}
+
+export function planReconciliation(options: {
+  balanceEntries: BalanceEntry[]
+  existingTransactions: Iterable<ExistingVariationTransaction>
+  payeeId?: string
+}): ReconciliationPlan {
+  const warnings: string[] = []
+  const balanceEntries = normalizeBalanceEntries(options.balanceEntries, warnings)
+  const variationTransactionsByDate = groupVariationTransactionsByDate(
+    options.existingTransactions,
+    options.payeeId,
+  )
+
+  const actions: ReconciliationAction[] = []
+  const processedDates = new Set<string>()
+
+  for (const balanceEntry of balanceEntries) {
+    const transaction = createVariationTransaction(balanceEntry, options.payeeId)
+    const existingTransactions = variationTransactionsByDate.get(transaction.date) ?? []
+    processedDates.add(transaction.date)
+
+    if (existingTransactions.length === 0) {
+      actions.push({ type: "create", transaction })
+      continue
+    }
+
+    const canonicalTransaction = getCanonicalVariationTransaction(
+      existingTransactions,
+      transaction.date,
+    )
+    actions.push({ type: "update", id: canonicalTransaction.id, transaction })
+    actions.push(...getDeleteActions(existingTransactions, canonicalTransaction.id))
+  }
+
+  for (const [date, existingTransactions] of variationTransactionsByDate.entries()) {
+    if (processedDates.has(date) || existingTransactions.length < 2) {
+      continue
+    }
+
+    const canonicalTransaction = getCanonicalVariationTransaction(existingTransactions, date)
+    actions.push(...getDeleteActions(existingTransactions, canonicalTransaction.id))
+  }
+
+  return { actions, warnings }
+}
+
+function normalizeBalanceEntries(
+  balanceEntries: BalanceEntry[],
+  warnings: string[],
+): BalanceEntry[] {
+  const entriesByDate = new Map<string, BalanceEntry[]>()
+
+  for (const balanceEntry of balanceEntries) {
+    const date = toIsoDate(balanceEntry.date)
+    const entries = entriesByDate.get(date) ?? []
+    entries.push(balanceEntry)
+    entriesByDate.set(date, entries)
+  }
+
+  const normalizedEntries: BalanceEntry[] = []
+
+  for (const [date, entries] of entriesByDate.entries()) {
+    const latestEntry = entries.sort((left, right) => right.date - left.date)[0]
+    normalizedEntries.push(latestEntry)
+
+    if (entries.length > 1) {
+      warnings.push(
+        `Fintual balance data contains ${entries.length} entries for ${date}. Keeping latest timestamp ${latestEntry.date}.`,
+      )
+    }
+  }
+
+  return normalizedEntries.sort((left, right) => left.date - right.date)
+}
+
+function createVariationTransaction(
+  balanceEntry: BalanceEntry,
+  payeeId: string | undefined,
+): VariationTransactionInput {
+  const date = toIsoDate(balanceEntry.date)
+
+  return {
+    date,
+    amount: Math.round(Math.round(balanceEntry.real_difference) * 100),
+    payee: payeeId,
+    notes: VARIATION_NOTES,
+    imported_id: getVariationImportedId(date),
+    cleared: true,
+  }
+}
+
+function getVariationImportedId(date: string): string {
+  return `${VARIATION_IMPORTED_ID_PREFIX}${date}`
+}
+
+function groupVariationTransactionsByDate(
+  transactions: Iterable<ExistingVariationTransaction>,
+  payeeId: string | undefined,
+): Map<string, ExistingVariationTransaction[]> {
+  const transactionsByDate = new Map<string, ExistingVariationTransaction[]>()
+
+  for (const transaction of transactions) {
+    if (!isManagedVariationTransaction(transaction, payeeId)) {
+      continue
+    }
+
+    const date = getVariationTransactionDate(transaction)
+    if (!date) {
+      continue
+    }
+
+    const dateTransactions = transactionsByDate.get(date) ?? []
+    dateTransactions.push(transaction)
+    transactionsByDate.set(date, dateTransactions)
+  }
+
+  return transactionsByDate
+}
+
+function isManagedVariationTransaction(
+  transaction: ExistingVariationTransaction,
+  payeeId: string | undefined,
+): boolean {
+  return transaction.notes === VARIATION_NOTES && (!payeeId || transaction.payee === payeeId)
+}
+
+function getVariationTransactionDate(transaction: ExistingVariationTransaction): string | null {
+  if (transaction.imported_id?.startsWith(VARIATION_IMPORTED_ID_PREFIX)) {
+    const date = transaction.imported_id.slice(VARIATION_IMPORTED_ID_PREFIX.length)
+    if (isIsoDate(date)) {
+      return date
+    }
+  }
+
+  if (transaction.imported_id && isNumericTimestamp(transaction.imported_id)) {
+    return toIsoDate(Number(transaction.imported_id))
+  }
+
+  if (transaction.date && isIsoDate(transaction.date)) {
+    return transaction.date
+  }
+
+  return null
+}
+
+function getCanonicalVariationTransaction(
+  transactions: ExistingVariationTransaction[],
+  date: string,
+): ExistingVariationTransaction {
+  return (
+    transactions.find((transaction) => transaction.imported_id === getVariationImportedId(date)) ??
+    transactions[0]
+  )
+}
+
+function getDeleteActions(
+  transactions: ExistingVariationTransaction[],
+  canonicalTransactionId: string,
+): ReconciliationAction[] {
+  return transactions
+    .filter((transaction) => transaction.id !== canonicalTransactionId)
+    .map((transaction) => ({ type: "delete", id: transaction.id }) as const)
+}
+
+function toIsoDate(timestamp: number): string {
+  return new Date(timestamp).toISOString().split("T")[0]
+}
+
+function isIsoDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value)
+}
+
+function isNumericTimestamp(value: string): boolean {
+  return /^\d+$/.test(value)
+}


### PR DESCRIPTION
Closes #267

## Summary

- extract deterministic reconciliation planning (create/update/delete choices) into an internal pure module, `src/actual/reconciliation-policy.ts`
- cover duplicates, legacy imported IDs, date normalization, canonical selection, and payee filtering with table-driven tests
- let the existing Actual SDK implementation execute the resulting plan; retry, health, and SDK lifecycle behavior remain outside the policy module

## Why

Verifying reconciliation decisions previously required the Actual SDK, filesystem data, network behavior, time, jitter, and sleeps. Concentrating the policy in one small deep module makes create/update/delete decisions locally testable while keeping SDK version changes inside the implementation.

## Validation

- `pnpm test` (37 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm fallow:audit`