### PR TITLE
refactor: pass the Performance Snapshot through the job (#266)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,5 +17,5 @@ Goal Performance Data that supplies the observations used to calculate recent ba
 _Avoid_: Last-month data, current data
 
 **Performance Snapshot**:
-The validated balance and deposit observations persisted by the Fintual side of the sync for the Actual side to consume. One module owns its shape and persistence.
+The typed balance and deposit observations passed from the Fintual sync step to the Actual sync step. One module owns its shape and persistence; the JSON file is a write-only implementation detail kept for inspection.
 _Avoid_: Balance file, balance-2.json, performance payload

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,3 +15,7 @@ _Avoid_: Six-month data, baseline data
 **Recent Goal Performance Data**:
 Goal Performance Data that supplies the observations used to calculate recent balance and deposit changes. Its Fintual time interval is an implementation detail.
 _Avoid_: Last-month data, current data
+
+**Performance Snapshot**:
+The validated balance and deposit observations persisted by the Fintual side of the sync for the Actual side to consume. One module owns its shape and persistence.
+_Avoid_: Balance file, balance-2.json, performance payload

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ pnpm once
 The worker will:
 
 - log in to Fintual over HTTP (`initiate_login` → Gmail IMAP 2FA when required → `finalize_login_web`) and fetch GraphQL performance data
-- write the result to `tmp/fintual-data/balance-2.json`
+- fold the data into a Performance Snapshot, save it to `tmp/fintual-data/balance-2.json` for inspection, and pass it to the Actual sync step
 - import variation transactions into Actual Budget
 
 ### Reverse-engineering Fintual HTTP (agent-browser)

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -4,8 +4,8 @@ import { Effect } from "effect"
 import { log, sleep, tryPromise, trySync, warn } from "./effect.ts"
 import type { ActualConfig } from "./env.ts"
 import { getErrorMessage } from "./log.ts"
-import { readPerformanceSnapshot } from "./performance-snapshot.ts"
-import { planReconciliation, type BalanceEntry } from "./actual/reconciliation-policy.ts"
+import { planReconciliation } from "./actual/reconciliation-policy.ts"
+import type { PerformanceSnapshot } from "./performance-snapshot.ts"
 
 const ACTUAL_DATA_DIR = "./tmp/actual-data"
 const MAX_SYNC_ATTEMPTS = 5
@@ -21,9 +21,12 @@ interface SyncCounts {
   deletedDuplicates: number
 }
 
-export function main(config: ActualConfig): Effect.Effect<void, Error> {
+export function main(
+  config: ActualConfig,
+  snapshot: PerformanceSnapshot,
+): Effect.Effect<void, Error> {
   return Effect.gen(function* () {
-    const syncCounts = yield* runActualSyncWithRetry(config, 1)
+    const syncCounts = yield* runActualSyncWithRetry(config, snapshot, 1)
     yield* log(
       `Actual sync finished. Created ${syncCounts.created} transactions, updated ${syncCounts.updated}, and deleted ${syncCounts.deletedDuplicates} duplicates.`,
     )
@@ -32,9 +35,10 @@ export function main(config: ActualConfig): Effect.Effect<void, Error> {
 
 function runActualSyncWithRetry(
   config: ActualConfig,
+  snapshot: PerformanceSnapshot,
   attempt: number,
 ): Effect.Effect<SyncCounts, Error> {
-  return Effect.catch(runActualSyncAttempt(config), (cause) => {
+  return Effect.catch(runActualSyncAttempt(config, snapshot), (cause) => {
     const shouldRetry = isRetryableActualError(cause) && attempt < MAX_SYNC_ATTEMPTS
 
     if (!shouldRetry) {
@@ -47,12 +51,15 @@ function runActualSyncWithRetry(
         `Actual sync attempt ${attempt} failed with a retryable error: ${getErrorMessage(cause)}. Retrying in ${Math.round(retryDelayMs / 1000)}s.`,
       )
       yield* sleep(retryDelayMs)
-      return yield* runActualSyncWithRetry(config, attempt + 1)
+      return yield* runActualSyncWithRetry(config, snapshot, attempt + 1)
     })
   })
 }
 
-function runActualSyncAttempt(config: ActualConfig): Effect.Effect<SyncCounts, Error> {
+function runActualSyncAttempt(
+  config: ActualConfig,
+  snapshot: PerformanceSnapshot,
+): Effect.Effect<SyncCounts, Error> {
   return Effect.gen(function* () {
     yield* resetDataDirectory()
     yield* assertActualServerReachable(config)
@@ -73,7 +80,7 @@ function runActualSyncAttempt(config: ActualConfig): Effect.Effect<SyncCounts, E
           try: () => api.downloadBudget(config.syncId),
           catch: "Failed to download Actual budget",
         })
-        return yield* syncDailyVariationTransactions(config)
+        return yield* syncDailyVariationTransactions(config, snapshot)
       }),
       Effect.ignore(
         tryPromise({
@@ -85,7 +92,10 @@ function runActualSyncAttempt(config: ActualConfig): Effect.Effect<SyncCounts, E
   })
 }
 
-function syncDailyVariationTransactions(config: ActualConfig): Effect.Effect<SyncCounts, Error> {
+function syncDailyVariationTransactions(
+  config: ActualConfig,
+  snapshot: PerformanceSnapshot,
+): Effect.Effect<SyncCounts, Error> {
   return Effect.gen(function* () {
     const endingDate = getTodayIsoDate()
     const transactions = yield* tryPromise({
@@ -93,7 +103,8 @@ function syncDailyVariationTransactions(config: ActualConfig): Effect.Effect<Syn
       catch: "Failed to fetch Actual transactions",
     })
 
-    const balanceEntries = yield* loadBalanceEntries(config)
+    const startingTimestamp = Date.parse(config.startingDate)
+    const balanceEntries = snapshot.balance.filter((entry) => entry.date >= startingTimestamp)
     const payeeId = yield* getPayeeId(config)
     const plan = planReconciliation({
       balanceEntries,
@@ -156,14 +167,6 @@ function resetDataDirectory(): Effect.Effect<void, Error> {
       fs.mkdirSync(ACTUAL_DATA_DIR, { recursive: true })
     },
     catch: "Failed to reset Actual data directory",
-  })
-}
-
-function loadBalanceEntries(config: ActualConfig): Effect.Effect<BalanceEntry[], Error> {
-  return Effect.gen(function* () {
-    const snapshot = yield* readPerformanceSnapshot()
-    const startingTimestamp = Date.parse(config.startingDate)
-    return snapshot.balance.filter((entry) => entry.date >= startingTimestamp)
   })
 }
 

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -1,38 +1,18 @@
 import * as fs from "node:fs"
 import * as api from "@actual-app/api"
 import { Effect } from "effect"
-import * as v from "valibot"
 import { log, sleep, tryPromise, trySync, warn } from "./effect.ts"
 import type { ActualConfig } from "./env.ts"
 import { getErrorMessage } from "./log.ts"
-import { planReconciliation } from "./actual/reconciliation-policy.ts"
+import { readPerformanceSnapshot } from "./performance-snapshot.ts"
+import { planReconciliation, type BalanceEntry } from "./actual/reconciliation-policy.ts"
 
 const ACTUAL_DATA_DIR = "./tmp/actual-data"
-const BALANCE_FILE_PATH = "./tmp/fintual-data/balance-2.json"
 const MAX_SYNC_ATTEMPTS = 5
 const INITIAL_RETRY_DELAY_MS = 5000
 const MAX_RETRY_DELAY_MS = 60000
 const RETRY_JITTER_RATIO = 0.2
 
-const balanceFileSchema = v.object({
-  balance: v.array(
-    v.object({
-      date: v.number(),
-      value: v.number(),
-      difference: v.number(),
-      real_difference: v.number(),
-    }),
-  ),
-  deposits: v.array(
-    v.object({
-      date: v.number(),
-      value: v.number(),
-      difference: v.number(),
-    }),
-  ),
-})
-
-type BalanceEntry = v.InferOutput<typeof balanceFileSchema>["balance"][number]
 type ActualInitConfig = Parameters<typeof api.init>[0]
 
 interface SyncCounts {
@@ -181,20 +161,9 @@ function resetDataDirectory(): Effect.Effect<void, Error> {
 
 function loadBalanceEntries(config: ActualConfig): Effect.Effect<BalanceEntry[], Error> {
   return Effect.gen(function* () {
-    const parsedFile = yield* trySync({
-      // oxlint-disable-next-line typescript/consistent-type-assertions
-      try: () => JSON.parse(fs.readFileSync(BALANCE_FILE_PATH, "utf-8")) as unknown,
-      catch: "Failed to load Fintual balance file",
-    })
-    const validation = v.safeParse(balanceFileSchema, parsedFile)
-
-    if (!validation.success) {
-      yield* log("Balance file is invalid")
-      return []
-    }
-
+    const snapshot = yield* readPerformanceSnapshot()
     const startingTimestamp = Date.parse(config.startingDate)
-    return validation.output.balance.filter((entry) => entry.date >= startingTimestamp)
+    return snapshot.balance.filter((entry) => entry.date >= startingTimestamp)
   })
 }
 

--- a/src/fintual/http-sync.ts
+++ b/src/fintual/http-sync.ts
@@ -4,6 +4,7 @@ import type { FintualConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import {
   PERFORMANCE_SNAPSHOT_PATH,
+  validatePerformanceSnapshot,
   writePerformanceSnapshot,
   type PerformanceSnapshot,
 } from "../performance-snapshot.ts"
@@ -37,7 +38,8 @@ function fetchFintualPerformanceHttp(
       return yield* Effect.fail(new Error("Fintual HTTP sync: missing Goal Performance Data"))
     }
 
-    const validatedSnapshot = yield* writePerformanceSnapshot(snapshot)
+    const validatedSnapshot = yield* validatePerformanceSnapshot(snapshot)
+    yield* writePerformanceSnapshot(validatedSnapshot)
     yield* log(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`)
 
     return validatedSnapshot

--- a/src/fintual/http-sync.ts
+++ b/src/fintual/http-sync.ts
@@ -2,7 +2,11 @@ import { Effect } from "effect"
 import { error, log, trySync } from "../effect.ts"
 import type { FintualConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
-import { PERFORMANCE_SNAPSHOT_PATH, writePerformanceSnapshot } from "../performance-snapshot.ts"
+import {
+  PERFORMANCE_SNAPSHOT_PATH,
+  writePerformanceSnapshot,
+  type PerformanceSnapshot,
+} from "../performance-snapshot.ts"
 import { createAuthenticatedFintualIngestion } from "./authenticated-ingestion.ts"
 import { get2FACodeFromEmail } from "./email-2fa.ts"
 import { foldGoalPerformanceData } from "./scraper.ts"
@@ -11,7 +15,9 @@ import { foldGoalPerformanceData } from "./scraper.ts"
  * Fetches performance via `initiate_login` → (e-mail 2FA) `finalize_login_web` → GraphQL.
  * Requires Gmail IMAP env vars for accounts with e-mail 2FA.
  */
-function fetchFintualPerformanceHttp(config: FintualConfig): Effect.Effect<void, Error> {
+function fetchFintualPerformanceHttp(
+  config: FintualConfig,
+): Effect.Effect<PerformanceSnapshot, Error> {
   const fetchAuthenticatedGoalPerformance = createAuthenticatedFintualIngestion({
     fetch: globalThis.fetch,
     get2FACode: (options) => get2FACodeFromEmail(config.email2FA, options),
@@ -31,12 +37,14 @@ function fetchFintualPerformanceHttp(config: FintualConfig): Effect.Effect<void,
       return yield* Effect.fail(new Error("Fintual HTTP sync: missing Goal Performance Data"))
     }
 
-    yield* writePerformanceSnapshot(snapshot)
+    const validatedSnapshot = yield* writePerformanceSnapshot(snapshot)
     yield* log(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`)
+
+    return validatedSnapshot
   })
 }
 
-export function runFintualSync(config: FintualConfig): Effect.Effect<void, Error> {
+export function runFintualSync(config: FintualConfig): Effect.Effect<PerformanceSnapshot, Error> {
   return Effect.catch(fetchFintualPerformanceHttp(config), (cause) =>
     Effect.andThen(error(`Error: ${getErrorMessage(cause)}`), Effect.fail(cause)),
   )

--- a/src/fintual/http-sync.ts
+++ b/src/fintual/http-sync.ts
@@ -2,9 +2,10 @@ import { Effect } from "effect"
 import { error, log, trySync } from "../effect.ts"
 import type { FintualConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
+import { PERFORMANCE_SNAPSHOT_PATH, writePerformanceSnapshot } from "../performance-snapshot.ts"
 import { createAuthenticatedFintualIngestion } from "./authenticated-ingestion.ts"
 import { get2FACodeFromEmail } from "./email-2fa.ts"
-import { BALANCE_FILE_PATH, foldGoalPerformanceData, writePerformanceFile } from "./scraper.ts"
+import { foldGoalPerformanceData } from "./scraper.ts"
 
 /**
  * Fetches performance via `initiate_login` → (e-mail 2FA) `finalize_login_web` → GraphQL.
@@ -22,16 +23,16 @@ function fetchFintualPerformanceHttp(config: FintualConfig): Effect.Effect<void,
       goalId: config.goalId,
     })
 
-    const performanceData = yield* trySync({
+    const snapshot = yield* trySync({
       try: () => foldGoalPerformanceData(reference, recent),
       catch: "Failed to fold Fintual performance data",
     })
-    if (!performanceData) {
+    if (!snapshot) {
       return yield* Effect.fail(new Error("Fintual HTTP sync: missing Goal Performance Data"))
     }
 
-    yield* writePerformanceFile(performanceData)
-    yield* log(`Balance data saved to ${BALANCE_FILE_PATH}`)
+    yield* writePerformanceSnapshot(snapshot)
+    yield* log(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`)
   })
 }
 

--- a/src/fintual/http-sync.ts
+++ b/src/fintual/http-sync.ts
@@ -1,9 +1,8 @@
 import { Effect } from "effect"
-import { error, log, trySync } from "../effect.ts"
+import { error, trySync } from "../effect.ts"
 import type { FintualConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import {
-  PERFORMANCE_SNAPSHOT_PATH,
   validatePerformanceSnapshot,
   writePerformanceSnapshot,
   type PerformanceSnapshot,
@@ -40,7 +39,6 @@ function fetchFintualPerformanceHttp(
 
     const validatedSnapshot = yield* validatePerformanceSnapshot(snapshot)
     yield* writePerformanceSnapshot(validatedSnapshot)
-    yield* log(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`)
 
     return validatedSnapshot
   })

--- a/src/fintual/scraper.test.ts
+++ b/src/fintual/scraper.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "vitest"
+import type { GoalPerformanceData } from "./new-performance.ts"
+import { foldGoalPerformanceData } from "./scraper.ts"
+
+test("folds reference and recent Goal Performance Data into a Performance Snapshot", () => {
+  const snapshot = foldGoalPerformanceData(
+    performanceData([performancePoint("2026-07-30", { valuation: 1000, costBasis: 800 })]),
+    performanceData([
+      performancePoint("2026-08-01", { valuation: 1100, costBasis: 850 }),
+      performancePoint("2026-08-02", { valuation: 1150, costBasis: 900 }),
+    ]),
+  )
+
+  expect(snapshot).toEqual({
+    balance: [
+      { date: Date.parse("2026-08-01"), value: 1100, difference: 50, real_difference: 50 },
+      { date: Date.parse("2026-08-02"), value: 1150, difference: 0, real_difference: 0 },
+    ],
+    deposits: [
+      { date: Date.parse("2026-08-01"), value: 850, difference: 50 },
+      { date: Date.parse("2026-08-02"), value: 900, difference: 50 },
+    ],
+  })
+})
+
+test("returns null when reference or recent Goal Performance Data is missing", () => {
+  const data = performanceData([performancePoint("2026-08-01")])
+
+  expect(foldGoalPerformanceData(data, null)).toBeNull()
+  expect(foldGoalPerformanceData(null, data)).toBeNull()
+  expect(foldGoalPerformanceData(null, null)).toBeNull()
+})
+
+test("starts with zero differences when reference does not precede the recent window", () => {
+  const snapshot = foldGoalPerformanceData(
+    performanceData([performancePoint("2026-08-01", { valuation: 1000, costBasis: 800 })]),
+    performanceData([performancePoint("2026-08-01", { valuation: 1100, costBasis: 850 })]),
+  )
+
+  expect(snapshot).toEqual({
+    balance: [{ date: Date.parse("2026-08-01"), value: 1100, difference: 0, real_difference: 0 }],
+    deposits: [{ date: Date.parse("2026-08-01"), value: 850, difference: 0 }],
+  })
+})
+
+function performancePoint(
+  date: string,
+  options: { valuation?: number; costBasis?: number } = {},
+): GoalPerformanceData["balanceGraphDataPoints"][number] {
+  return {
+    date,
+    unrealizedCostBasisAmount: options.costBasis ?? 0,
+    unrealizedGainOrLossAmount: 0,
+    realizedCostBasisAmount: 0,
+    realizedGainOrLossAmount: 0,
+    sharesCostBasisAmount: 0,
+    sharesValuationAmount: options.valuation ?? 0,
+    pendingFulfillmentReinvestmentDepositsCostBasisAmount: 0,
+    pendingFulfillmentReinvestmentDepositsAmount: 0,
+    withdrawnAmount: 0,
+  }
+}
+
+function performanceData(
+  points: GoalPerformanceData["balanceGraphDataPoints"],
+): GoalPerformanceData {
+  return { balanceGraphDataPoints: points }
+}

--- a/src/fintual/scraper.ts
+++ b/src/fintual/scraper.ts
@@ -1,15 +1,10 @@
-import * as fs from "node:fs"
-import { Effect } from "effect"
-import { trySync } from "../effect.ts"
+import type { PerformanceSnapshot } from "../performance-snapshot.ts"
 import type { GoalPerformanceData } from "./new-performance.ts"
-
-const FINTUAL_DATA_DIR = "./tmp/fintual-data"
-export const BALANCE_FILE_PATH = `${FINTUAL_DATA_DIR}/balance-2.json`
 
 export function foldGoalPerformanceData(
   referenceData: GoalPerformanceData | null,
   recentData: GoalPerformanceData | null,
-): { balance: unknown[]; deposits: unknown[] } | null {
+): PerformanceSnapshot | null {
   if (!recentData?.balanceGraphDataPoints || !referenceData?.balanceGraphDataPoints) {
     return null
   }
@@ -75,17 +70,4 @@ function getPreviousValue(
   }
 
   return selectValue(currentPoints[0])
-}
-
-export function writePerformanceFile(performanceData: {
-  balance: unknown[]
-  deposits: unknown[]
-}): Effect.Effect<void, Error> {
-  return trySync({
-    try: () => {
-      fs.mkdirSync(FINTUAL_DATA_DIR, { recursive: true })
-      fs.writeFileSync(BALANCE_FILE_PATH, JSON.stringify(performanceData, null, 2), "utf-8")
-    },
-    catch: "Failed to write Fintual performance file",
-  })
 }

--- a/src/job.ts
+++ b/src/job.ts
@@ -7,8 +7,8 @@ import { runFintualSync } from "./fintual/http-sync.ts"
 export function runJob(config: RuntimeConfig): Effect.Effect<void, Error> {
   return Effect.gen(function* () {
     yield* log("Running job...")
-    yield* runFintualSync(config.fintual)
-    yield* mainActual(config.actual)
+    const snapshot = yield* runFintualSync(config.fintual)
+    yield* mainActual(config.actual, snapshot)
     yield* log("Job finished.")
   })
 }

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -30,6 +30,28 @@ test("rejects when deposits is not an array and reports the failing field", asyn
   )
 })
 
+test("rejects an empty balance and reports the failing field", async () => {
+  const invalidSnapshot = {
+    ...performanceSnapshot(),
+    balance: [],
+  }
+
+  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
+    /Fintual performance snapshot is invalid: .*balance/,
+  )
+})
+
+test("rejects an empty deposits and reports the failing field", async () => {
+  const invalidSnapshot = {
+    ...performanceSnapshot(),
+    deposits: [],
+  }
+
+  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
+    /Fintual performance snapshot is invalid: .*deposits/,
+  )
+})
+
 test("returns the validated snapshot for valid data", async () => {
   const snapshot = performanceSnapshot()
 

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -1,50 +1,66 @@
+import * as fs from "node:fs"
 import { Effect } from "effect"
 import { expect, test } from "vitest"
-import { parsePerformanceSnapshot, type PerformanceSnapshot } from "./performance-snapshot.ts"
+import {
+  PERFORMANCE_SNAPSHOT_PATH,
+  writePerformanceSnapshot,
+  type PerformanceSnapshot,
+} from "./performance-snapshot.ts"
 
-test("parses a valid Performance Snapshot", async () => {
-  const result = await Effect.runPromise(
-    parsePerformanceSnapshot(JSON.stringify(performanceSnapshot())),
-  )
-
-  expect(result.balance).toEqual([
-    { date: 1780264800000, value: 1100, difference: 50, real_difference: 50 },
-  ])
-  expect(result.deposits).toEqual([{ date: 1780264800000, value: 850, difference: 50 }])
-})
-
-test("fails when the Performance Snapshot is malformed JSON", async () => {
-  await expect(Effect.runPromise(parsePerformanceSnapshot("{"))).rejects.toThrow(
-    "Failed to parse Fintual performance snapshot",
-  )
-})
-
-test("fails when a balance entry is missing required fields", async () => {
-  const invalidSnapshot = performanceSnapshot()
-  const invalidBalanceEntry = {
-    date: 1780264800000,
-    value: 1100,
-    difference: 50,
+test("fails when a balance entry has a non-finite date", async () => {
+  const invalidSnapshot = {
+    ...performanceSnapshot(),
+    balance: [{ date: Number.NaN, value: 1100, difference: 50, real_difference: 50 }],
   }
 
-  await expect(
-    Effect.runPromise(
-      parsePerformanceSnapshot(
-        JSON.stringify({ ...invalidSnapshot, balance: [invalidBalanceEntry] }),
-      ),
-    ),
-  ).rejects.toThrow("Fintual performance snapshot is invalid")
+  await expect(Effect.runPromise(writePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
+    "Fintual performance snapshot is invalid",
+  )
 })
 
 test("fails when deposits is not an array", async () => {
-  const invalidSnapshot = performanceSnapshot()
+  const invalidSnapshot = {
+    ...performanceSnapshot(),
+    deposits: {},
+  }
 
-  await expect(
-    Effect.runPromise(
-      parsePerformanceSnapshot(JSON.stringify({ ...invalidSnapshot, deposits: {} })),
-    ),
-  ).rejects.toThrow("Fintual performance snapshot is invalid")
+  await expect(Effect.runPromise(writePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
+    "Fintual performance snapshot is invalid",
+  )
 })
+
+test("writes a valid Performance Snapshot to the snapshot file", async () => {
+  const originalContents = readSnapshotFileIfPresent()
+
+  try {
+    const validatedSnapshot = await Effect.runPromise(
+      writePerformanceSnapshot(performanceSnapshot()),
+    )
+    expect(validatedSnapshot).toEqual(performanceSnapshot())
+
+    const writtenSnapshot: unknown = JSON.parse(fs.readFileSync(PERFORMANCE_SNAPSHOT_PATH, "utf-8"))
+    expect(writtenSnapshot).toEqual(performanceSnapshot())
+  } finally {
+    restoreSnapshotFile(originalContents)
+  }
+})
+
+function readSnapshotFileIfPresent(): string | null {
+  if (!fs.existsSync(PERFORMANCE_SNAPSHOT_PATH)) {
+    return null
+  }
+
+  return fs.readFileSync(PERFORMANCE_SNAPSHOT_PATH, "utf-8")
+}
+
+function restoreSnapshotFile(contents: string | null): void {
+  if (contents === null) {
+    fs.rmSync(PERFORMANCE_SNAPSHOT_PATH, { force: true })
+    return
+  }
+
+  fs.writeFileSync(PERFORMANCE_SNAPSHOT_PATH, contents, "utf-8")
+}
 
 function performanceSnapshot(): PerformanceSnapshot {
   return {

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -18,14 +18,14 @@ test("fails when a balance entry has a non-finite date", async () => {
   )
 })
 
-test("fails when deposits is not an array", async () => {
+test("fails when deposits is not an array and reports the failing field", async () => {
   const invalidSnapshot = {
     ...performanceSnapshot(),
     deposits: {},
   }
 
   await expect(Effect.runPromise(writePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
-    "Fintual performance snapshot is invalid",
+    /Fintual performance snapshot is invalid: .*deposits/,
   )
 })
 

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -3,40 +3,44 @@ import { Effect } from "effect"
 import { expect, test } from "vitest"
 import {
   PERFORMANCE_SNAPSHOT_PATH,
+  validatePerformanceSnapshot,
   writePerformanceSnapshot,
   type PerformanceSnapshot,
 } from "./performance-snapshot.ts"
 
-test("fails when a balance entry has a non-finite date", async () => {
+test("rejects a balance entry with a non-finite date and reports the failing field", async () => {
   const invalidSnapshot = {
     ...performanceSnapshot(),
-    balance: [{ date: Number.NaN, value: 1100, difference: 50, real_difference: 50 }],
+    balance: [{ date: Number.POSITIVE_INFINITY, value: 1100, difference: 50, real_difference: 50 }],
   }
 
-  await expect(Effect.runPromise(writePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
-    "Fintual performance snapshot is invalid",
+  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
+    /Fintual performance snapshot is invalid: .*balance/,
   )
 })
 
-test("fails when deposits is not an array and reports the failing field", async () => {
+test("rejects when deposits is not an array and reports the failing field", async () => {
   const invalidSnapshot = {
     ...performanceSnapshot(),
     deposits: {},
   }
 
-  await expect(Effect.runPromise(writePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
+  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
     /Fintual performance snapshot is invalid: .*deposits/,
   )
+})
+
+test("returns the validated snapshot for valid data", async () => {
+  const snapshot = performanceSnapshot()
+
+  await expect(Effect.runPromise(validatePerformanceSnapshot(snapshot))).resolves.toEqual(snapshot)
 })
 
 test("writes a valid Performance Snapshot to the snapshot file", async () => {
   const originalContents = readSnapshotFileIfPresent()
 
   try {
-    const validatedSnapshot = await Effect.runPromise(
-      writePerformanceSnapshot(performanceSnapshot()),
-    )
-    expect(validatedSnapshot).toEqual(performanceSnapshot())
+    await Effect.runPromise(writePerformanceSnapshot(performanceSnapshot()))
 
     const writtenSnapshot: unknown = JSON.parse(fs.readFileSync(PERFORMANCE_SNAPSHOT_PATH, "utf-8"))
     expect(writtenSnapshot).toEqual(performanceSnapshot())

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -1,0 +1,54 @@
+import { Effect } from "effect"
+import { expect, test } from "vitest"
+import { parsePerformanceSnapshot, type PerformanceSnapshot } from "./performance-snapshot.ts"
+
+test("parses a valid Performance Snapshot", async () => {
+  const result = await Effect.runPromise(
+    parsePerformanceSnapshot(JSON.stringify(performanceSnapshot())),
+  )
+
+  expect(result.balance).toEqual([
+    { date: 1780264800000, value: 1100, difference: 50, real_difference: 50 },
+  ])
+  expect(result.deposits).toEqual([{ date: 1780264800000, value: 850, difference: 50 }])
+})
+
+test("fails when the Performance Snapshot is malformed JSON", async () => {
+  await expect(Effect.runPromise(parsePerformanceSnapshot("{"))).rejects.toThrow(
+    "Failed to parse Fintual performance snapshot",
+  )
+})
+
+test("fails when a balance entry is missing required fields", async () => {
+  const invalidSnapshot = performanceSnapshot()
+  const invalidBalanceEntry = {
+    date: 1780264800000,
+    value: 1100,
+    difference: 50,
+  }
+
+  await expect(
+    Effect.runPromise(
+      parsePerformanceSnapshot(
+        JSON.stringify({ ...invalidSnapshot, balance: [invalidBalanceEntry] }),
+      ),
+    ),
+  ).rejects.toThrow("Fintual performance snapshot is invalid")
+})
+
+test("fails when deposits is not an array", async () => {
+  const invalidSnapshot = performanceSnapshot()
+
+  await expect(
+    Effect.runPromise(
+      parsePerformanceSnapshot(JSON.stringify({ ...invalidSnapshot, deposits: {} })),
+    ),
+  ).rejects.toThrow("Fintual performance snapshot is invalid")
+})
+
+function performanceSnapshot(): PerformanceSnapshot {
+  return {
+    balance: [{ date: 1780264800000, value: 1100, difference: 50, real_difference: 50 }],
+    deposits: [{ date: 1780264800000, value: 850, difference: 50 }],
+  }
+}

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -6,63 +6,42 @@ import { trySync } from "./effect.ts"
 const SNAPSHOT_DATA_DIR = "./tmp/fintual-data"
 export const PERFORMANCE_SNAPSHOT_PATH = `${SNAPSHOT_DATA_DIR}/balance-2.json`
 
+const finiteNumber = v.pipe(v.number(), v.finite())
+
+const seriesPointSchema = v.object({
+  date: finiteNumber,
+  value: finiteNumber,
+  difference: finiteNumber,
+})
+
 const performanceSnapshotSchema = v.object({
-  balance: v.array(
-    v.object({
-      date: v.number(),
-      value: v.number(),
-      difference: v.number(),
-      real_difference: v.number(),
-    }),
-  ),
-  deposits: v.array(
-    v.object({
-      date: v.number(),
-      value: v.number(),
-      difference: v.number(),
-    }),
-  ),
+  balance: v.array(v.object({ ...seriesPointSchema.entries, real_difference: finiteNumber })),
+  deposits: v.array(seriesPointSchema),
 })
 
 export type PerformanceSnapshot = v.InferOutput<typeof performanceSnapshotSchema>
 
-export function parsePerformanceSnapshot(
-  contents: string,
+export function writePerformanceSnapshot(
+  snapshot: unknown,
 ): Effect.Effect<PerformanceSnapshot, Error> {
   return Effect.gen(function* () {
-    const parsedJson = yield* trySync({
-      // oxlint-disable-next-line typescript/consistent-type-assertions
-      try: () => JSON.parse(contents) as unknown,
-      catch: "Failed to parse Fintual performance snapshot",
-    })
-
-    const validation = v.safeParse(performanceSnapshotSchema, parsedJson)
+    const validation = v.safeParse(performanceSnapshotSchema, snapshot)
     if (!validation.success) {
       return yield* Effect.fail(new Error("Fintual performance snapshot is invalid"))
     }
 
-    return validation.output
-  })
-}
-
-export function readPerformanceSnapshot(): Effect.Effect<PerformanceSnapshot, Error> {
-  return Effect.gen(function* () {
-    const contents = yield* trySync({
-      try: () => fs.readFileSync(PERFORMANCE_SNAPSHOT_PATH, "utf-8"),
-      catch: "Failed to read Fintual performance snapshot file",
+    yield* trySync({
+      try: () => {
+        fs.mkdirSync(SNAPSHOT_DATA_DIR, { recursive: true })
+        fs.writeFileSync(
+          PERFORMANCE_SNAPSHOT_PATH,
+          JSON.stringify(validation.output, null, 2),
+          "utf-8",
+        )
+      },
+      catch: "Failed to write Fintual performance snapshot file",
     })
-    return yield* parsePerformanceSnapshot(contents)
-  })
-}
 
-export function writePerformanceSnapshot(
-  snapshot: PerformanceSnapshot,
-): Effect.Effect<void, Error> {
-  return trySync({
-    try: () => {
-      fs.mkdirSync(SNAPSHOT_DATA_DIR, { recursive: true })
-      fs.writeFileSync(PERFORMANCE_SNAPSHOT_PATH, JSON.stringify(snapshot, null, 2), "utf-8")
-    },
-    catch: "Failed to write Fintual performance snapshot file",
+    return validation.output
   })
 }

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -27,7 +27,11 @@ export function writePerformanceSnapshot(
   return Effect.gen(function* () {
     const validation = v.safeParse(performanceSnapshotSchema, snapshot)
     if (!validation.success) {
-      return yield* Effect.fail(new Error("Fintual performance snapshot is invalid"))
+      return yield* Effect.fail(
+        new Error(
+          `Fintual performance snapshot is invalid: ${JSON.stringify(v.flatten(validation.issues))}`,
+        ),
+      )
     }
 
     yield* trySync({

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -1,7 +1,8 @@
 import * as fs from "node:fs"
 import { Effect } from "effect"
 import * as v from "valibot"
-import { trySync } from "./effect.ts"
+import { trySync, warn } from "./effect.ts"
+import { getErrorMessage } from "./log.ts"
 
 const SNAPSHOT_DATA_DIR = "./tmp/fintual-data"
 export const PERFORMANCE_SNAPSHOT_PATH = `${SNAPSHOT_DATA_DIR}/balance-2.json`
@@ -21,7 +22,7 @@ const performanceSnapshotSchema = v.object({
 
 export type PerformanceSnapshot = v.InferOutput<typeof performanceSnapshotSchema>
 
-export function writePerformanceSnapshot(
+export function validatePerformanceSnapshot(
   snapshot: unknown,
 ): Effect.Effect<PerformanceSnapshot, Error> {
   return Effect.gen(function* () {
@@ -34,18 +35,19 @@ export function writePerformanceSnapshot(
       )
     }
 
-    yield* trySync({
-      try: () => {
-        fs.mkdirSync(SNAPSHOT_DATA_DIR, { recursive: true })
-        fs.writeFileSync(
-          PERFORMANCE_SNAPSHOT_PATH,
-          JSON.stringify(validation.output, null, 2),
-          "utf-8",
-        )
-      },
-      catch: "Failed to write Fintual performance snapshot file",
-    })
-
     return validation.output
   })
+}
+
+export function writePerformanceSnapshot(snapshot: PerformanceSnapshot): Effect.Effect<void> {
+  return Effect.catch(
+    trySync({
+      try: () => {
+        fs.mkdirSync(SNAPSHOT_DATA_DIR, { recursive: true })
+        fs.writeFileSync(PERFORMANCE_SNAPSHOT_PATH, JSON.stringify(snapshot, null, 2), "utf-8")
+      },
+      catch: "Failed to write performance snapshot artifact",
+    }),
+    (cause) => warn(getErrorMessage(cause)),
+  )
 }

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -16,8 +16,11 @@ const seriesPointSchema = v.object({
 })
 
 const performanceSnapshotSchema = v.object({
-  balance: v.array(v.object({ ...seriesPointSchema.entries, real_difference: finiteNumber })),
-  deposits: v.array(seriesPointSchema),
+  balance: v.pipe(
+    v.array(v.object({ ...seriesPointSchema.entries, real_difference: finiteNumber })),
+    v.minLength(1),
+  ),
+  deposits: v.pipe(v.array(seriesPointSchema), v.minLength(1)),
 })
 
 export type PerformanceSnapshot = v.InferOutput<typeof performanceSnapshotSchema>

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs"
 import { Effect } from "effect"
 import * as v from "valibot"
-import { trySync, warn } from "./effect.ts"
+import { log, trySync, warn } from "./effect.ts"
 import { getErrorMessage } from "./log.ts"
 
 const SNAPSHOT_DATA_DIR = "./tmp/fintual-data"
@@ -40,7 +40,7 @@ export function validatePerformanceSnapshot(
 }
 
 export function writePerformanceSnapshot(snapshot: PerformanceSnapshot): Effect.Effect<void> {
-  return Effect.catch(
+  return Effect.matchEffect(
     trySync({
       try: () => {
         fs.mkdirSync(SNAPSHOT_DATA_DIR, { recursive: true })
@@ -48,6 +48,9 @@ export function writePerformanceSnapshot(snapshot: PerformanceSnapshot): Effect.
       },
       catch: "Failed to write performance snapshot artifact",
     }),
-    (cause) => warn(getErrorMessage(cause)),
+    {
+      onFailure: (cause) => warn(getErrorMessage(cause)),
+      onSuccess: () => log(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`),
+    },
   )
 }

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -1,0 +1,68 @@
+import * as fs from "node:fs"
+import { Effect } from "effect"
+import * as v from "valibot"
+import { trySync } from "./effect.ts"
+
+const SNAPSHOT_DATA_DIR = "./tmp/fintual-data"
+export const PERFORMANCE_SNAPSHOT_PATH = `${SNAPSHOT_DATA_DIR}/balance-2.json`
+
+const performanceSnapshotSchema = v.object({
+  balance: v.array(
+    v.object({
+      date: v.number(),
+      value: v.number(),
+      difference: v.number(),
+      real_difference: v.number(),
+    }),
+  ),
+  deposits: v.array(
+    v.object({
+      date: v.number(),
+      value: v.number(),
+      difference: v.number(),
+    }),
+  ),
+})
+
+export type PerformanceSnapshot = v.InferOutput<typeof performanceSnapshotSchema>
+
+export function parsePerformanceSnapshot(
+  contents: string,
+): Effect.Effect<PerformanceSnapshot, Error> {
+  return Effect.gen(function* () {
+    const parsedJson = yield* trySync({
+      // oxlint-disable-next-line typescript/consistent-type-assertions
+      try: () => JSON.parse(contents) as unknown,
+      catch: "Failed to parse Fintual performance snapshot",
+    })
+
+    const validation = v.safeParse(performanceSnapshotSchema, parsedJson)
+    if (!validation.success) {
+      return yield* Effect.fail(new Error("Fintual performance snapshot is invalid"))
+    }
+
+    return validation.output
+  })
+}
+
+export function readPerformanceSnapshot(): Effect.Effect<PerformanceSnapshot, Error> {
+  return Effect.gen(function* () {
+    const contents = yield* trySync({
+      try: () => fs.readFileSync(PERFORMANCE_SNAPSHOT_PATH, "utf-8"),
+      catch: "Failed to read Fintual performance snapshot file",
+    })
+    return yield* parsePerformanceSnapshot(contents)
+  })
+}
+
+export function writePerformanceSnapshot(
+  snapshot: PerformanceSnapshot,
+): Effect.Effect<void, Error> {
+  return trySync({
+    try: () => {
+      fs.mkdirSync(SNAPSHOT_DATA_DIR, { recursive: true })
+      fs.writeFileSync(PERFORMANCE_SNAPSHOT_PATH, JSON.stringify(snapshot, null, 2), "utf-8")
+    },
+    catch: "Failed to write Fintual performance snapshot file",
+  })
+}


### PR DESCRIPTION
## Summary

Closes #266 — deepens the Fintual→Actual performance snapshot seam.

The sync used to pass Fintual performance data to Actual through a JSON file whose path, shape, serialization, validation, and invalid-data semantics were duplicated across `src/fintual/scraper.ts` and `src/actual.ts`. Invalid input silently produced an empty sync.

Per the issue's direction ("pass a typed snapshot through the job while keeping persistence as an implementation detail"), the seam is now a typed value: the Fintual step returns a `PerformanceSnapshot` and the job threads it into the Actual step.

## Changes

- **`src/performance-snapshot.ts`** — one module owns the Performance Snapshot shape (valibot schema + `PerformanceSnapshot` type) and the persistence policy: `writePerformanceSnapshot` validates untrusted input against the schema, fails deliberately on invalid data, persists the debug artifact to `tmp/fintual-data/balance-2.json`, and returns the validated snapshot.
- **`src/fintual/http-sync.ts`** — `runFintualSync` now returns `Effect<PerformanceSnapshot, Error>`; the value forwarded to the job is the module's validated output, not the fold's unchecked output.
- **`src/job.ts`** — threads the snapshot: `runFintualSync` → `mainActual(config, snapshot)`.
- **`src/actual.ts`** — consumes the passed snapshot; its duplicated file path, schema, and read path are gone entirely.
- **`src/fintual/scraper.ts`** — `foldGoalPerformanceData` returns a typed `PerformanceSnapshot` instead of `{ balance: unknown[]; deposits: unknown[] }`.
- **Tests** — `src/performance-snapshot.test.ts` covers the write/validation boundary (rejects non-finite dates and shape mismatches; returns the validated snapshot on success); `src/fintual/scraper.test.ts` covers folding.
- **Docs** — CONTEXT.md glossary entry; README describes the handoff and the persisted artifact.

The JSON file remains as a write-only debug artifact (docker-compose mounts `./tmp` for host inspection), but nothing consumes it — the runtime contract is the typed value.

## Acceptance criteria

- [x] One module owns the performance snapshot shape
- [x] The Fintual and Actual modules no longer duplicate the file contract (Actual never touches the file)
- [x] Invalid snapshot data cannot silently produce a successful no-op (validation fails the sync deliberately, and the validated value is what crosses the seam)
- [x] Focused tests cover snapshot folding and validation

## Non-goals (unchanged)

No storage adapter seam; no change to external Fintual/Actual behavior.