### PR TITLE
docs(adr): record the email 2FA deep module decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,8 @@ This context covers the investment performance information transferred from Fint
 
 ## Language
 
+### Goal Performance
+
 **Goal Performance Data**:
 Validated valuation and cost-basis observations for a Fintual goal over a requested time interval. The sync uses two datasets with different time intervals to calculate recent balance and deposit changes.
 _Avoid_: Raw GraphQL response, performance payload
@@ -19,3 +21,23 @@ _Avoid_: Last-month data, current data
 **Performance Snapshot**:
 The typed balance and deposit observations passed from the Fintual sync step to the Actual sync step. One module owns its shape and persistence; the JSON file is a write-only implementation detail kept for inspection.
 _Avoid_: Balance file, balance-2.json, performance payload
+
+### Sign-in
+
+**Email 2FA Code**:
+The six-digit code Fintual sends by email to complete sign-in when the account has two-factor authentication enabled.
+_Avoid_: OTP, verification code, security code
+
+### Synchronization
+
+**Variation Transaction**:
+A balance-change transaction for one date, identified by the `fintual-variation:<date>` imported id, managed as a unit by the Actual sync.
+_Avoid_: Balance transaction, sync entry
+
+**Reconciliation Plan**:
+The create, update, and delete actions plus warnings derived from comparing balance entries against existing Variation Transactions.
+_Avoid_: Diff, action list
+
+**Synchronization Attempt**:
+One download → plan → mutate → sync unit, retryable as a whole because each attempt re-derives its plan from freshly downloaded state.
+_Avoid_: Retry, run

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,8 +4,6 @@ This context covers the investment performance information transferred from Fint
 
 ## Language
 
-### Goal Performance
-
 **Goal Performance Data**:
 Validated valuation and cost-basis observations for a Fintual goal over a requested time interval. The sync uses two datasets with different time intervals to calculate recent balance and deposit changes.
 _Avoid_: Raw GraphQL response, performance payload
@@ -27,17 +25,3 @@ _Avoid_: Balance file, balance-2.json, performance payload
 **Email 2FA Code**:
 The six-digit code Fintual sends by email to complete sign-in when the account has two-factor authentication enabled.
 _Avoid_: OTP, verification code, security code
-
-### Synchronization
-
-**Variation Transaction**:
-A balance-change transaction for one date, identified by the `fintual-variation:<date>` imported id, managed as a unit by the Actual sync.
-_Avoid_: Balance transaction, sync entry
-
-**Reconciliation Plan**:
-The create, update, and delete actions plus warnings derived from comparing balance entries against existing Variation Transactions.
-_Avoid_: Diff, action list
-
-**Synchronization Attempt**:
-One download → plan → mutate → sync unit, retryable as a whole because each attempt re-derives its plan from freshly downloaded state.
-_Avoid_: Retry, run

--- a/docs/adr/0002-email-2fa-deep-module.md
+++ b/docs/adr/0002-email-2fa-deep-module.md
@@ -1,0 +1,21 @@
+# Email 2FA retrieval is a deep module with typed outcomes
+
+Email 2FA retrieval lives in `src/fintual/email-2fa/` behind a single public entry point: it takes a real `Email2FAConfig` and returns a branded `Email2FACode` or a tagged failure (`TimedOut | Operational`). Disabled 2FA is caller-side configuration, not a module outcome — `http-sync.ts` fails fast when the login requires a code but Gmail credentials are not configured. The module owns the IMAP lifecycle through Effect Scope, the 120-second polling window, mailbox traversal (Gmail mailbox fallback list), search-query fallback, deduplication, parsing policy, and cleanup; a thin operation-level client seam separates the ImapFlow adapter from the module so tests run against a fake client with deterministic polling via Clock/Schedule.
+
+## Status
+
+accepted
+
+## Considered Options
+
+- **`string | null` return (previous design)** — collapsed disabled, timeout, and every operational failure into one value; the consumer reported all three as "no code received before timeout". Rejected: operational failures must remain truthful.
+- **Explicit result variant (`code | TimedOut` as a success value)** — rejected because the consumer treats every non-code outcome as a login failure; failure-side typing composes with `catch`/`retry`, and the tagged union lets future callers retry timeouts without folding on a success variant.
+- **Disabled handled inside the module** — rejected: configuration assembly is the caller's concern; the module never needs a "disabled" branch.
+- **Flat sibling files** — rejected: one entry point per module is the point of the deepening.
+
+## Consequences
+
+- Consumer error messages are now truthful: timeout stays "no code received before timeout"; operational failures carry the IMAP cause.
+- Cleanup (logout exactly once, even on interruption) becomes a testable invariant via Scope finalizers observed by the fake client.
+- Deterministic timeout and polling tests are possible with the test clock.
+- `debug` in `Email2FAConfig` only controls logging; it no longer participates in recoverability decisions.


### PR DESCRIPTION
## Summary

Records the accepted design from the #284 architecture discussion: make email 2FA retrieval a deep module with a branded `Email2FACode`, tagged timeout and operational failures, Effect Scope-owned lifecycle, deterministic polling, and best-effort mailbox policy.

## Files

- `docs/adr/0002-email-2fa-deep-module.md` — documents the module boundary, outcomes, lifecycle, rejected alternatives, and consequences.
- `CONTEXT.md` — adds only the **Email 2FA Code** glossary term under Sign-in.

## Scope

Documentation only. This PR records the decision; implementation remains follow-up work for #284.

## Validation

- formatting check
- typecheck
- 46 tests
- Fallow audit

Related to #284.
