### PR TITLE
docs(adr): record the Effect error and logging conventions

### DIFF
--- a/docs/adr/0003-typed-failures-at-domain-seams.md
+++ b/docs/adr/0003-typed-failures-at-domain-seams.md
@@ -1,0 +1,5 @@
+# Typed failures at domain seams
+
+The old `src/effect.ts` aliases wrapped every third-party rejection in a plain `Error`, erasing domain distinctions and forcing consumers like the Actual retry classifier to string-match messages. We delete the generic aliases and model expected failures per domain seam (Actual, Fintual HTTP, IMAP, configuration, snapshot artifact) as `Schema.TaggedErrorClass` values, preserving the existing message wording verbatim and keeping the original failure in `cause`. Retryability and other control-flow decisions are computed at the seam where the third-party rejection is visible and carried on the error; consumers use `catchTag`/`catchIf` and never inspect message text. Per-seam implementations land with the domain issues (Actual: #286, Fintual/artifact: #283, IMAP: #284); this decision is the shared convention.
+
+Considered and rejected: a single shared tagged error with a source field (loses per-domain recovery), and keeping plain `Error`s with string classification (the status quo, and the source of the retry bug where the record-shaped `PostError` branch was dead).

--- a/docs/adr/0003-typed-failures-at-domain-seams.md
+++ b/docs/adr/0003-typed-failures-at-domain-seams.md
@@ -1,5 +1,20 @@
 # Typed failures at domain seams
 
-The old `src/effect.ts` aliases wrapped every third-party rejection in a plain `Error`, erasing domain distinctions and forcing consumers like the Actual retry classifier to string-match messages. We delete the generic aliases and model expected failures per domain seam (Actual, Fintual HTTP, IMAP, configuration, snapshot artifact) as `Schema.TaggedErrorClass` values, preserving the existing message wording verbatim and keeping the original failure in `cause`. Retryability and other control-flow decisions are computed at the seam where the third-party rejection is visible and carried on the error; consumers use `catchTag`/`catchIf` and never inspect message text. Per-seam implementations land with the domain issues (Actual: #286, Fintual/artifact: #283, IMAP: #284); this decision is the shared convention.
+The old `src/effect.ts` aliases wrap third-party rejections in a plain `Error`, erasing domain distinctions and forcing consumers such as the Actual retry classifier to inspect message text. Delete the generic aliases and model expected failures at each domain seam as `Schema.TaggedErrorClass` values. Preserve the existing message wording, keep the original failure in `cause`, and compute retryability or other control-flow classification where the third-party failure is first visible. Consumers use `catchTag` or `catchIf`; they do not classify failures by message text.
 
-Considered and rejected: a single shared tagged error with a source field (loses per-domain recovery), and keeping plain `Error`s with string classification (the status quo, and the source of the retry bug where the record-shaped `PostError` branch was dead).
+Per-seam implementations are owned by the domain issues: Actual by #286, Fintual HTTP and the snapshot artifact by #283, and IMAP by #284. This ADR records the shared convention used by those implementations and by #285 when it removes the aliases.
+
+## Status
+
+accepted
+
+## Considered Options
+
+- **One shared tagged error with a source field** — rejected because it centralizes unrelated failures and weakens domain-specific recovery.
+- **Plain `Error` values with message classification** — rejected because message wording becomes a hidden control-flow API; it also leaves the record-shaped `PostError` retry branch unreachable after the aliases wrap the original failure.
+
+## Consequences
+
+- Public domain seams expose discoverable failure unions instead of generic errors.
+- Existing human-readable error messages remain stable while control flow depends on tags and fields.
+- Each domain issue owns its error taxonomy and third-party failure mapping; this convention does not add configuration work outside those issue scopes.

--- a/docs/adr/0004-redaction-at-the-logging-render-edge.md
+++ b/docs/adr/0004-redaction-at-the-logging-render-edge.md
@@ -1,0 +1,5 @@
+# Redaction at the logging render edge
+
+Credentials and email addresses must never appear in job output. Previously redaction ran inside the `effect.ts` aliases at error-message creation, coupling message building to the redaction policy and leaving any code path that bypassed the aliases unprotected. We keep `src/log.ts` as the redaction policy module, and the `once.ts` process edge renders all logs through a custom `Logger` (installed on `NodeRuntime.runMain`, which adds `@effect/platform-node`) that redacts message, cause, and annotation values at render time; creation-time redaction via `getErrorMessage` is retained as belt-and-suspenders during the transition. Output is deliberately upgraded from bare `console.log` lines to timestamped, level-prefixed plain-text lines, since the logs are human-read from cron.
+
+Considered and rejected: creation-time-only redaction (every call site becomes a leak boundary), and no redaction integration (secrets in logs).

--- a/docs/adr/0004-redaction-at-the-logging-render-edge.md
+++ b/docs/adr/0004-redaction-at-the-logging-render-edge.md
@@ -1,5 +1,21 @@
 # Redaction at the logging render edge
 
-Credentials and email addresses must never appear in job output. Previously redaction ran inside the `effect.ts` aliases at error-message creation, coupling message building to the redaction policy and leaving any code path that bypassed the aliases unprotected. We keep `src/log.ts` as the redaction policy module, and the `once.ts` process edge renders all logs through a custom `Logger` (installed on `NodeRuntime.runMain`, which adds `@effect/platform-node`) that redacts message, cause, and annotation values at render time; creation-time redaction via `getErrorMessage` is retained as belt-and-suspenders during the transition. Output is deliberately upgraded from bare `console.log` lines to timestamped, level-prefixed plain-text lines, since the logs are human-read from cron.
+Credentials and email addresses must never appear in job output. Redaction currently runs while error messages are created, coupling message construction to the policy and leaving any logging path that bypasses the aliases unprotected. Keep `src/log.ts` as the redaction policy module, and install a custom `Logger` at the `once.ts` process edge through `NodeRuntime.runMain` from `@effect/platform-node`. The logger redacts message, cause, and annotation values when it renders every log event. Retain creation-time redaction through `getErrorMessage` during the domain migration as an additional safeguard.
 
-Considered and rejected: creation-time-only redaction (every call site becomes a leak boundary), and no redaction integration (secrets in logs).
+The rendered output is timestamped, level-prefixed plain text because the cron output is read by humans.
+
+## Status
+
+accepted
+
+## Considered Options
+
+- **Creation-time-only redaction** — rejected because every call site becomes a possible leak boundary.
+- **No logger integration** — rejected because causes and annotations can contain secrets even when the main message has already been sanitized.
+- **Structured JSON output** — rejected for now because the job output is consumed directly by humans rather than a log ingestion system.
+
+## Consequences
+
+- All Effect logs cross one redacting render edge before reaching process output.
+- `src/log.ts` remains the policy module and keeps its current configuration API; #285 does not introduce a new configuration service.
+- `once.ts` uses `NodeRuntime.runMain`, preserving the runtime's standard exit behavior while reporting unhandled failures through the logger.


### PR DESCRIPTION
## Summary

Records the two cross-cutting conventions selected for #285: typed failures at domain seams and redaction at the logging render edge.

## Files

- `docs/adr/0003-typed-failures-at-domain-seams.md` — defines the shared tagged-error convention and assigns per-seam implementation to #283, #284, and #286.
- `docs/adr/0004-redaction-at-the-logging-render-edge.md` — defines the custom logger boundary while keeping `src/log.ts` as the existing redaction policy module.

## Scope

Documentation only. This PR does not implement #285 or add configuration work outside the four issue scopes.

## Validation

- formatting check
- typecheck
- 46 tests
- Fallow audit

Related to #285, #283, #284, and #286.
