### PR TITLE
refactor(fintual): make foldGoalPerformanceData total (#292)

### DIFF
--- a/src/fintual/http-sync.ts
+++ b/src/fintual/http-sync.ts
@@ -33,9 +33,6 @@ function fetchFintualPerformanceHttp(
       try: () => foldGoalPerformanceData(reference, recent),
       catch: "Failed to fold Fintual performance data",
     })
-    if (!snapshot) {
-      return yield* Effect.fail(new Error("Fintual HTTP sync: missing Goal Performance Data"))
-    }
 
     const validatedSnapshot = yield* validatePerformanceSnapshot(snapshot)
     yield* writePerformanceSnapshot(validatedSnapshot)

--- a/src/fintual/scraper.test.ts
+++ b/src/fintual/scraper.test.ts
@@ -23,14 +23,6 @@ test("folds reference and recent Goal Performance Data into a Performance Snapsh
   })
 })
 
-test("returns null when reference or recent Goal Performance Data is missing", () => {
-  const data = performanceData([performancePoint("2026-08-01")])
-
-  expect(foldGoalPerformanceData(data, null)).toBeNull()
-  expect(foldGoalPerformanceData(null, data)).toBeNull()
-  expect(foldGoalPerformanceData(null, null)).toBeNull()
-})
-
 test("starts with zero differences when reference does not precede the recent window", () => {
   const snapshot = foldGoalPerformanceData(
     performanceData([performancePoint("2026-08-01", { valuation: 1000, costBasis: 800 })]),

--- a/src/fintual/scraper.ts
+++ b/src/fintual/scraper.ts
@@ -2,13 +2,9 @@ import type { PerformanceSnapshot } from "../performance-snapshot.ts"
 import type { GoalPerformanceData } from "./new-performance.ts"
 
 export function foldGoalPerformanceData(
-  referenceData: GoalPerformanceData | null,
-  recentData: GoalPerformanceData | null,
-): PerformanceSnapshot | null {
-  if (!recentData?.balanceGraphDataPoints || !referenceData?.balanceGraphDataPoints) {
-    return null
-  }
-
+  referenceData: GoalPerformanceData,
+  recentData: GoalPerformanceData,
+): PerformanceSnapshot {
   const recentPoints = recentData.balanceGraphDataPoints
   const previousDeposits = getPreviousValue(
     referenceData,


### PR DESCRIPTION
## What

Implements #292 — the fold seam becomes total. `foldGoalPerformanceData` now takes two non-null Goal Performance Data values and always returns a Performance Snapshot; the dead `null` input paths and the "missing data" failure are removed. No behavior change at the seam.

## Changes

- `src/fintual/scraper.ts` — signature is now `(reference: GoalPerformanceData, recent: GoalPerformanceData): PerformanceSnapshot`; null guard removed
- `src/fintual/http-sync.ts` — "missing Goal Performance Data" failure removed (the null path was unreachable; ingestion schema requires `balanceGraphDataPoints`)
- `src/fintual/scraper.test.ts` — null-path tests removed, nothing added

## Verification

- `pnpm test` — 45 passed
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm format:check` — clean

Closes #292