### PR TITLE
feat(fintual): surface FintualError typed failures (#291)

### DIFF
--- a/src/fintual/authenticated-ingestion.test.ts
+++ b/src/fintual/authenticated-ingestion.test.ts
@@ -60,10 +60,23 @@ test("fails when email 2FA does not return a code", async () => {
     get2FACode: () => Effect.succeed(null),
   })
 
-  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toThrow(
-    "no code received before timeout",
-  )
+  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toMatchObject({
+    _tag: "Email2FAFailure",
+  })
   expect(script.requests).toHaveLength(2)
+})
+
+test("fails with LoginFailed on a 401 initiate_login response", async () => {
+  const script = createFetchScript([response(""), response("{}", 401)])
+  const ingestion = createAuthenticatedFintualIngestion({
+    fetch: script.fetch,
+    get2FACode: () => Effect.succeed(null),
+  })
+
+  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toMatchObject({
+    _tag: "LoginFailed",
+    status: 401,
+  })
 })
 
 test("fails on an unexpected login response without exposing its body", async () => {
@@ -73,9 +86,18 @@ test("fails on an unexpected login response without exposing its body", async ()
     get2FACode: () => Effect.succeed(null),
   })
 
-  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toSatisfy((error) =>
-    errorMessageIncludes(error, "Fintual login: unexpected HTTP status 418", "secret"),
-  )
+  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toSatisfy((error) => {
+    expect(error).toMatchObject({
+      _tag: "UnexpectedHttpStatus",
+      stage: "Fintual login",
+      status: 418,
+    })
+    expect(error).toBeInstanceOf(Error)
+    if (error instanceof Error) {
+      expect(error.message).not.toContain("secret")
+    }
+    return true
+  })
 })
 
 test("fails atomically when the reference request fails", async () => {
@@ -85,9 +107,11 @@ test("fails atomically when the reference request fails", async () => {
     get2FACode: () => Effect.succeed(null),
   })
 
-  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toThrow(
-    "Fintual reference Goal Performance Data: unexpected HTTP status 503",
-  )
+  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toMatchObject({
+    _tag: "UnexpectedHttpStatus",
+    stage: "Fintual reference Goal Performance Data",
+    status: 503,
+  })
   expect(script.requests).toHaveLength(3)
 })
 
@@ -103,9 +127,45 @@ test("fails atomically when the recent request fails", async () => {
     get2FACode: () => Effect.succeed(null),
   })
 
-  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toThrow(
-    "Fintual recent Goal Performance Data: unexpected HTTP status 503",
-  )
+  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toMatchObject({
+    _tag: "UnexpectedHttpStatus",
+    stage: "Fintual recent Goal Performance Data",
+    status: 503,
+  })
+})
+
+test("fails with HttpTransportFailure when a request throws", async () => {
+  const script = createFetchScript([response(""), response("{}")])
+  const ingestion = createAuthenticatedFintualIngestion({
+    fetch: script.fetch,
+    get2FACode: () => Effect.succeed(null),
+  })
+
+  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toSatisfy((error) => {
+    expect(error).toMatchObject({
+      _tag: "HttpTransportFailure",
+      stage: "Fintual reference Goal Performance Data",
+    })
+    if (error instanceof Error) {
+      expect(error.cause).toBeInstanceOf(Error)
+    }
+    return true
+  })
+})
+
+test("fails with HttpTransportFailure when a response body cannot be read", async () => {
+  const brokenBody = response("")
+  brokenBody.text = () => Promise.reject(new Error("stream broken"))
+  const script = createFetchScript([brokenBody])
+  const ingestion = createAuthenticatedFintualIngestion({
+    fetch: script.fetch,
+    get2FACode: () => Effect.succeed(null),
+  })
+
+  await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toMatchObject({
+    _tag: "HttpTransportFailure",
+    stage: "Fintual sign-in page",
+  })
 })
 
 describe("fails when Goal Performance Data is malformed or invalid", () => {
@@ -116,7 +176,16 @@ describe("fails when Goal Performance Data is malformed or invalid", () => {
       get2FACode: () => Effect.succeed(null),
     })
 
-    await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toThrow("validation failed")
+    await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toSatisfy((error) => {
+      expect(error).toMatchObject({
+        _tag: "MalformedGoalPerformanceData",
+        purpose: "reference",
+      })
+      if (error instanceof Error) {
+        expect(error.cause).toBeInstanceOf(Error)
+      }
+      return true
+    })
   })
 
   test("invalid shape", async () => {
@@ -130,7 +199,10 @@ describe("fails when Goal Performance Data is malformed or invalid", () => {
       get2FACode: () => Effect.succeed(null),
     })
 
-    await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toThrow("validation failed")
+    await expect(Effect.runPromise(ingestion(OPTIONS))).rejects.toMatchObject({
+      _tag: "MalformedGoalPerformanceData",
+      purpose: "reference",
+    })
   })
 })
 
@@ -230,14 +302,4 @@ function requestBody(request: RecordedRequest | undefined): string {
 
 function requestHeaders(request: RecordedRequest | undefined): Headers {
   return new Headers(request?.init.headers)
-}
-
-function errorMessageIncludes(error: unknown, included: string, excluded: string): boolean {
-  if (!(error instanceof Error)) {
-    return false
-  }
-
-  expect(error.message).toContain(included)
-  expect(error.message).not.toContain(excluded)
-  return true
 }

--- a/src/fintual/authenticated-ingestion.ts
+++ b/src/fintual/authenticated-ingestion.ts
@@ -1,6 +1,14 @@
 import { Effect } from "effect"
 import { tryPromise, trySync } from "../effect.ts"
 import {
+  Email2FAFailure,
+  HttpTransportFailure,
+  LoginFailed,
+  MalformedGoalPerformanceData,
+  UnexpectedHttpStatus,
+  type FintualError,
+} from "./fintual-error.ts"
+import {
   createGoalPerformanceRequest,
   type GoalPerformanceData,
   parseGoalPerformanceResponseBody,
@@ -35,7 +43,7 @@ export interface AuthenticatedGoalPerformanceData {
 
 export type AuthenticatedFintualIngestion = (
   options: AuthenticatedIngestionOptions,
-) => Effect.Effect<AuthenticatedGoalPerformanceData, Error>
+) => Effect.Effect<AuthenticatedGoalPerformanceData, FintualError>
 
 export function createAuthenticatedFintualIngestion(
   dependencies: AuthenticatedIngestionDependencies,
@@ -73,7 +81,7 @@ class FintualHttpSession {
     this.fetchRequest = fetchRequest
   }
 
-  request(path: string, init: RequestInit, stage: string): Effect.Effect<Response, Error> {
+  request(path: string, init: RequestInit, stage: string): Effect.Effect<Response, FintualError> {
     return Effect.gen({ self: this }, function* () {
       const headers = new Headers(init.headers)
       headers.set("User-Agent", BROWSER_USER_AGENT)
@@ -84,22 +92,28 @@ class FintualHttpSession {
         headers.set("Cookie", cookieHeader)
       }
 
-      const response = yield* tryPromise({
-        try: () => this.fetchRequest(`${FINTUAL_ORIGIN}${path}`, { ...init, headers }),
-        catch: `${stage}: request failed`,
-      })
+      const response = yield* Effect.mapError(
+        tryPromise({
+          try: () => this.fetchRequest(`${FINTUAL_ORIGIN}${path}`, { ...init, headers }),
+          catch: `${stage}: request failed`,
+        }),
+        (cause) => new HttpTransportFailure({ stage, cause }),
+      )
 
-      yield* trySync({
-        try: () => mergeSetCookieHeaders(response.headers, this.cookies),
-        catch: `${stage}: failed to update session cookies`,
-      })
+      yield* Effect.mapError(
+        trySync({
+          try: () => mergeSetCookieHeaders(response.headers, this.cookies),
+          catch: `${stage}: failed to update session cookies`,
+        }),
+        (cause) => new HttpTransportFailure({ stage, cause }),
+      )
 
       return response
     })
   }
 }
 
-function loadSignInPage(session: FintualHttpSession): Effect.Effect<void, Error> {
+function loadSignInPage(session: FintualHttpSession): Effect.Effect<void, FintualError> {
   return Effect.gen(function* () {
     const response = yield* session.request(
       "/f/sign-in/",
@@ -121,7 +135,7 @@ function authenticate(
   get2FACode: AuthenticatedIngestionDependencies["get2FACode"],
   email: string,
   password: string,
-): Effect.Effect<void, Error> {
+): Effect.Effect<void, FintualError> {
   return Effect.gen(function* () {
     const loginResponse = yield* session.request(
       "/auth/sessions/initiate_login",
@@ -142,17 +156,28 @@ function authenticate(
       return
     }
 
+    if (loginResponse.status === 401) {
+      return yield* Effect.fail(new LoginFailed({ status: loginResponse.status }))
+    }
+
     if (loginResponse.status !== 201) {
       return yield* failUnexpectedStatus("Fintual login", loginResponse.status)
     }
 
     const loginStartedAt = new Date()
-    const code = yield* get2FACode({
-      afterTimestamp: loginStartedAt,
-      timeoutMs: HTTP_2FA_EMAIL_TIMEOUT_MS,
-    })
+    const code = yield* Effect.catch(
+      get2FACode({
+        afterTimestamp: loginStartedAt,
+        timeoutMs: HTTP_2FA_EMAIL_TIMEOUT_MS,
+      }),
+      (cause) => Effect.fail(new Email2FAFailure({ cause })),
+    )
     if (!code) {
-      return yield* Effect.fail(new Error("Fintual email 2FA: no code received before timeout"))
+      return yield* Effect.fail(
+        new Email2FAFailure({
+          cause: new Error("Fintual email 2FA: no code received before timeout"),
+        }),
+      )
     }
 
     const finalizeResponse = yield* session.request(
@@ -181,7 +206,7 @@ function fetchGoalPerformanceData(
   goalId: string,
   timeInterval: GoalPerformanceTimeInterval,
   purpose: "reference" | "recent",
-): Effect.Effect<GoalPerformanceData, Error> {
+): Effect.Effect<GoalPerformanceData, FintualError> {
   const stage = `Fintual ${purpose} Goal Performance Data`
 
   return Effect.gen(function* () {
@@ -206,20 +231,23 @@ function fetchGoalPerformanceData(
 
     return yield* Effect.mapError(
       parseGoalPerformanceResponseBody(body),
-      (cause) => new Error(`${stage}: validation failed`, { cause }),
+      (cause) => new MalformedGoalPerformanceData({ purpose, cause }),
     )
   })
 }
 
-function readResponseBody(response: Response, stage: string): Effect.Effect<string, Error> {
-  return tryPromise({
-    try: () => response.text(),
-    catch: `${stage}: failed to read response body`,
-  })
+function readResponseBody(response: Response, stage: string): Effect.Effect<string, FintualError> {
+  return Effect.mapError(
+    tryPromise({
+      try: () => response.text(),
+      catch: `${stage}: failed to read response body`,
+    }),
+    (cause) => new HttpTransportFailure({ stage, cause }),
+  )
 }
 
-function failUnexpectedStatus(stage: string, status: number): Effect.Effect<never, Error> {
-  return Effect.fail(new Error(`${stage}: unexpected HTTP status ${status}`))
+function failUnexpectedStatus(stage: string, status: number): Effect.Effect<never, FintualError> {
+  return Effect.fail(new UnexpectedHttpStatus({ stage, status }))
 }
 
 function mergeSetCookieHeaders(headers: Headers, jar: Map<string, string>): void {

--- a/src/fintual/fintual-error.ts
+++ b/src/fintual/fintual-error.ts
@@ -1,0 +1,85 @@
+import { Schema } from "effect"
+import { getErrorMessage } from "../log.ts"
+
+export class UnexpectedHttpStatus extends Schema.TaggedError<UnexpectedHttpStatus>()(
+  "UnexpectedHttpStatus",
+  {
+    stage: Schema.String,
+    status: Schema.Number,
+  },
+) {
+  get message(): string {
+    return `${this.stage}: unexpected HTTP status ${this.status}`
+  }
+}
+
+export class HttpTransportFailure extends Schema.TaggedError<HttpTransportFailure>()(
+  "HttpTransportFailure",
+  {
+    stage: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  get message(): string {
+    return getErrorMessage(this.cause)
+  }
+}
+
+export class LoginFailed extends Schema.TaggedError<LoginFailed>()("LoginFailed", {
+  status: Schema.Number,
+}) {
+  get message(): string {
+    return `Fintual login: unexpected HTTP status ${this.status}`
+  }
+}
+
+export class MalformedGoalPerformanceData extends Schema.TaggedError<MalformedGoalPerformanceData>()(
+  "MalformedGoalPerformanceData",
+  {
+    purpose: Schema.Literals(["reference", "recent"]),
+    cause: Schema.Defect(),
+  },
+) {
+  get message(): string {
+    return `Fintual ${this.purpose} Goal Performance Data: validation failed`
+  }
+}
+
+export class MalformedPerformanceSnapshot extends Schema.TaggedError<MalformedPerformanceSnapshot>()(
+  "MalformedPerformanceSnapshot",
+  {
+    issues: Schema.String,
+  },
+) {
+  get message(): string {
+    return `Fintual performance snapshot is invalid: ${this.issues}`
+  }
+}
+
+export class Email2FAFailure extends Schema.TaggedError<Email2FAFailure>()("Email2FAFailure", {
+  cause: Schema.Defect(),
+}) {
+  get message(): string {
+    return getErrorMessage(this.cause)
+  }
+}
+
+export class SnapshotWriteFailure extends Schema.TaggedError<SnapshotWriteFailure>()(
+  "SnapshotWriteFailure",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  get message(): string {
+    return getErrorMessage(this.cause)
+  }
+}
+
+export type FintualError =
+  | UnexpectedHttpStatus
+  | HttpTransportFailure
+  | LoginFailed
+  | MalformedGoalPerformanceData
+  | MalformedPerformanceSnapshot
+  | Email2FAFailure
+  | SnapshotWriteFailure

--- a/src/fintual/http-sync.ts
+++ b/src/fintual/http-sync.ts
@@ -3,12 +3,18 @@ import { error, trySync } from "../effect.ts"
 import type { FintualConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import {
+  PerformanceSnapshotValidationError,
   validatePerformanceSnapshot,
   writePerformanceSnapshot,
   type PerformanceSnapshot,
 } from "../performance-snapshot.ts"
 import { createAuthenticatedFintualIngestion } from "./authenticated-ingestion.ts"
 import { get2FACodeFromEmail } from "./email-2fa.ts"
+import {
+  MalformedPerformanceSnapshot,
+  SnapshotWriteFailure,
+  type FintualError,
+} from "./fintual-error.ts"
 import { foldGoalPerformanceData } from "./scraper.ts"
 
 /**
@@ -17,7 +23,7 @@ import { foldGoalPerformanceData } from "./scraper.ts"
  */
 function fetchFintualPerformanceHttp(
   config: FintualConfig,
-): Effect.Effect<PerformanceSnapshot, Error> {
+): Effect.Effect<PerformanceSnapshot, FintualError> {
   const fetchAuthenticatedGoalPerformance = createAuthenticatedFintualIngestion({
     fetch: globalThis.fetch,
     get2FACode: (options) => get2FACodeFromEmail(config.email2FA, options),
@@ -29,19 +35,32 @@ function fetchFintualPerformanceHttp(
       goalId: config.goalId,
     })
 
-    const snapshot = yield* trySync({
-      try: () => foldGoalPerformanceData(reference, recent),
-      catch: "Failed to fold Fintual performance data",
-    })
+    const snapshot = yield* Effect.mapError(
+      trySync({
+        try: () => foldGoalPerformanceData(reference, recent),
+        catch: "Failed to fold Fintual performance data",
+      }),
+      (cause) => new MalformedPerformanceSnapshot({ issues: getErrorMessage(cause) }),
+    )
 
-    const validatedSnapshot = yield* validatePerformanceSnapshot(snapshot)
-    yield* writePerformanceSnapshot(validatedSnapshot)
+    const validatedSnapshot = yield* Effect.catchIf(
+      validatePerformanceSnapshot(snapshot),
+      (error): error is PerformanceSnapshotValidationError =>
+        error instanceof PerformanceSnapshotValidationError,
+      (error) => Effect.fail(new MalformedPerformanceSnapshot({ issues: error.issues })),
+    )
+    yield* Effect.mapError(
+      writePerformanceSnapshot(validatedSnapshot),
+      (cause) => new SnapshotWriteFailure({ cause }),
+    )
 
     return validatedSnapshot
   })
 }
 
-export function runFintualSync(config: FintualConfig): Effect.Effect<PerformanceSnapshot, Error> {
+export function runFintualSync(
+  config: FintualConfig,
+): Effect.Effect<PerformanceSnapshot, FintualError> {
   return Effect.catch(fetchFintualPerformanceHttp(config), (cause) =>
     Effect.andThen(error(`Error: ${getErrorMessage(cause)}`), Effect.fail(cause)),
   )

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs"
+import * as path from "node:path"
 import { Effect } from "effect"
 import { expect, test } from "vitest"
 import {
@@ -59,7 +60,7 @@ test("returns the validated snapshot for valid data", async () => {
 })
 
 test("writes a valid Performance Snapshot to the snapshot file", async () => {
-  const originalContents = readSnapshotFileIfPresent()
+  const originalContents = readFileIfPresent(PERFORMANCE_SNAPSHOT_PATH)
 
   try {
     await Effect.runPromise(writePerformanceSnapshot(performanceSnapshot()))
@@ -67,25 +68,41 @@ test("writes a valid Performance Snapshot to the snapshot file", async () => {
     const writtenSnapshot: unknown = JSON.parse(fs.readFileSync(PERFORMANCE_SNAPSHOT_PATH, "utf-8"))
     expect(writtenSnapshot).toEqual(performanceSnapshot())
   } finally {
-    restoreSnapshotFile(originalContents)
+    restoreFile(PERFORMANCE_SNAPSHOT_PATH, originalContents)
   }
 })
 
-function readSnapshotFileIfPresent(): string | null {
-  if (!fs.existsSync(PERFORMANCE_SNAPSHOT_PATH)) {
+test("fails when the Performance Snapshot cannot be written", async () => {
+  const snapshotPath = PERFORMANCE_SNAPSHOT_PATH
+  const originalContents = readFileIfPresent(snapshotPath)
+  fs.mkdirSync(path.dirname(snapshotPath), { recursive: true })
+
+  try {
+    fs.mkdirSync(snapshotPath, { recursive: true })
+    await expect(
+      Effect.runPromise(writePerformanceSnapshot(performanceSnapshot())),
+    ).rejects.toThrow("Failed to write performance snapshot artifact")
+  } finally {
+    fs.rmSync(snapshotPath, { force: true, recursive: true })
+    restoreFile(snapshotPath, originalContents)
+  }
+})
+
+function readFileIfPresent(filePath: string): string | null {
+  if (!fs.existsSync(filePath)) {
     return null
   }
 
-  return fs.readFileSync(PERFORMANCE_SNAPSHOT_PATH, "utf-8")
+  return fs.readFileSync(filePath, "utf-8")
 }
 
-function restoreSnapshotFile(contents: string | null): void {
+function restoreFile(filePath: string, contents: string | null): void {
   if (contents === null) {
-    fs.rmSync(PERFORMANCE_SNAPSHOT_PATH, { force: true })
+    fs.rmSync(filePath, { force: true })
     return
   }
 
-  fs.writeFileSync(PERFORMANCE_SNAPSHOT_PATH, contents, "utf-8")
+  fs.writeFileSync(filePath, contents, "utf-8")
 }
 
 function performanceSnapshot(): PerformanceSnapshot {

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -1,11 +1,21 @@
 import * as fs from "node:fs"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import * as v from "valibot"
-import { log, trySync, warn } from "./effect.ts"
-import { getErrorMessage } from "./log.ts"
+import { log, trySync } from "./effect.ts"
 
 const SNAPSHOT_DATA_DIR = "./tmp/fintual-data"
 export const PERFORMANCE_SNAPSHOT_PATH = `${SNAPSHOT_DATA_DIR}/balance-2.json`
+
+export class PerformanceSnapshotValidationError extends Schema.TaggedError<PerformanceSnapshotValidationError>()(
+  "PerformanceSnapshotValidationError",
+  {
+    issues: Schema.String,
+  },
+) {
+  get message(): string {
+    return `Fintual performance snapshot is invalid: ${this.issues}`
+  }
+}
 
 const finiteNumber = v.pipe(v.number(), v.finite())
 
@@ -27,14 +37,14 @@ export type PerformanceSnapshot = v.InferOutput<typeof performanceSnapshotSchema
 
 export function validatePerformanceSnapshot(
   snapshot: unknown,
-): Effect.Effect<PerformanceSnapshot, Error> {
+): Effect.Effect<PerformanceSnapshot, PerformanceSnapshotValidationError> {
   return Effect.gen(function* () {
     const validation = v.safeParse(performanceSnapshotSchema, snapshot)
     if (!validation.success) {
       return yield* Effect.fail(
-        new Error(
-          `Fintual performance snapshot is invalid: ${JSON.stringify(v.flatten(validation.issues))}`,
-        ),
+        new PerformanceSnapshotValidationError({
+          issues: JSON.stringify(v.flatten(validation.issues)),
+        }),
       )
     }
 
@@ -42,8 +52,10 @@ export function validatePerformanceSnapshot(
   })
 }
 
-export function writePerformanceSnapshot(snapshot: PerformanceSnapshot): Effect.Effect<void> {
-  return Effect.matchEffect(
+export function writePerformanceSnapshot(
+  snapshot: PerformanceSnapshot,
+): Effect.Effect<void, Error> {
+  return Effect.andThen(
     trySync({
       try: () => {
         fs.mkdirSync(SNAPSHOT_DATA_DIR, { recursive: true })
@@ -51,9 +63,6 @@ export function writePerformanceSnapshot(snapshot: PerformanceSnapshot): Effect.
       },
       catch: "Failed to write performance snapshot artifact",
     }),
-    {
-      onFailure: (cause) => warn(getErrorMessage(cause)),
-      onSuccess: () => log(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`),
-    },
+    () => log(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`),
   )
 }


### PR DESCRIPTION
## What

Implements #291 — every failure the Fintual sync pipeline can produce now surfaces as a tagged `FintualError` variant, matching the ADR-0001 taxonomy and ADR-0003 convention. The sync keeps its current module shape; only the failure channel becomes typed.

## Changes

- **`src/fintual/fintual-error.ts`** (new) — `FintualError` tagged union with the seven variants from ADR-0001, modeled as `Schema.TaggedError` values (the installed `effect@4.0.0-beta.106` does not expose `Schema.TaggedErrorClass`; `Schema.TaggedError` is its equivalent in this version). Message getters preserve today's exact log wording.
- **`authenticated-ingestion.ts`** — typed seam: `initiate_login` 401 → `LoginFailed`; other non-2xx login/GraphQL responses → `UnexpectedHttpStatus`; request/body-read/cookie failures → `HttpTransportFailure`; malformed JSON / schema mismatch / GraphQL errors → `MalformedGoalPerformanceData` with the correct purpose; no 2FA code before timeout → `Email2FAFailure` (cause required, explanatory error for the timeout).
- **`performance-snapshot.ts`** — `writePerformanceSnapshot` drops its catch+warn and propagates failures (write failures now fail the sync instead of warn-and-succeed), keeps the "saved to" log. Validation fails with a typed `PerformanceSnapshotValidationError` carrying the flattened-JSON issues string.
- **`http-sync.ts`** — maps snapshot validation → `MalformedPerformanceSnapshot` (via `catchIf` on the typed validation error, no message-text coupling), write failures → `SnapshotWriteFailure`. The `error(...)` logging wrapper is unchanged.

## Tests

- Existing tests assert failures by `_tag`/fields instead of message text, including the login body-not-leaked test (strengthened: failure must be an `Error`).
- New coverage: `LoginFailed` on 401, `HttpTransportFailure` for request-throw and body-read failures, and a snapshot write-failure test.

## Behavior change (deliberate, per issue)

A failed snapshot write now fails the sync instead of warn-and-succeed.

## Verification

`pnpm test` (50 tests), `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm fallow:audit` — all green.