### PR TITLE
feat(once): ship the redacting logging edge at the process boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	},
 	"dependencies": {
 		"@actual-app/api": "26.8.1",
+		"@effect/platform-node": "4.0.0-beta.106",
 		"dotenv": "17.4.2",
 		"effect": "4.0.0-beta.106",
 		"imapflow": "1.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@actual-app/api':
         specifier: 26.8.1
         version: 26.8.1
+      '@effect/platform-node':
+        specifier: 4.0.0-beta.106
+        version: 4.0.0-beta.106(effect@4.0.0-beta.106)(ioredis@5.11.1)
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -67,6 +70,19 @@ packages:
   '@bufbuild/protobuf@2.13.0':
     resolution: {integrity: sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==}
 
+  '@effect/platform-node-shared@4.0.0-beta.107':
+    resolution: {integrity: sha512-y6BqcRi86BfTJv+tvDrob4ozYVHxxlHYcn/zIQqZjXI9CvKnkgD6ng+38G1o45c4f2ucU+6HRI9POCmFdMoVGA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-beta.107
+
+  '@effect/platform-node@4.0.0-beta.106':
+    resolution: {integrity: sha512-Me7uorWWroWp4OuWHbFg7EqyIex45QzZ3EPwh2p8y/t3VCWVy4KSFtL9AKOKpd7QK1krUWxRK/26J/hTsqvwZg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      effect: ^4.0.0-beta.106
+      ioredis: '>=5.7.0 <6.0.0'
+
   '@fallow-cli/darwin-arm64@3.14.0':
     resolution: {integrity: sha512-seaix3OqADcq90PkPOOPrN8Jl7QZDGjFziHA85Ikp+lGSHVjJ2IMyGh/QKLhvi9Q6Ha3Y//F0+PFFGNd0Gi4mw==}
     cpu: [arm64]
@@ -106,6 +122,9 @@ packages:
     resolution: {integrity: sha512-ihyCZ5GMoYGnzlPP6b5pZBBcGZhDHDW2u1YEGkZEuf3pbW6E45U7Hhf213cE2CCheScXOirK6AKWnLM/Qj4c2A==}
     cpu: [x64]
     os: [win32]
+
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
 
   '@jlongster/sql.js@1.6.7':
     resolution: {integrity: sha512-4hf0kZr5WPoirdR5hUSfQ9O0JpH/qlW1CaR2wZ6zGrDz1xjSdTPuR8AW/oXzIHnJvZSEvlcIE+dfXJZwh/Lxfw==}
@@ -547,6 +566,9 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
     engines: {node: '>=16.20.0'}
@@ -736,6 +758,10 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
@@ -751,6 +777,15 @@ packages:
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -762,6 +797,10 @@ packages:
   deepmerge-ts@7.1.5:
     resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
     engines: {node: '>=16.0.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -898,6 +937,10 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -1004,6 +1047,11 @@ packages:
   mailparser@3.9.15:
     resolution: {integrity: sha512-/5hgybKDMKFS05jAh8OPeEE7N53lj8nF6ywlo89VPjF2TtwqIQbjaxumQWnJIkmaagnJ6u1eansMOViHFxIXwQ==}
 
+  mime@4.1.0:
+    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -1016,6 +1064,9 @@ packages:
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   msgpackr-extract@3.0.4:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
@@ -1155,6 +1206,14 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   regexp-to-ast@0.4.0:
     resolution: {integrity: sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==}
 
@@ -1223,6 +1282,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -1288,6 +1350,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -1399,6 +1465,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
@@ -1444,6 +1522,26 @@ snapshots:
 
   '@bufbuild/protobuf@2.13.0': {}
 
+  '@effect/platform-node-shared@4.0.0-beta.107(effect@4.0.0-beta.106)':
+    dependencies:
+      '@types/ws': 8.18.1
+      effect: 4.0.0-beta.106
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@4.0.0-beta.106(effect@4.0.0-beta.106)(ioredis@5.11.1)':
+    dependencies:
+      '@effect/platform-node-shared': 4.0.0-beta.107(effect@4.0.0-beta.106)
+      effect: 4.0.0-beta.106
+      ioredis: 5.11.1
+      mime: 4.1.0
+      undici: 8.10.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@fallow-cli/darwin-arm64@3.14.0':
     optional: true
 
@@ -1467,6 +1565,8 @@ snapshots:
 
   '@fallow-cli/win32-x64-msvc@3.14.0':
     optional: true
+
+  '@ioredis/commands@1.10.0': {}
 
   '@jlongster/sql.js@1.6.7': {}
 
@@ -1702,6 +1802,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
@@ -1847,6 +1951,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  cluster-key-slot@1.1.1: {}
+
   compare-versions@6.1.1: {}
 
   convert-source-map@2.0.0: {}
@@ -1857,6 +1963,10 @@ snapshots:
 
   date-fns@4.4.0: {}
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -1864,6 +1974,8 @@ snapshots:
   deep-extend@0.6.0: {}
 
   deepmerge-ts@7.1.5: {}
+
+  denque@2.1.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -2011,6 +2123,18 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ioredis@5.11.1:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.2.0: {}
 
   kubernetes-types@1.30.0: {}
@@ -2100,6 +2224,8 @@ snapshots:
       punycode.js: 2.3.1
       tlds: 1.261.0
 
+  mime@4.1.0: {}
+
   mimic-response@3.1.0: {}
 
   minimist@1.2.8: {}
@@ -2107,6 +2233,8 @@ snapshots:
   mitt@3.0.1: {}
 
   mkdirp-classic@0.5.3: {}
+
+  ms@2.1.3: {}
 
   msgpackr-extract@3.0.4:
     dependencies:
@@ -2289,6 +2417,12 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   regexp-to-ast@0.4.0: {}
 
   rolldown@1.2.3:
@@ -2355,6 +2489,8 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@4.2.0: {}
 
@@ -2434,6 +2570,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici@8.10.0: {}
+
   util-deprecate@1.0.2: {}
 
   uuid@14.0.1: {}
@@ -2488,6 +2626,8 @@ snapshots:
   wordwrap@1.0.0: {}
 
   wrappy@1.0.2: {}
+
+  ws@8.21.3: {}
 
   xml2js@0.6.2:
     dependencies:

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -69,6 +69,7 @@ function runActualSyncAttempt(
           dataDir: ACTUAL_DATA_DIR,
           serverURL: config.serverUrl,
           password: config.password,
+          verbose: false,
         } satisfies ActualInitConfig),
       catch: (error) => toError(error, "Failed to initialize Actual API"),
     })

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,12 +1,11 @@
 import { Effect } from "effect"
 import { main as mainActual } from "./actual.ts"
-import { log } from "./effect.ts"
 import { FintualConfigService, type RuntimeConfig } from "./env.ts"
 import { FintualPerformance } from "./fintual/performance.ts"
 
 export function runJob(config: RuntimeConfig): Effect.Effect<void, Error> {
   return Effect.gen(function* () {
-    yield* log("Running job...")
+    yield* Effect.logInfo("Running job...")
     const snapshot = yield* Effect.gen(function* () {
       const service = yield* FintualPerformance
       return yield* service.fetchPerformanceSnapshot()
@@ -15,6 +14,6 @@ export function runJob(config: RuntimeConfig): Effect.Effect<void, Error> {
       Effect.provideService(FintualConfigService, config.fintual),
     )
     yield* mainActual(config.actual, snapshot)
-    yield* log("Job finished.")
+    yield* Effect.logInfo("Job finished.")
   })
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -46,7 +46,7 @@ export function toError(error: unknown, message: string | ((error: unknown) => s
   return new Error(`${message}: ${getErrorMessage(error)}`, { cause: error })
 }
 
-function redactSensitiveText(value: string): string {
+export function redactSensitiveText(value: string): string {
   let redactedValue = value
 
   for (const sensitiveValue of configuredRedactionSecrets) {

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -1,0 +1,155 @@
+import { Cause, Console, Effect, Logger } from "effect"
+import { describe, expect, it } from "vitest"
+import type { RuntimeConfig } from "./env.ts"
+import { configureSensitiveValues } from "./log.ts"
+import { redactingLogger, reportUnhandledFailure } from "./once.ts"
+
+const secret = "hunter2-super-secret"
+
+const runtimeConfig: RuntimeConfig = {
+  actual: {
+    serverUrl: "http://localhost:5006",
+    password: secret,
+    syncId: "sync-1",
+    fintualAccount: "fintual-account",
+    startingDate: "2024-03-01",
+    payee: "Fintual",
+  },
+  fintual: {
+    email: "user@example.com",
+    password: "fintual-pass",
+    goalId: "goal-42",
+    email2FA: null,
+  },
+}
+
+function captureConsole(lines: Array<string>): Console.Console {
+  return {
+    assert: () => {},
+    clear: () => {},
+    count: () => {},
+    countReset: () => {},
+    debug: (line: string) => lines.push(line),
+    dir: () => {},
+    dirxml: () => {},
+    error: (line: string) => lines.push(line),
+    group: () => {},
+    groupCollapsed: () => {},
+    groupEnd: () => {},
+    info: (line: string) => lines.push(line),
+    log: (line: string) => lines.push(line),
+    table: () => {},
+    time: () => {},
+    timeEnd: () => {},
+    timeLog: () => {},
+    trace: () => {},
+    warn: (line: string) => lines.push(line),
+  }
+}
+
+describe("redactingLogger", () => {
+  it("renders timestamped, level-prefixed lines with sensitive values redacted", async () => {
+    configureSensitiveValues(runtimeConfig)
+    const lines: Array<string> = []
+    const program = Effect.gen(function* () {
+      yield* Effect.logInfo(`Connecting with password ${secret}`)
+      yield* Effect.logError(Cause.fail(new Error(`auth failed with ${secret}`)))
+    })
+
+    await Effect.runPromise(
+      program.pipe(
+        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provideService(Console.Console, captureConsole(lines)),
+      ),
+    )
+
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toMatch(
+      /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: Connecting with password \[redacted\]$/,
+    )
+    expect(lines[1]).toMatch(
+      /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] ERROR: Error: auth failed with \[redacted\]/,
+    )
+    expect(lines[1]).not.toContain(secret)
+  })
+
+  it("redacts annotation values", async () => {
+    configureSensitiveValues(runtimeConfig)
+    const lines: Array<string> = []
+    const program = Effect.gen(function* () {
+      yield* Effect.logInfo("creating goal").pipe(Effect.annotateLogs({ goalId: "goal-42" }))
+    })
+
+    await Effect.runPromise(
+      program.pipe(
+        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provideService(Console.Console, captureConsole(lines)),
+      ),
+    )
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatch(
+      /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: creating goal goalId: \[redacted\]$/,
+    )
+  })
+
+  it("redacts secrets split across message parts", async () => {
+    configureSensitiveValues(runtimeConfig)
+    const lines: Array<string> = []
+    const program = Effect.gen(function* () {
+      yield* Effect.logInfo("password is", secret, "on", "goal-42")
+    })
+
+    await Effect.runPromise(
+      program.pipe(
+        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provideService(Console.Console, captureConsole(lines)),
+      ),
+    )
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatch(
+      /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: password is \[redacted\] on \[redacted\]$/,
+    )
+  })
+})
+
+describe("reportUnhandledFailure", () => {
+  it("reports non-interrupt failures through the redacting logger", async () => {
+    configureSensitiveValues(runtimeConfig)
+    const lines: Array<string> = []
+    const program = Effect.fail(new Error(`unexpected ${secret}`)).pipe(
+      Effect.tapCause(reportUnhandledFailure),
+      Effect.catchCause(() => Effect.void),
+    )
+
+    await Effect.runPromise(
+      program.pipe(
+        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provideService(Console.Console, captureConsole(lines)),
+      ),
+    )
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatch(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\] ERROR: Error: unexpected \[redacted\]/)
+    expect(lines[0]).not.toContain(secret)
+  })
+
+  it("stays silent for interrupt-only causes", async () => {
+    configureSensitiveValues(runtimeConfig)
+    const lines: Array<string> = []
+    const program = Effect.interrupt.pipe(
+      Effect.tapCause(reportUnhandledFailure),
+      Effect.catchCause(() => Effect.void),
+    )
+
+    await Effect.runPromise(
+      program.pipe(
+        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provideService(Console.Console, captureConsole(lines)),
+      ),
+    )
+
+    expect(lines).toHaveLength(0)
+  })
+})

--- a/src/once.ts
+++ b/src/once.ts
@@ -1,31 +1,63 @@
 import { pathToFileURL } from "node:url"
+import { NodeRuntime } from "@effect/platform-node"
 import { config as loadDotEnv } from "dotenv"
-import { Effect } from "effect"
-import { log } from "./effect.ts"
+import { Array as EffectArray, Cause, Effect, Formatter, Logger, References } from "effect"
 import { resolveRuntimeConfig } from "./env.ts"
 import { runJob } from "./job.ts"
-import { configureSensitiveValues, getErrorMessage } from "./log.ts"
+import { configureSensitiveValues, redactSensitiveText } from "./log.ts"
 
 loadDotEnv()
 
 const main: Effect.Effect<void, Error> = Effect.gen(function* () {
   const runtimeConfig = yield* resolveRuntimeConfig(process.env)
   configureSensitiveValues(runtimeConfig)
-  yield* log("Running task once...")
+  yield* Effect.logInfo("Running task once...")
   yield* runJob(runtimeConfig)
-  yield* log("Task completed.")
+  yield* Effect.logInfo("Task completed.")
 })
+
+export const redactingLogger = Logger.withLeveledConsole(
+  Logger.make(({ cause, date, fiber, logLevel, message }) => {
+    const parts: Array<string> = []
+    for (const part of EffectArray.ensure(message)) {
+      parts.push(renderPlain(part))
+    }
+    if (cause.reasons.length > 0) {
+      parts.push(Cause.pretty(cause))
+    }
+    for (const [key, value] of Object.entries(fiber.getRef(References.CurrentLogAnnotations))) {
+      parts.push(`${key}: ${renderPlain(value)}`)
+    }
+    const line = `[${formatTimestamp(date)}] ${logLevel.toUpperCase()}: ${parts.join(" ")}`
+    return redactSensitiveText(line)
+  }),
+)
+
+export const reportUnhandledFailure = (cause: Cause.Cause<unknown>): Effect.Effect<void> =>
+  Cause.hasInterruptsOnly(cause) ? Effect.void : Effect.logError(cause)
+
+function renderPlain(value: unknown): string {
+  return typeof value === "string" ? value : Formatter.format(value)
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (value: number, width: number): string => value.toString().padStart(width, "0")
+  return `${pad(date.getHours(), 2)}:${pad(date.getMinutes(), 2)}:${pad(
+    date.getSeconds(),
+    2,
+  )}.${pad(date.getMilliseconds(), 3)}`
+}
 
 function isMainModule(): boolean {
   return import.meta.url === pathToFileURL(process.argv[1] ?? "").href
 }
 
 if (isMainModule()) {
-  try {
-    await Effect.runPromise(main)
-    process.exit(0)
-  } catch (error) {
-    console.error(`Error running task: ${getErrorMessage(error)}`)
-    process.exit(1)
-  }
+  NodeRuntime.runMain(
+    main.pipe(
+      Effect.tapCause(reportUnhandledFailure),
+      Effect.provide(Logger.layer([redactingLogger])),
+    ),
+    { disableErrorReporting: true },
+  )
 }


### PR DESCRIPTION
Closes #297

## What

`src/once.ts` is now the process boundary that renders every Effect log event as timestamped, level-prefixed, redacted plain-text lines (ADR 0004). The task runner and the job it runs use native Effect logging; failures exit with the standard codes (0 success, 1 failure, 130 interrupted) via `NodeRuntime.runMain`'s `defaultTeardown` — no manual `console.error` catch or `process.exit` remains.

## Changes

- **`src/once.ts`** — custom `Logger` (`Logger.withLeveledConsole` + `Logger.make`) that composes the message, cause, and annotation values and redacts the final line once at render time, closing the split-secret gap; `NodeRuntime.runMain` with `disableErrorReporting: true` and an explicit `Effect.tapCause(reportUnhandledFailure)` inside the logger provide, so unreported failures render through the redacting logger (runMain's built-in report bypasses provided loggers).
- **`src/job.ts`** — `log` alias calls converted to `Effect.logInfo`.
- **`src/log.ts`** — exports `redactSensitiveText` for the render edge; stays the redaction policy module.
- **`package.json`** — adds `@effect/platform-node@4.0.0-beta.106`.
- **`src/once.test.ts`** — covers rendering (timestamped, level-prefixed, redacted), annotation and split-secret redaction, and the failure-reporting / interrupt-silence edge.

## Verification

- Exit codes verified end-to-end: 0 success, 1 failure, 130 SIGINT; ERROR lines route to stderr, INFO to stdout.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test` (57 passing), `pnpm fallow:audit` all green.