### PR TITLE
chore: set up Frog friction logging

### DIFF
--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -1,0 +1,38 @@
+# Friction log
+
+Friction hit while working in this repository, one directory per item:
+
+```
+<id>/
+  friction.md   the write-up
+  artifacts/    optional, whatever reproduces it
+```
+
+Reporting an entry gives it an owner. The write-up then carries an `issue:` link and mirrors what happens
+to it. The whole directory is deleted once the friction is resolved. Every entry left here is still
+outstanding, including friction in dependencies.
+
+Do not maintain an index here. This directory is the index.
+
+## Logging Friction
+
+```sh
+pnpx frog list    # what is already known
+pnpx frog log     # add one
+```
+
+`pnpx frog log` writes the sections to fill in. Each id is when the friction was hit plus its title, so
+the directory reads oldest-first.
+
+Put anything that reproduces the friction in that entry's `artifacts/` and reference it from the
+write-up. The next reader runs the reproduction instead of rebuilding it.
+
+## For Agents
+
+Add these rules near the top of `AGENTS.md`, under the appropriate section. Create the file if missing; otherwise amend it in place, preserve all existing content, and never replace the file.
+
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `pnpx frog log`.
+- Do not add global, system, or internal friction.
+- Run `pnpx frog list` first to see what is already known.
+
+Managed by [Frog](https://github.com/wevm/frog).

--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -2,7 +2,7 @@
 
 Friction hit while working in this repository, one directory per item:
 
-```
+```text
 <id>/
   friction.md   the write-up
   artifacts/    optional, whatever reproduces it
@@ -23,6 +23,9 @@ pnpx frog log     # add one
 
 `pnpx frog log` writes the sections to fill in. Each id is when the friction was hit plus its title, so
 the directory reads oldest-first.
+
+Before logging or submitting friction, redact credentials, tokens, customer data,
+email addresses, and other PII from the write-up, artifacts, and issue text.
 
 Put anything that reproduces the friction in that entry's `artifacts/` and reference it from the
 write-up. The next reader runs the reproduction instead of rebuilding it.

--- a/.agents/friction-log/config.json
+++ b/.agents/friction-log/config.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://unpkg.com/frog/schema.json",
+  "inbound": {
+    "enabled": false
+  }
+}

--- a/.github/ISSUE_TEMPLATE/friction.yml
+++ b/.github/ISSUE_TEMPLATE/friction.yml
@@ -1,0 +1,34 @@
+name: Friction
+description: Something about this project cost you time.
+labels: [friction]
+body:
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: Describe what should happen.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: Describe what happens instead.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Possible Solution
+      description: Optional. Suggest a fix or a reason for the friction.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Minimal Reproducible Example
+      description: Add a minimal reproducible example under `artifacts/`, or an unambiguous set of steps to reproduce this. Include code where relevant.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Context
+      description: Describe how this affected you, and what you were trying to accomplish.
+    validations:
+      required: false

--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -1,0 +1,38 @@
+name: Friction Log
+on:
+  push:
+  issues:
+    types: [closed, reopened]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: friction-log
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  friction-log:
+    name: Friction Log
+    if: >-
+      (github.event_name != 'push' || github.ref_name == github.event.repository.default_branch) &&
+      (github.event_name != 'issues' || github.event.issue.user.login == 'github-actions[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Report and reconcile frictions
+        uses: wevm/frog/action@v1
+        with:
+          issue-author: github-actions[bot]

--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -21,18 +21,22 @@ jobs:
       (github.event_name != 'issues' || github.event.issue.user.login == 'github-actions[bot]')
     runs-on: ubuntu-latest
     permissions:
+      # Creates and updates the frog/sync cleanup branch.
       contents: write
+      # Reports and reconciles friction issues.
       issues: write
+      # Creates and updates the frog/sync pull request.
       pull-requests: write
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ github.sha }}
 
       - name: Report and reconcile frictions
-        uses: wevm/frog/action@v1
+        uses: wevm/frog/action@702c4eadefe175a208290a99c36e7f4ac1390e53 # v1
         with:
           issue-author: github-actions[bot]
+          version: 1.1.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,11 @@ Domain documentation uses a single-context layout. See `docs/agents/domain.md`.
 ### Testing principles
 
 Tests favor readable, behavior-focused workflows with explicit setup. See `docs/agents/testing-principles.md`.
+
+### Friction logging
+
+Friction is logged with Frog (see https://frog.fm). Use `pnpx frog log` to write an entry, and `pnpx frog list` first to see what is already known.
+
+- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `pnpx frog log`.
+- Do not add global, system, or internal friction.
+- Run `pnpx frog list` first to see what is already known.


### PR DESCRIPTION
## Summary

Set up [Frog](https://frog.fm) so agents log friction as they hit it, instead of carrying each workaround silently to the next session.

## Changes

- **`.agents/friction-log/`** — the log directory (`README.md` + `config.json`). Inbound reports are **disabled** (`inbound.enabled: false`), so no other repo can report friction here.
- **`.github/ISSUE_TEMPLATE/friction.yml`** — issue form used when Frog reports a pending entry (labeled `friction`).
- **`.github/workflows/friction-log.yml`** — Action-only automation: runs on push to `main`, closed/reopened issues, manual dispatch, and a daily sweep. Reports pending entries as issues and maintains the accumulating `frog/sync` PR that deletes entries once their issue closes. No third-party App installed; uses the repo's `GITHUB_TOKEN`.
- **`AGENTS.md`** — rules telling agents to `pnpx frog list` before starting and `pnpx frog log` when they hit friction.

## Manual step remaining

Enable **Allow GitHub Actions to create and approve pull requests** under Settings → Actions → General (no REST API exists for this toggle). Required for the `frog/sync` cleanup PR.