### PR TITLE
refactor(fintual): use native Effect primitives (#299)

### DIFF
--- a/src/fintual/authenticated-ingestion.ts
+++ b/src/fintual/authenticated-ingestion.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer } from "effect"
-import { tryPromise, trySync } from "../effect.ts"
+import { getErrorMessage } from "../log.ts"
 import { HttpTransportFailure, type FintualError } from "./fintual-error.ts"
 
 export const FINTUAL_ORIGIN = "https://fintual.cl"
@@ -46,22 +46,26 @@ class FintualHttpSession {
       }
 
       const response = yield* Effect.mapError(
-        tryPromise({
+        Effect.tryPromise({
           try: () =>
             this.fetchRequest(`${FINTUAL_ORIGIN}${path}`, {
               ...init,
               headers,
               signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
             }),
-          catch: `${stage}: request failed`,
+          catch: (cause) =>
+            new Error(`${stage}: request failed: ${getErrorMessage(cause)}`, { cause }),
         }),
         (cause) => new HttpTransportFailure({ stage, cause }),
       )
 
       yield* Effect.mapError(
-        trySync({
+        Effect.try({
           try: () => mergeSetCookieHeaders(response.headers, this.cookies),
-          catch: `${stage}: failed to update session cookies`,
+          catch: (cause) =>
+            new Error(`${stage}: failed to update session cookies: ${getErrorMessage(cause)}`, {
+              cause,
+            }),
         }),
         (cause) => new HttpTransportFailure({ stage, cause }),
       )

--- a/src/fintual/new-performance.ts
+++ b/src/fintual/new-performance.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import * as v from "valibot"
-import { trySync } from "../effect.ts"
+import { getErrorMessage } from "../log.ts"
 
 export const TimeIntervalCode = {
   LastMonth: "last_month",
@@ -40,10 +40,13 @@ export function parseGoalPerformanceResponseBody(
   body: string,
 ): Effect.Effect<GoalPerformanceData, Error> {
   return Effect.gen(function* () {
-    const parsedJson = yield* trySync({
+    const parsedJson = yield* Effect.try({
       // oxlint-disable-next-line typescript/consistent-type-assertions
       try: () => JSON.parse(body) as unknown,
-      catch: "Failed to parse goal performance response body",
+      catch: (cause) =>
+        new Error(`Failed to parse goal performance response body: ${getErrorMessage(cause)}`, {
+          cause,
+        }),
     })
 
     const parsedData = v.safeParse(newPerformanceSchema, parsedJson)

--- a/src/fintual/performance.ts
+++ b/src/fintual/performance.ts
@@ -1,5 +1,4 @@
 import { Context, Effect, Layer } from "effect"
-import { tryPromise, trySync } from "../effect.ts"
 import { FintualConfigService } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import {
@@ -62,9 +61,12 @@ export class FintualPerformance extends Context.Service<
           )
 
           const snapshot = yield* Effect.mapError(
-            trySync({
+            Effect.try({
               try: () => foldGoalPerformanceData(reference, recent),
-              catch: "Failed to fold Fintual performance data",
+              catch: (cause) =>
+                new Error(`Failed to fold Fintual performance data: ${getErrorMessage(cause)}`, {
+                  cause,
+                }),
             }),
             (cause) => new MalformedPerformanceSnapshot({ issues: getErrorMessage(cause) }),
           )
@@ -212,9 +214,10 @@ function fetchGoalPerformanceData(
 
 function readResponseBody(response: Response, stage: string): Effect.Effect<string, FintualError> {
   return Effect.mapError(
-    tryPromise({
+    Effect.tryPromise({
       try: () => response.text(),
-      catch: `${stage}: failed to read response body`,
+      catch: (cause) =>
+        new Error(`${stage}: failed to read response body: ${getErrorMessage(cause)}`, { cause }),
     }),
     (cause) => new HttpTransportFailure({ stage, cause }),
   )

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs"
 import { Context, Effect, Layer, Schema } from "effect"
 import * as v from "valibot"
-import { log, trySync } from "./effect.ts"
+import { getErrorMessage } from "./log.ts"
 import { SnapshotWriteFailure } from "./fintual/fintual-error.ts"
 
 const SNAPSHOT_DATA_DIR = "./tmp/fintual-data"
@@ -75,13 +75,16 @@ export function writePerformanceSnapshot(
   snapshot: PerformanceSnapshot,
 ): Effect.Effect<void, Error> {
   return Effect.andThen(
-    trySync({
+    Effect.try({
       try: () => {
         fs.mkdirSync(SNAPSHOT_DATA_DIR, { recursive: true })
         fs.writeFileSync(PERFORMANCE_SNAPSHOT_PATH, JSON.stringify(snapshot, null, 2), "utf-8")
       },
-      catch: "Failed to write performance snapshot artifact",
+      catch: (cause) =>
+        new Error(`Failed to write performance snapshot artifact: ${getErrorMessage(cause)}`, {
+          cause,
+        }),
     }),
-    () => log(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`),
+    () => Effect.logInfo(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`),
   )
 }


### PR DESCRIPTION
## What

Converts the Fintual HTTP session, performance endpoints, and the performance snapshot artifact module to native Effect primitives, per #299. Stops importing generic aliases from `src/effect.ts`; the typed `FintualError` mapping from #295 stays intact.

## Acceptance criteria

- [x] Fintual HTTP modules and snapshot artifact module import no names from the generic alias module
- [x] Fallible operations use native `Effect.tryPromise`/`Effect.try`; `FintualError` typed mapping, message wording, and cause chaining unchanged (`new Error(\`${message}: ${getErrorMessage(cause)}\`, { cause })`, matching the old alias output exactly)
- [x] Log calls become native `Effect.logInfo` with identical wording
- [x] Existing Fintual and snapshot tests pass unchanged
- [x] `typecheck`, `lint`, `test`, `format:check` all pass
- [x] Read `node_modules/effect/AGENTS.md` first (repo rule)

## Commits

- `refactor(fintual): use native Effect primitives in the HTTP session`
- `refactor(fintual): use native Effect primitives in performance data retrieval`
- `refactor(snapshot): use native Effect primitives in the snapshot artifact`

Closes #299