### PR TITLE
refactor(fintual): extract typed IMAP client seam for email 2FA retrieval (#301)

### DIFF
--- a/src/fintual/email-2fa-client.test.ts
+++ b/src/fintual/email-2fa-client.test.ts
@@ -27,6 +27,33 @@ test("surfaces a plain search failure with the preserved message and original ca
   expect(error.cause).toBe(originalError)
 })
 
+test("exposes only the subject from the message envelope across the seam", async () => {
+  const raw = new ImapFlow({
+    host: "imap.example.com",
+    port: 993,
+    secure: true,
+    auth: { user: "user@example.com", pass: "app-password" },
+    logger: false,
+  })
+  raw.fetchOne = async () => ({
+    seq: 1,
+    uid: 123,
+    source: Buffer.from("Subject: Codigo 123456\n\nCodigo: 123456"),
+    envelope: {
+      subject: "Codigo 123456",
+      date: new Date("2026-07-14T10:31:00"),
+      from: [{ address: "security@fintual.com" }],
+      to: [{ address: "user@example.com" }],
+      messageId: "<message-id>",
+    },
+    internalDate: new Date("2026-07-14T10:31:00"),
+  })
+
+  const message = await Effect.runPromise(new ImapFlowClient(raw).fetchOne(123))
+
+  expect(message?.envelope).toEqual({ subject: "Codigo 123456" })
+})
+
 function clientWithSearchError(error: Error): ImapFlowClient {
   const raw = new ImapFlow({
     host: "imap.example.com",

--- a/src/fintual/email-2fa-client.test.ts
+++ b/src/fintual/email-2fa-client.test.ts
@@ -1,0 +1,42 @@
+import { Effect } from "effect"
+import { ImapFlow } from "imapflow"
+import { expect, test } from "vitest"
+import { ImapFlowClient, MissingServerExtension } from "./email-2fa-client.ts"
+
+test("surfaces a MissingServerExtension search rejection as a typed error", async () => {
+  const client = clientWithSearchError(
+    Object.assign(new Error("Server does not support X-GM-EXT-1 extension"), {
+      code: "MissingServerExtension",
+    }),
+  )
+
+  const error = await Effect.runPromise(Effect.flip(client.search({ gmraw: "from:a" })))
+
+  expect(error).toBeInstanceOf(MissingServerExtension)
+})
+
+test("surfaces a plain search failure with the preserved message and original cause", async () => {
+  const originalError = new Error("boom")
+  const client = clientWithSearchError(originalError)
+
+  const error = await Effect.runPromise(Effect.flip(client.search({ gmraw: "from:a" })))
+
+  expect(error).toBeInstanceOf(Error)
+  expect(error).not.toBeInstanceOf(MissingServerExtension)
+  expect(error.message).toBe("Failed to search Gmail IMAP mailbox: boom")
+  expect(error.cause).toBe(originalError)
+})
+
+function clientWithSearchError(error: Error): ImapFlowClient {
+  const raw = new ImapFlow({
+    host: "imap.example.com",
+    port: 993,
+    secure: true,
+    auth: { user: "user@example.com", pass: "app-password" },
+    logger: false,
+  })
+  raw.search = async () => {
+    throw error
+  }
+  return new ImapFlowClient(raw)
+}

--- a/src/fintual/email-2fa-client.ts
+++ b/src/fintual/email-2fa-client.ts
@@ -1,0 +1,121 @@
+import { Effect, Schema } from "effect"
+import { ImapFlow, type SearchObject } from "imapflow"
+import { tryPromise } from "../effect.ts"
+import type { Email2FAConfig } from "../env.ts"
+import { getErrorMessage } from "../log.ts"
+
+export interface ImapMailboxLock {
+  release(): void
+}
+
+export interface ImapMessage {
+  source?: Buffer
+  envelope?: { subject?: string }
+  internalDate?: Date | string
+}
+
+export interface ImapClient {
+  readonly usable: boolean
+  connect(): Effect.Effect<void, Error>
+  getMailboxLock(path: string): Effect.Effect<ImapMailboxLock, Error>
+  search(query: SearchObject): Effect.Effect<number[] | false, Error | MissingServerExtension>
+  fetchOne(uid: number): Effect.Effect<ImapMessage | null, Error>
+  logout(): Effect.Effect<void, Error>
+}
+
+export class MissingServerExtension extends Schema.TaggedError<MissingServerExtension>()(
+  "MissingServerExtension",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  get message(): string {
+    return getErrorMessage(this.cause)
+  }
+}
+
+export class ImapFlowClient implements ImapClient {
+  private readonly raw: ImapFlow
+
+  constructor(raw: ImapFlow) {
+    this.raw = raw
+  }
+
+  get usable(): boolean {
+    return this.raw.usable
+  }
+
+  connect(): Effect.Effect<void, Error> {
+    return tryPromise({
+      try: () => this.raw.connect(),
+      catch: "Failed to connect to Gmail IMAP",
+    })
+  }
+
+  getMailboxLock(path: string): Effect.Effect<ImapMailboxLock, Error> {
+    return tryPromise({
+      try: () => this.raw.getMailboxLock(path),
+      catch: `Failed to lock Gmail IMAP mailbox ${path}`,
+    })
+  }
+
+  search(query: SearchObject): Effect.Effect<number[] | false, Error | MissingServerExtension> {
+    return Effect.tryPromise({
+      try: () => this.raw.search(query, { uid: true }),
+      catch: (cause) => {
+        // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+        const originalError = cause as { code?: string } | undefined
+        if (originalError?.code === "MissingServerExtension") {
+          return new MissingServerExtension({ cause })
+        }
+        return new Error(`Failed to search Gmail IMAP mailbox: ${getErrorMessage(cause)}`, {
+          cause,
+        })
+      },
+    })
+  }
+
+  fetchOne(uid: number): Effect.Effect<ImapMessage | null, Error> {
+    return Effect.map(
+      tryPromise({
+        try: () =>
+          this.raw.fetchOne(
+            String(uid),
+            { source: true, envelope: true, internalDate: true },
+            { uid: true },
+          ),
+        catch: "Failed to fetch Gmail IMAP message",
+      }),
+      (message) =>
+        message
+          ? {
+              source: message.source,
+              envelope: message.envelope,
+              internalDate: message.internalDate,
+            }
+          : null,
+    )
+  }
+
+  logout(): Effect.Effect<void, Error> {
+    return tryPromise({
+      try: () => this.raw.logout(),
+      catch: "Failed to close IMAP connection cleanly",
+    })
+  }
+}
+
+export function createImapClient(config: Email2FAConfig): ImapClient {
+  return new ImapFlowClient(
+    new ImapFlow({
+      host: config.host,
+      port: config.port,
+      secure: true,
+      auth: {
+        user: config.userEmail,
+        pass: config.appPassword,
+      },
+      logger: false,
+    }),
+  )
+}

--- a/src/fintual/email-2fa-client.ts
+++ b/src/fintual/email-2fa-client.ts
@@ -90,7 +90,7 @@ export class ImapFlowClient implements ImapClient {
         message
           ? {
               source: message.source,
-              envelope: message.envelope,
+              envelope: message.envelope ? { subject: message.envelope.subject } : undefined,
               internalDate: message.internalDate,
             }
           : null,

--- a/src/fintual/email-2fa.ts
+++ b/src/fintual/email-2fa.ts
@@ -1,8 +1,8 @@
 import { Clock, Context, Effect, Layer } from "effect"
-import { ImapFlow } from "imapflow"
-import { error, log, sleep, tryPromise, warn } from "../effect.ts"
+import { error, log, sleep, warn } from "../effect.ts"
 import { FintualConfigService, type Email2FAConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
+import { createImapClient, MissingServerExtension, type ImapClient } from "./email-2fa-client.ts"
 import { Email2FAFailure } from "./fintual-error.ts"
 import {
   buildEmail2FASearchQueries,
@@ -70,10 +70,7 @@ function get2FACodeFromEmail(
     const seenMessageKeys = new Set<string>()
 
     const program = Effect.gen(function* () {
-      yield* tryPromise({
-        try: () => imapClient.connect(),
-        catch: "Failed to connect to Gmail IMAP",
-      })
+      yield* imapClient.connect()
 
       while ((yield* Clock.currentTimeMillis) - startedAt < timeoutMs) {
         const code = yield* searchForCode(config, imapClient, afterTimestamp, seenMessageKeys)
@@ -98,22 +95,9 @@ function get2FACodeFromEmail(
   })
 }
 
-function createImapClient(config: Email2FAConfig): ImapFlow {
-  return new ImapFlow({
-    host: config.host,
-    port: config.port,
-    secure: true,
-    auth: {
-      user: config.userEmail,
-      pass: config.appPassword,
-    },
-    logger: false,
-  })
-}
-
 function searchForCode(
   config: Email2FAConfig,
-  imapClient: ImapFlow,
+  imapClient: ImapClient,
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
 ): Effect.Effect<string | null, Error> {
@@ -121,15 +105,10 @@ function searchForCode(
 
   return Effect.gen(function* () {
     for (const mailboxPath of paths) {
-      const lock = yield* Effect.catch(
-        tryPromise({
-          try: () => imapClient.getMailboxLock(mailboxPath),
-          catch: `Failed to lock Gmail IMAP mailbox ${mailboxPath}`,
-        }),
-        () =>
-          config.debug
-            ? Effect.as(log(`Gmail IMAP: skip missing mailbox ${mailboxPath}`), undefined)
-            : Effect.succeed(undefined),
+      const lock = yield* Effect.catch(imapClient.getMailboxLock(mailboxPath), () =>
+        config.debug
+          ? Effect.as(log(`Gmail IMAP: skip missing mailbox ${mailboxPath}`), undefined)
+          : Effect.succeed(undefined),
       )
       if (!lock) {
         continue
@@ -178,7 +157,7 @@ function messageSeenKey(mailboxPath: string, uid: number): string {
 }
 
 function extractCodeFromMailboxUids(
-  imapClient: ImapFlow,
+  imapClient: ImapClient,
   mailboxPath: string,
   messageUids: number[],
   afterTimestamp: Date,
@@ -195,19 +174,7 @@ function extractCodeFromMailboxUids(
       }
       seenMessageKeys.add(key)
 
-      const message = yield* tryPromise({
-        try: () =>
-          imapClient.fetchOne(
-            String(uid),
-            {
-              source: true,
-              envelope: true,
-              internalDate: true,
-            },
-            { uid: true },
-          ),
-        catch: "Failed to fetch Gmail IMAP message",
-      })
+      const message = yield* imapClient.fetchOne(uid)
       if (!message || !message.source) {
         continue
       }
@@ -229,26 +196,17 @@ function extractCodeFromMailboxUids(
 
 function runMailboxSearch(
   config: Email2FAConfig,
-  imapClient: ImapFlow,
+  imapClient: ImapClient,
   afterTimestamp: Date,
 ): Effect.Effect<number[] | false, Error> {
   const queries = buildEmail2FASearchQueries(config, afterTimestamp)
 
   return Effect.gen(function* () {
     for (const query of queries) {
-      const messageUids = yield* Effect.catch(
-        tryPromise({
-          try: () => imapClient.search(query, { uid: true }),
-          catch: "Failed to search Gmail IMAP mailbox",
-        }),
-        (cause) => {
-          // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
-          const originalError = cause.cause as { code?: string } | undefined
-          if (originalError?.code === "MissingServerExtension") {
-            return Effect.succeed(false as const)
-          }
-          return Effect.fail(cause)
-        },
+      const messageUids = yield* Effect.catchIf(
+        imapClient.search(query),
+        (cause): cause is MissingServerExtension => cause instanceof MissingServerExtension,
+        () => Effect.succeed(false as const),
       )
       if (messageUids && messageUids.length > 0) {
         return messageUids
@@ -259,16 +217,12 @@ function runMailboxSearch(
   })
 }
 
-function closeImapClient(imapClient: ImapFlow): Effect.Effect<void> {
+function closeImapClient(imapClient: ImapClient): Effect.Effect<void> {
   if (!imapClient.usable) {
     return Effect.void
   }
 
-  return Effect.catch(
-    tryPromise({
-      try: () => imapClient.logout(),
-      catch: "Failed to close IMAP connection cleanly",
-    }),
-    (cause) => warn(`Failed to close IMAP connection cleanly: ${getErrorMessage(cause)}`),
+  return Effect.catch(imapClient.logout(), (cause) =>
+    warn(`Failed to close IMAP connection cleanly: ${getErrorMessage(cause)}`),
   )
 }


### PR DESCRIPTION
## What

Extracts the IMAP operations behind a typed seam (`ImapClient`) per #301, the seam-extraction slice of #284 following ADR 0002/0003. Adds `src/fintual/email-2fa-client.ts` and re-routes the existing retrieval flow in `email-2fa.ts` through it — behavior unchanged.

## Changes

- **`src/fintual/email-2fa-client.ts`** (new): `ImapClient` interface (six Effect-typed operations), `MissingServerExtension` `Schema.TaggedError` with `cause: Schema.Defect()`, `ImapFlowClient` adapter wrapping the raw `ImapFlow` (constructor-injected, live `usable` getter), and `createImapClient` factory.
  - The adapter pre-classifies the `code === "MissingServerExtension"` search rejection into the typed error at the seam; other search failures keep the byte-identical `Failed to search Gmail IMAP mailbox: …` message with the original `cause`.
  - `fetchOne` slims imapflow's `FetchMessageObject` to `source`/`envelope`/`internalDate`; the fixed fetch query moves into the adapter.
- **`src/fintual/email-2fa.ts`**: pure re-routing. Deletes the local `createImapClient`/`ImapFlow` construction and the `cause.cause` cast; `runMailboxSearch` narrows with `Effect.catchIf` + `instanceof MissingServerExtension`. Every message string stays byte-identical.
- **`src/fintual/email-2fa-client.test.ts`** (new): adapter tests over a real-but-unconnected `ImapFlow` with `search` stubbed — asserts both error pre-classifications.

## Verification

- [x] `pnpm test` (59 passing, incl. unchanged `email-2fa-policy.test.ts`)
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check`
- [x] `pnpm fallow:audit` — no new findings in the 3 changed files
- [x] Code reviewed (standards + spec): no findings

Closes #301
