### PR TITLE
fix(fintual): preserve truthful email 2FA sign-in outcomes (#303)

### DIFF
--- a/src/fintual/email-2fa.ts
+++ b/src/fintual/email-2fa.ts
@@ -1,49 +1,31 @@
 import { Context, Effect, Layer } from "effect"
-import { FintualConfigService } from "../env.ts"
-import { Email2FAFailure } from "./fintual-error.ts"
+import type { Email2FAConfig } from "../env.ts"
 import {
   Email2FACode,
   ImapClientFactoryLive,
+  Operational,
   retrieveEmail2FACode,
+  TimedOut,
   type Email2FAOptions,
 } from "./email-2fa/retrieve.ts"
 
 export class Email2FAService extends Context.Service<
   Email2FAService,
   {
-    get2FACode: (options: Email2FAOptions) => Effect.Effect<Email2FACode, Email2FAFailure>
+    get2FACode: (
+      config: Email2FAConfig,
+      options: Email2FAOptions,
+    ) => Effect.Effect<Email2FACode, TimedOut | Operational>
   }
 >()("Email2FAService") {
-  static readonly layer = Layer.effect(
+  static readonly layer = Layer.succeed(
     Email2FAService,
-    Effect.gen(function* () {
-      const config = yield* FintualConfigService
-
-      return Email2FAService.of({
-        get2FACode: Effect.fn("Email2FAService.get2FACode")(function* (options) {
-          if (!config.email2FA) {
-            return yield* Effect.fail(
-              new Email2FAFailure({
-                cause: new Error("Fintual email 2FA: Gmail IMAP credentials not configured"),
-              }),
-            )
-          }
-
-          return yield* retrieveEmail2FACode(config.email2FA, options).pipe(
-            Effect.provide(ImapClientFactoryLive),
-            Effect.catchTags({
-              TimedOut: () =>
-                Effect.fail(
-                  new Email2FAFailure({
-                    cause: new Error("Fintual email 2FA: no code received before timeout"),
-                  }),
-                ),
-              Operational: (operational) =>
-                Effect.fail(new Email2FAFailure({ cause: operational.cause })),
-            }),
-          )
-        }),
-      })
+    Email2FAService.of({
+      get2FACode: Effect.fn("Email2FAService.get2FACode")(function* (config, options) {
+        return yield* retrieveEmail2FACode(config, options).pipe(
+          Effect.provide(ImapClientFactoryLive),
+        )
+      }),
     }),
   )
 }

--- a/src/fintual/fintual-error.ts
+++ b/src/fintual/fintual-error.ts
@@ -57,6 +57,7 @@ export class MalformedPerformanceSnapshot extends Schema.TaggedError<MalformedPe
 }
 
 export class Email2FAFailure extends Schema.TaggedError<Email2FAFailure>()("Email2FAFailure", {
+  stage: Schema.String,
   cause: Schema.Defect(),
 }) {
   get message(): string {

--- a/src/fintual/performance.test.ts
+++ b/src/fintual/performance.test.ts
@@ -1,24 +1,31 @@
-import { Effect, Layer } from "effect"
+import { Effect } from "effect"
 import { describe, expect, test } from "vitest"
 import { FintualConfigService } from "../env.ts"
 import { SnapshotWriter, type PerformanceSnapshot } from "../performance-snapshot.ts"
 import { FetchService } from "./authenticated-ingestion.ts"
 import { Email2FAService } from "./email-2fa.ts"
-import { Email2FACode } from "./email-2fa/retrieve.ts"
-import { Email2FAFailure, SnapshotWriteFailure } from "./fintual-error.ts"
+import { Email2FACode, Operational, TimedOut } from "./email-2fa/retrieve.ts"
+import { SnapshotWriteFailure } from "./fintual-error.ts"
 import { FintualPerformance } from "./performance.ts"
 
 const CONFIG = {
   email: "investor@example.com",
   password: "secret-password",
   goalId: "goal-123",
-  email2FA: null,
+  email2FA: {
+    userEmail: "inbox@example.com",
+    appPassword: "app-password",
+    host: "imap.example.com",
+    port: 993,
+    debug: false,
+    sender: "notifications@example.com",
+  },
 }
 
 interface TestOverrides {
   get2FACode?: Email2FAService["Service"]["get2FACode"]
   write?: SnapshotWriter["Service"]["write"]
-  useLiveEmail2FALayer?: boolean
+  config?: typeof CONFIG | (Omit<typeof CONFIG, "email2FA"> & { email2FA: null })
 }
 
 function performanceProgram(script: FetchScript, overrides: TestOverrides = {}) {
@@ -27,21 +34,13 @@ function performanceProgram(script: FetchScript, overrides: TestOverrides = {}) 
     return yield* service.fetchPerformanceSnapshot()
   })
 
-  if (overrides.useLiveEmail2FALayer && overrides.get2FACode) {
-    throw new Error("get2FACode cannot override the live email 2FA layer")
-  }
-
-  const email2FALayer = overrides.useLiveEmail2FALayer
-    ? Email2FAService.layer
-    : Layer.succeed(Email2FAService, {
-        get2FACode: overrides.get2FACode ?? (() => Effect.succeed(Email2FACode.make("123456"))),
-      })
-
   return program.pipe(
     Effect.provide(FintualPerformance.layer),
-    Effect.provide(email2FALayer),
-    Effect.provideService(FintualConfigService, CONFIG),
+    Effect.provideService(FintualConfigService, overrides.config ?? CONFIG),
     Effect.provide(FetchService.layer(script.fetch)),
+    Effect.provideService(Email2FAService, {
+      get2FACode: overrides.get2FACode ?? (() => Effect.succeed(Email2FACode.make("123456"))),
+    }),
     Effect.provideService(SnapshotWriter, {
       write: overrides.write ?? (() => Effect.void),
     }),
@@ -99,27 +98,61 @@ test("completes email 2FA before it requests Goal Performance Data", async () =>
 describe("fails when email 2FA cannot produce a code", () => {
   test("login requires 2FA but Gmail credentials are not configured", async () => {
     const script = createFetchScript([response(""), response("{}", 201)])
+    let codeRequests = 0
 
     await expect(
-      Effect.runPromise(performanceProgram(script, { useLiveEmail2FALayer: true })),
-    ).rejects.toMatchObject({ _tag: "Email2FAFailure" })
+      Effect.runPromise(
+        performanceProgram(script, {
+          config: { ...CONFIG, email2FA: null },
+          get2FACode: () => {
+            codeRequests += 1
+            return Effect.succeed(Email2FACode.make("123456"))
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      _tag: "Email2FAFailure",
+      stage: "Fintual email 2FA",
+      message: "Fintual email 2FA: Gmail IMAP credentials not configured",
+    })
+    expect(codeRequests).toBe(0)
     expect(script.requests).toHaveLength(2)
   })
 
-  test("code retrieval failure", async () => {
+  test("code retrieval times out", async () => {
     const script = createFetchScript([response(""), response("{}", 201)])
 
     await expect(
       Effect.runPromise(
         performanceProgram(script, {
-          get2FACode: () =>
-            Effect.fail(new Email2FAFailure({ cause: new Error("IMAP connection refused") })),
+          get2FACode: () => Effect.fail(new TimedOut()),
+        }),
+      ),
+    ).rejects.toMatchObject({
+      _tag: "Email2FAFailure",
+      stage: "Fintual email 2FA",
+      message: "Fintual email 2FA: no code received before timeout",
+    })
+  })
+
+  test("operational failure preserves its IMAP cause and sign-in stage", async () => {
+    const script = createFetchScript([response(""), response("{}", 201)])
+    const imapCause = new Error("IMAP connection refused")
+
+    await expect(
+      Effect.runPromise(
+        performanceProgram(script, {
+          get2FACode: () => Effect.fail(new Operational({ cause: imapCause })),
         }),
       ),
     ).rejects.toSatisfy((error) => {
-      expect(error).toMatchObject({ _tag: "Email2FAFailure" })
+      expect(error).toMatchObject({
+        _tag: "Email2FAFailure",
+        stage: "Fintual email 2FA",
+        cause: imapCause,
+      })
       if (error instanceof Error) {
-        expect(error.cause).toBeInstanceOf(Error)
+        expect(error.cause).toBe(imapCause)
       }
       return true
     })

--- a/src/fintual/performance.ts
+++ b/src/fintual/performance.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer } from "effect"
-import { FintualConfigService } from "../env.ts"
+import { FintualConfigService, type Email2FAConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import {
   SnapshotWriter,
@@ -10,6 +10,7 @@ import { FetchService, FINTUAL_ORIGIN } from "./authenticated-ingestion.ts"
 import { Email2FAService } from "./email-2fa.ts"
 import {
   HttpTransportFailure,
+  Email2FAFailure,
   LoginFailed,
   MalformedGoalPerformanceData,
   MalformedPerformanceSnapshot,
@@ -25,7 +26,7 @@ import {
   type TimeIntervalCode as GoalPerformanceTimeInterval,
 } from "./new-performance.ts"
 
-const HTTP_2FA_EMAIL_TIMEOUT_MS = 120_000
+const EMAIL_2FA_STAGE = "Fintual email 2FA"
 
 export class FintualPerformance extends Context.Service<
   FintualPerformance,
@@ -44,7 +45,13 @@ export class FintualPerformance extends Context.Service<
       const fetchPerformanceSnapshot = Effect.fn("FintualPerformance.fetchPerformanceSnapshot")(
         function* () {
           yield* loadSignInPage(fetchService)
-          yield* authenticate(fetchService, email2FAService, config.email, config.password)
+          yield* authenticate(
+            fetchService,
+            email2FAService,
+            config.email,
+            config.password,
+            config.email2FA,
+          )
 
           const reference = yield* fetchGoalPerformanceData(
             fetchService,
@@ -113,6 +120,7 @@ function authenticate(
   email2FAService: Email2FAService["Service"],
   email: string,
   password: string,
+  email2FAConfig: Email2FAConfig | null,
 ): Effect.Effect<void, FintualError> {
   return Effect.gen(function* () {
     const loginResponse = yield* session.request(
@@ -142,11 +150,28 @@ function authenticate(
       return yield* failUnexpectedStatus("Fintual login", loginResponse.status)
     }
 
-    const loginStartedAt = new Date()
-    const code = yield* email2FAService.get2FACode({
-      afterTimestamp: loginStartedAt,
-      timeoutMs: HTTP_2FA_EMAIL_TIMEOUT_MS,
-    })
+    if (!email2FAConfig) {
+      return yield* new Email2FAFailure({
+        stage: EMAIL_2FA_STAGE,
+        cause: new Error("Fintual email 2FA: Gmail IMAP credentials not configured"),
+      })
+    }
+
+    const code = yield* email2FAService
+      .get2FACode(email2FAConfig, { afterTimestamp: new Date() })
+      .pipe(
+        Effect.catchTags({
+          TimedOut: () =>
+            Effect.fail(
+              new Email2FAFailure({
+                stage: EMAIL_2FA_STAGE,
+                cause: new Error("Fintual email 2FA: no code received before timeout"),
+              }),
+            ),
+          Operational: (failure) =>
+            Effect.fail(new Email2FAFailure({ stage: EMAIL_2FA_STAGE, cause: failure.cause })),
+        }),
+      )
 
     const finalizeResponse = yield* session.request(
       "/auth/sessions/finalize_login_web",
@@ -159,12 +184,12 @@ function authenticate(
         },
         body: JSON.stringify({ email, password, code }),
       },
-      "Fintual email 2FA",
+      EMAIL_2FA_STAGE,
     )
-    yield* readResponseBody(finalizeResponse, "Fintual email 2FA")
+    yield* readResponseBody(finalizeResponse, EMAIL_2FA_STAGE)
 
     if (!finalizeResponse.ok) {
-      return yield* failUnexpectedStatus("Fintual email 2FA", finalizeResponse.status)
+      return yield* failUnexpectedStatus(EMAIL_2FA_STAGE, finalizeResponse.status)
     }
   })
 }

--- a/src/fintual/performance.ts
+++ b/src/fintual/performance.ts
@@ -1,5 +1,5 @@
-import { Context, Effect, Layer } from "effect"
-import { FintualConfigService, type Email2FAConfig } from "../env.ts"
+import { Context, DateTime, Effect, Layer } from "effect"
+import { FintualConfigService, type FintualConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import {
   SnapshotWriter,
@@ -45,13 +45,7 @@ export class FintualPerformance extends Context.Service<
       const fetchPerformanceSnapshot = Effect.fn("FintualPerformance.fetchPerformanceSnapshot")(
         function* () {
           yield* loadSignInPage(fetchService)
-          yield* authenticate(
-            fetchService,
-            email2FAService,
-            config.email,
-            config.password,
-            config.email2FA,
-          )
+          yield* authenticate(fetchService, email2FAService, config)
 
           const reference = yield* fetchGoalPerformanceData(
             fetchService,
@@ -115,84 +109,81 @@ function loadSignInPage(session: FetchService["Service"]): Effect.Effect<void, F
   })
 }
 
-function authenticate(
+const authenticate = Effect.fn("authenticate")(function* (
   session: FetchService["Service"],
   email2FAService: Email2FAService["Service"],
-  email: string,
-  password: string,
-  email2FAConfig: Email2FAConfig | null,
-): Effect.Effect<void, FintualError> {
-  return Effect.gen(function* () {
-    const loginResponse = yield* session.request(
-      "/auth/sessions/initiate_login",
-      {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          Referer: `${FINTUAL_ORIGIN}/f/sign-in/`,
-        },
-        body: JSON.stringify({ email, password }),
+  config: FintualConfig,
+): Effect.fn.Return<void, FintualError> {
+  const loginResponse = yield* session.request(
+    "/auth/sessions/initiate_login",
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Referer: `${FINTUAL_ORIGIN}/f/sign-in/`,
       },
-      "Fintual login",
+      body: JSON.stringify({ email: config.email, password: config.password }),
+    },
+    "Fintual login",
+  )
+  yield* readResponseBody(loginResponse, "Fintual login")
+
+  if (loginResponse.status === 200) {
+    return
+  }
+
+  if (loginResponse.status === 401) {
+    return yield* Effect.fail(new LoginFailed({ status: loginResponse.status }))
+  }
+
+  if (loginResponse.status !== 201) {
+    return yield* failUnexpectedStatus("Fintual login", loginResponse.status)
+  }
+
+  if (!config.email2FA) {
+    return yield* new Email2FAFailure({
+      stage: EMAIL_2FA_STAGE,
+      cause: new Error("Fintual email 2FA: Gmail IMAP credentials not configured"),
+    })
+  }
+
+  const loginStartedAt = yield* DateTime.now
+  const code = yield* email2FAService
+    .get2FACode(config.email2FA, { afterTimestamp: DateTime.toDate(loginStartedAt) })
+    .pipe(
+      Effect.catchTags({
+        TimedOut: () =>
+          Effect.fail(
+            new Email2FAFailure({
+              stage: EMAIL_2FA_STAGE,
+              cause: new Error("Fintual email 2FA: no code received before timeout"),
+            }),
+          ),
+        Operational: (failure) =>
+          Effect.fail(new Email2FAFailure({ stage: EMAIL_2FA_STAGE, cause: failure.cause })),
+      }),
     )
-    yield* readResponseBody(loginResponse, "Fintual login")
 
-    if (loginResponse.status === 200) {
-      return
-    }
-
-    if (loginResponse.status === 401) {
-      return yield* Effect.fail(new LoginFailed({ status: loginResponse.status }))
-    }
-
-    if (loginResponse.status !== 201) {
-      return yield* failUnexpectedStatus("Fintual login", loginResponse.status)
-    }
-
-    if (!email2FAConfig) {
-      return yield* new Email2FAFailure({
-        stage: EMAIL_2FA_STAGE,
-        cause: new Error("Fintual email 2FA: Gmail IMAP credentials not configured"),
-      })
-    }
-
-    const code = yield* email2FAService
-      .get2FACode(email2FAConfig, { afterTimestamp: new Date() })
-      .pipe(
-        Effect.catchTags({
-          TimedOut: () =>
-            Effect.fail(
-              new Email2FAFailure({
-                stage: EMAIL_2FA_STAGE,
-                cause: new Error("Fintual email 2FA: no code received before timeout"),
-              }),
-            ),
-          Operational: (failure) =>
-            Effect.fail(new Email2FAFailure({ stage: EMAIL_2FA_STAGE, cause: failure.cause })),
-        }),
-      )
-
-    const finalizeResponse = yield* session.request(
-      "/auth/sessions/finalize_login_web",
-      {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          Referer: `${FINTUAL_ORIGIN}/f/sign-in/`,
-        },
-        body: JSON.stringify({ email, password, code }),
+  const finalizeResponse = yield* session.request(
+    "/auth/sessions/finalize_login_web",
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Referer: `${FINTUAL_ORIGIN}/f/sign-in/`,
       },
-      EMAIL_2FA_STAGE,
-    )
-    yield* readResponseBody(finalizeResponse, EMAIL_2FA_STAGE)
+      body: JSON.stringify({ email: config.email, password: config.password, code }),
+    },
+    EMAIL_2FA_STAGE,
+  )
+  yield* readResponseBody(finalizeResponse, EMAIL_2FA_STAGE)
 
-    if (!finalizeResponse.ok) {
-      return yield* failUnexpectedStatus(EMAIL_2FA_STAGE, finalizeResponse.status)
-    }
-  })
-}
+  if (!finalizeResponse.ok) {
+    return yield* failUnexpectedStatus(EMAIL_2FA_STAGE, finalizeResponse.status)
+  }
+})
 
 function fetchGoalPerformanceData(
   session: FetchService["Service"],


### PR DESCRIPTION
Closes #303

Stacked on #309.

The sign-in flow now consumes the email 2FA deep module's typed outcomes directly. Missing Gmail configuration fails before retrieval, timeouts retain the existing message, and operational failures preserve both the IMAP cause and sign-in stage.

## Changes

- keep `Email2FAService` typed as `Email2FACode | TimedOut | Operational`
- handle disabled email 2FA configuration at the sign-in caller
- translate timeout and operational outcomes into stage-aware `Email2FAFailure` values
- cover fail-fast, timeout, and operational propagation at the `FintualPerformance` consumer seam
- use Effect clock-backed current time for the email cutoff

## Verification

- `pnpm test` (71 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm fallow:audit`