### PR TITLE
fix(fintual): cancel HTTP requests with Effect fibers

### DIFF
--- a/.agents/friction-log/20260811062211-fallow-audit-warnings/friction.md
+++ b/.agents/friction-log/20260811062211-fallow-audit-warnings/friction.md
@@ -1,0 +1,19 @@
+---
+title: 'fallow audit warnings'
+severity: 'minor'
+---
+
+## Expected Behavior
+The required Fallow audit should run without configuration-parser warnings.
+
+## Current Behavior
+The audit reports no issues but emits repeated warnings about invalid package dependency glob patterns.
+
+## Possible Solution
+Update the Fallow entry patterns to syntax accepted by its glob parser, or remove patterns that are no longer needed.
+
+## Minimal Reproducible Example
+Run `pnpm fallow:audit` from the repository root.
+
+## Context
+This appeared while validating issue #313. The audit passed, but the warnings add noise to a required check.

--- a/src/fintual/authenticated-ingestion.test.ts
+++ b/src/fintual/authenticated-ingestion.test.ts
@@ -30,3 +30,34 @@ test("aborts the underlying fetch when its request fiber is interrupted", async 
   expect(observedSignal).toBeDefined()
   expect(observedSignal?.aborted).toBe(true)
 })
+
+test("fails with HttpTransportFailure when the request deadline aborts fetch", async () => {
+  let observedSignal: AbortSignal | undefined
+  let resolveRequestStarted!: () => void
+  const requestStarted = new Promise<void>((resolve) => {
+    resolveRequestStarted = resolve
+  })
+
+  const fetch: typeof globalThis.fetch = async (_input, init = {}) => {
+    observedSignal = init.signal ?? undefined
+    resolveRequestStarted()
+
+    return new Promise<Response>((_resolve, reject) => {
+      init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true })
+    })
+  }
+
+  const request = Effect.gen(function* () {
+    const service = yield* FetchService
+    yield* service.request("/slow", {}, "Fintual deadline")
+  }).pipe(Effect.provide(FetchService.layer(fetch, { requestTimeoutMs: 0 })))
+
+  const fiber = Effect.runFork(request)
+  await requestStarted
+
+  await expect(Effect.runPromise(Fiber.join(fiber))).rejects.toMatchObject({
+    _tag: "HttpTransportFailure",
+    stage: "Fintual deadline",
+  })
+  expect(observedSignal?.aborted).toBe(true)
+})

--- a/src/fintual/authenticated-ingestion.test.ts
+++ b/src/fintual/authenticated-ingestion.test.ts
@@ -1,0 +1,32 @@
+import { Effect, Fiber } from "effect"
+import { expect, test } from "vitest"
+import { FetchService } from "./authenticated-ingestion.ts"
+
+test("aborts the underlying fetch when its request fiber is interrupted", async () => {
+  let observedSignal: AbortSignal | undefined
+  let resolveRequestStarted!: () => void
+  const requestStarted = new Promise<void>((resolve) => {
+    resolveRequestStarted = resolve
+  })
+
+  const fetch: typeof globalThis.fetch = async (_input, init = {}) => {
+    observedSignal = init.signal ?? undefined
+    resolveRequestStarted()
+
+    return new Promise<Response>((_resolve, reject) => {
+      init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true })
+    })
+  }
+
+  const request = Effect.gen(function* () {
+    const service = yield* FetchService
+    yield* service.request("/slow", {}, "Fintual slow request")
+  }).pipe(Effect.provide(FetchService.layer(fetch)))
+
+  const fiber = Effect.runFork(request)
+  await requestStarted
+  await Effect.runPromise(Fiber.interrupt(fiber))
+
+  expect(observedSignal).toBeDefined()
+  expect(observedSignal?.aborted).toBe(true)
+})

--- a/src/fintual/authenticated-ingestion.ts
+++ b/src/fintual/authenticated-ingestion.ts
@@ -17,9 +17,15 @@ export class FetchService extends Context.Service<
     ) => Effect.Effect<Response, FintualError>
   }
 >()("FetchService") {
-  static readonly layer = (fetch: typeof globalThis.fetch) =>
+  static readonly layer = (
+    fetch: typeof globalThis.fetch,
+    options: { readonly requestTimeoutMs?: number } = {},
+  ) =>
     Layer.sync(FetchService, () => {
-      const session = new FintualHttpSession(fetch)
+      const session = new FintualHttpSession(
+        fetch,
+        options.requestTimeoutMs ?? HTTP_REQUEST_TIMEOUT_MS,
+      )
       return FetchService.of({
         request: (path, init, stage) => session.request(path, init, stage),
       })
@@ -29,9 +35,11 @@ export class FetchService extends Context.Service<
 class FintualHttpSession {
   private readonly cookies = new Map<string, string>()
   private readonly fetchRequest: typeof globalThis.fetch
+  private readonly requestTimeoutMs: number
 
-  constructor(fetchRequest: typeof globalThis.fetch) {
+  constructor(fetchRequest: typeof globalThis.fetch, requestTimeoutMs: number) {
     this.fetchRequest = fetchRequest
+    this.requestTimeoutMs = requestTimeoutMs
   }
 
   readonly request = Effect.fn("FintualHttpSession.request")(
@@ -57,7 +65,7 @@ class FintualHttpSession {
             this.fetchRequest(`${FINTUAL_ORIGIN}${path}`, {
               ...init,
               headers,
-              signal: AbortSignal.any([signal, AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS)]),
+              signal: AbortSignal.any([signal, AbortSignal.timeout(this.requestTimeoutMs)]),
             }),
           catch: (cause) =>
             new Error(`${stage}: request failed: ${getErrorMessage(cause)}`, { cause }),

--- a/src/fintual/authenticated-ingestion.ts
+++ b/src/fintual/authenticated-ingestion.ts
@@ -34,8 +34,14 @@ class FintualHttpSession {
     this.fetchRequest = fetchRequest
   }
 
-  request(path: string, init: RequestInit, stage: string): Effect.Effect<Response, FintualError> {
-    return Effect.gen({ self: this }, function* () {
+  readonly request = Effect.fn("FintualHttpSession.request")(
+    { self: this },
+    function* (
+      this: FintualHttpSession,
+      path: string,
+      init: RequestInit,
+      stage: string,
+    ): Effect.fn.Return<Response, FintualError> {
       const headers = new Headers(init.headers)
       headers.set("User-Agent", BROWSER_USER_AGENT)
       headers.set("Origin", FINTUAL_ORIGIN)
@@ -47,11 +53,11 @@ class FintualHttpSession {
 
       const response = yield* Effect.mapError(
         Effect.tryPromise({
-          try: () =>
+          try: (signal) =>
             this.fetchRequest(`${FINTUAL_ORIGIN}${path}`, {
               ...init,
               headers,
-              signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
+              signal: AbortSignal.any([signal, AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS)]),
             }),
           catch: (cause) =>
             new Error(`${stage}: request failed: ${getErrorMessage(cause)}`, { cause }),
@@ -71,8 +77,8 @@ class FintualHttpSession {
       )
 
       return response
-    })
-  }
+    },
+  )
 }
 
 function mergeSetCookieHeaders(headers: Headers, jar: Map<string, string>): void {


### PR DESCRIPTION
## Summary

- name the Fintual HTTP session request as an `Effect.fn` boundary
- compose the Effect interruption signal with the existing 30-second request timeout
- add a deterministic scripted-fetch regression for fiber interruption
- record the pre-existing Fallow configuration warning in the repository friction log

## Validation

- `pnpm test` (74 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm fallow:audit` (passes; existing invalid-pattern warnings are logged)

Fixes #313