### PR TITLE
refactor(snapshot): model Performance Snapshots with Effect Schema

### DIFF
--- a/.agents/friction-log/20260811064709-fallow-audit-emits/friction.md
+++ b/.agents/friction-log/20260811064709-fallow-audit-emits/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Fallow audit emits invalid dependency entry-pattern warnings'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The documented Fallow audit should run without warnings for valid configuration entries.
+
+## Current Behavior
+
+Every `pnpm fallow:audit` run emits repeated warnings that `pkg.dependencies?.['@actual-app/api']` and `pkg.devDependencies?.['@actual-app/api']` are invalid globs because the bracket contents are parsed as a character range. The audit still succeeds, but the warnings add noise and make it unclear whether the configuration is applied.
+
+## Possible Solution
+
+Escape or otherwise express the dependency-key patterns in the Fallow configuration using syntax accepted by the current Fallow glob parser.
+
+## Minimal Reproducible Example
+
+Run `pnpm fallow:audit` in this repository and observe the repeated invalid entry-pattern warnings before the green audit summary.
+
+## Context
+
+Observed while verifying issue #314 on 2026-08-11. The warning is unrelated to the Effect Schema migration and appears in the existing repository configuration.

--- a/.agents/friction-log/20260811075217-concurrent-pnpm-pre/friction.md
+++ b/.agents/friction-log/20260811075217-concurrent-pnpm-pre/friction.md
@@ -1,0 +1,27 @@
+---
+title: 'Concurrent pnpm pre-push checks race over node_modules binaries'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Running the repository pre-push verification should execute the configured checks without transient dependency-install warnings.
+
+## Current Behavior
+
+The pre-push hook runs several checks concurrently. During the dependency transition between the wire-only and snapshot stack layers, pnpm emitted warnings that it could not create `node_modules/.bin/fallow` and `node_modules/.bin/tsgolint` because those paths briefly did not exist. The checks recovered and all passed.
+
+## Possible Solution
+
+Avoid concurrent pnpm lifecycle installs in hook jobs, or isolate each check from shared node_modules mutations before running the checks.
+
+## Minimal Reproducible Example
+
+1. Push a stack branch whose manifest changes the Valibot dependency set.
+2. Observe the pre-push hook start multiple pnpm commands in parallel.
+3. Observe transient `Failed to create bin` warnings while pnpm removes and recreates dependency links.
+4. Observe the checks finish successfully after the links settle.
+
+## Context
+
+Observed while pushing the Effect Schema wire migration branch for issue #314 on 2026-08-11. This is repository tooling friction only; no source or test failure resulted.

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
 		"dotenv": "17.4.2",
 		"effect": "4.0.0-beta.106",
 		"imapflow": "1.6.6",
-		"mailparser": "3.9.15",
-		"valibot": "1.4.2"
+		"mailparser": "3.9.15"
 	},
 	"scripts": {
 		"test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       mailparser:
         specifier: 3.9.15
         version: 3.9.15
-      valibot:
-        specifier: 1.4.2
-        version: 1.4.2(typescript@7.0.2)
     devDependencies:
       '@types/mailparser':
         specifier: 3.4.6
@@ -1362,14 +1359,6 @@ packages:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
-  valibot@1.4.2:
-    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   vite@8.2.1:
     resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2575,10 +2564,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@14.0.1: {}
-
-  valibot@1.4.2(typescript@7.0.2):
-    optionalDependencies:
-      typescript: 7.0.2
 
   vite@8.2.1(@types/node@24.13.3):
     dependencies:

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -20,6 +20,17 @@ test("rejects a balance entry with a non-finite date and reports the failing fie
   )
 })
 
+test("rejects a deposit entry with a non-finite value and reports the failing field", async () => {
+  const invalidSnapshot = {
+    ...performanceSnapshot(),
+    deposits: [{ date: 1780264800000, value: Number.NEGATIVE_INFINITY, difference: 50 }],
+  }
+
+  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
+    /Fintual performance snapshot is invalid: .*deposits/,
+  )
+})
+
 test("rejects when deposits is not an array and reports the failing field", async () => {
   const invalidSnapshot = {
     ...performanceSnapshot(),

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -1,6 +1,5 @@
 import * as fs from "node:fs"
 import { Context, Effect, Layer, Schema } from "effect"
-import * as v from "valibot"
 import { getErrorMessage } from "./log.ts"
 import { SnapshotWriteFailure } from "./fintual/fintual-error.ts"
 
@@ -36,40 +35,35 @@ class PerformanceSnapshotValidationError extends Schema.TaggedError<PerformanceS
   }
 }
 
-const finiteNumber = v.pipe(v.number(), v.finite())
+const finiteNumber = Schema.Finite
 
-const seriesPointSchema = v.object({
+const seriesPointSchema = Schema.Struct({
   date: finiteNumber,
   value: finiteNumber,
   difference: finiteNumber,
 })
 
-const performanceSnapshotSchema = v.object({
-  balance: v.pipe(
-    v.array(v.object({ ...seriesPointSchema.entries, real_difference: finiteNumber })),
-    v.minLength(1),
-  ),
-  deposits: v.pipe(v.array(seriesPointSchema), v.minLength(1)),
+const performanceSnapshotSchema = Schema.Struct({
+  balance: Schema.Array(
+    Schema.Struct({ ...seriesPointSchema.fields, real_difference: finiteNumber }),
+  ).pipe(Schema.check(Schema.isNonEmpty())),
+  deposits: Schema.Array(seriesPointSchema).pipe(Schema.check(Schema.isNonEmpty())),
 })
 
-export type PerformanceSnapshot = v.InferOutput<typeof performanceSnapshotSchema>
+export type PerformanceSnapshot = typeof performanceSnapshotSchema.Type
 
-export function validatePerformanceSnapshot(
+export const validatePerformanceSnapshot = Effect.fn("validatePerformanceSnapshot")(function* (
   snapshot: unknown,
-): Effect.Effect<PerformanceSnapshot, PerformanceSnapshotValidationError> {
-  return Effect.gen(function* () {
-    const validation = v.safeParse(performanceSnapshotSchema, snapshot)
-    if (!validation.success) {
-      return yield* Effect.fail(
+): Effect.fn.Return<PerformanceSnapshot, PerformanceSnapshotValidationError> {
+  return yield* Schema.decodeUnknownEffect(performanceSnapshotSchema)(snapshot).pipe(
+    Effect.mapError(
+      (cause) =>
         new PerformanceSnapshotValidationError({
-          issues: JSON.stringify(v.flatten(validation.issues)),
+          issues: cause.message.replace(/\s+/g, " ").trim(),
         }),
-      )
-    }
-
-    return validation.output
-  })
-}
+    ),
+  )
+})
 
 export function writePerformanceSnapshot(
   snapshot: PerformanceSnapshot,


### PR DESCRIPTION
Refs #314

## Summary

- Replace Valibot Performance Snapshot validation with Effect Schema.Struct models.
- Derive PerformanceSnapshot from the schema with finite numeric fields and runtime non-empty series checks.
- Preserve path-bearing validation evidence in the existing MalformedPerformanceSnapshot taxonomy.
- Remove the unused Valibot dependency from package.json and pnpm-lock.yaml.
- Record the pre-existing Fallow entry-pattern warning in the repository friction log.

## Validation

- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm fallow:audit

This is the top layer of the #314 stack and depends on #325.
