### PR TITLE
refactor(fintual): model wire data with Effect Schema

### DIFF
--- a/src/fintual/new-performance.test.ts
+++ b/src/fintual/new-performance.test.ts
@@ -37,7 +37,31 @@ test("fails when the Goal Performance Data response has an invalid shape", async
   ).rejects.toThrow("response does not match the Goal Performance Data schema")
 })
 
-function goalPerformanceResponse(): Record<string, unknown> {
+test("fails when the GraphQL response contains errors", async () => {
+  await expect(
+    Effect.runPromise(
+      parseGoalPerformanceResponseBody(
+        JSON.stringify({ ...goalPerformanceResponse(), errors: [{ message: "request failed" }] }),
+      ),
+    ),
+  ).rejects.toThrow("GraphQL response contains errors")
+})
+
+test("preserves non-finite wire amounts for snapshot validation", async () => {
+  const response = goalPerformanceResponse()
+  const body = JSON.stringify(response).replace(
+    '"unrealizedCostBasisAmount":100',
+    '"unrealizedCostBasisAmount":1e400',
+  )
+
+  const result = await Effect.runPromise(parseGoalPerformanceResponseBody(body))
+
+  expect(result.balanceGraphDataPoints[0]?.unrealizedCostBasisAmount).toBe(Number.POSITIVE_INFINITY)
+})
+
+function goalPerformanceResponse(): {
+  data: { balanceGraphDataPoints: Array<Record<string, unknown>> }
+} {
   return {
     data: {
       balanceGraphDataPoints: [

--- a/src/fintual/new-performance.test.ts
+++ b/src/fintual/new-performance.test.ts
@@ -37,27 +37,32 @@ test("fails when the Goal Performance Data response has an invalid shape", async
   ).rejects.toThrow("response does not match the Goal Performance Data schema")
 })
 
-test("fails when a Goal Performance Data date is not an ISO date", async () => {
-  const response = goalPerformanceResponse()
-  const point = response.data.balanceGraphDataPoints[0]
-  if (!point) {
-    throw new Error("expected a performance point")
-  }
-  point.date = "2026-13-45"
+test.each(["2026-13-45", "2026-02-31", "2025-02-29"])(
+  "fails when a Goal Performance Data date is not a valid ISO date: %s",
+  async (date) => {
+    const response = goalPerformanceResponse()
+    const point = response.data.balanceGraphDataPoints[0]
+    if (!point) {
+      throw new Error("expected a performance point")
+    }
+    point.date = date
 
-  await expect(
-    Effect.runPromise(parseGoalPerformanceResponseBody(JSON.stringify(response))),
-  ).rejects.toThrow("response does not match the Goal Performance Data schema")
-})
+    await expect(
+      Effect.runPromise(parseGoalPerformanceResponseBody(JSON.stringify(response))),
+    ).rejects.toThrow("response does not match the Goal Performance Data schema")
+  },
+)
 
 test("fails when the GraphQL response contains errors", async () => {
-  await expect(
-    Effect.runPromise(
-      parseGoalPerformanceResponseBody(
-        JSON.stringify({ ...goalPerformanceResponse(), errors: [{ message: "request failed" }] }),
-      ),
-    ),
-  ).rejects.toThrow("GraphQL response contains errors")
+  const response = {
+    ...goalPerformanceResponse(),
+    errors: [{ message: "request failed" }],
+  }
+  const body = JSON.stringify(response)
+
+  await expect(Effect.runPromise(parseGoalPerformanceResponseBody(body))).rejects.toThrow(
+    "GraphQL response contains errors",
+  )
 })
 
 test("preserves non-finite wire amounts for snapshot validation", async () => {

--- a/src/fintual/new-performance.test.ts
+++ b/src/fintual/new-performance.test.ts
@@ -37,6 +37,19 @@ test("fails when the Goal Performance Data response has an invalid shape", async
   ).rejects.toThrow("response does not match the Goal Performance Data schema")
 })
 
+test("fails when a Goal Performance Data date is not an ISO date", async () => {
+  const response = goalPerformanceResponse()
+  const point = response.data.balanceGraphDataPoints[0]
+  if (!point) {
+    throw new Error("expected a performance point")
+  }
+  point.date = "2026-13-45"
+
+  await expect(
+    Effect.runPromise(parseGoalPerformanceResponseBody(JSON.stringify(response))),
+  ).rejects.toThrow("response does not match the Goal Performance Data schema")
+})
+
 test("fails when the GraphQL response contains errors", async () => {
   await expect(
     Effect.runPromise(

--- a/src/fintual/new-performance.ts
+++ b/src/fintual/new-performance.ts
@@ -14,9 +14,35 @@ export type TimeIntervalCode = (typeof TimeIntervalCode)[keyof typeof TimeInterv
 const NEW_PERFORMANCE_QUERY =
   "query GoalInvestedBalanceGraphDataPoints($goalId: ID!, $timeIntervalCode: String!) {\n  balanceGraphDataPoints: clGoalBalanceGraphDataPoints(\n    goalId: $goalId\n    timeIntervalCode: $timeIntervalCode\n  ) {\n    date\n    unrealizedCostBasisAmount\n    unrealizedGainOrLossAmount\n    realizedCostBasisAmount\n    realizedGainOrLossAmount\n    sharesCostBasisAmount\n    sharesValuationAmount\n    pendingFulfillmentReinvestmentDepositsCostBasisAmount\n    pendingFulfillmentReinvestmentDepositsAmount\n    withdrawnAmount\n    __typename\n  }\n}"
 
+const ISO_DATE_PATTERN = /^(\d{4})-(0[1-9]|1[0-2])-([12]\d|0[1-9]|3[01])$/u
+
+function isValidIsoDate(date: string): boolean {
+  const match = ISO_DATE_PATTERN.exec(date)
+  if (!match) {
+    return false
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const daysInMonth =
+    month === 2
+      ? year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+        ? 29
+        : 28
+      : [4, 6, 9, 11].includes(month)
+        ? 30
+        : 31
+
+  return day <= daysInMonth
+}
+
 const goalPerformancePointSchema = Schema.Struct({
   date: Schema.String.pipe(
-    Schema.check(Schema.isPattern(/^\d{4}-(?:0[1-9]|1[0-2])-(?:[12]\d|0[1-9]|3[01])$/u)),
+    Schema.check(Schema.isPattern(ISO_DATE_PATTERN)),
+    Schema.check(
+      Schema.makeFilter((date) => (isValidIsoDate(date) ? undefined : "a valid ISO calendar date")),
+    ),
   ),
   unrealizedCostBasisAmount: Schema.Number,
   unrealizedGainOrLossAmount: Schema.Number,

--- a/src/fintual/new-performance.ts
+++ b/src/fintual/new-performance.ts
@@ -15,7 +15,9 @@ const NEW_PERFORMANCE_QUERY =
   "query GoalInvestedBalanceGraphDataPoints($goalId: ID!, $timeIntervalCode: String!) {\n  balanceGraphDataPoints: clGoalBalanceGraphDataPoints(\n    goalId: $goalId\n    timeIntervalCode: $timeIntervalCode\n  ) {\n    date\n    unrealizedCostBasisAmount\n    unrealizedGainOrLossAmount\n    realizedCostBasisAmount\n    realizedGainOrLossAmount\n    sharesCostBasisAmount\n    sharesValuationAmount\n    pendingFulfillmentReinvestmentDepositsCostBasisAmount\n    pendingFulfillmentReinvestmentDepositsAmount\n    withdrawnAmount\n    __typename\n  }\n}"
 
 const goalPerformancePointSchema = Schema.Struct({
-  date: Schema.String.pipe(Schema.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}$/))),
+  date: Schema.String.pipe(
+    Schema.check(Schema.isPattern(/^\d{4}-(?:0[1-9]|1[0-2])-(?:[12]\d|0[1-9]|3[01])$/u)),
+  ),
   unrealizedCostBasisAmount: Schema.Number,
   unrealizedGainOrLossAmount: Schema.Number,
   realizedCostBasisAmount: Schema.Number,

--- a/src/fintual/new-performance.ts
+++ b/src/fintual/new-performance.ts
@@ -70,10 +70,6 @@ function getValidationFailure(parsedJson: unknown): string {
     return "response is not an object"
   }
 
-  if ("errors" in parsedJson) {
-    return "GraphQL response contains errors"
-  }
-
   return "response does not match the Goal Performance Data schema"
 }
 

--- a/src/fintual/new-performance.ts
+++ b/src/fintual/new-performance.ts
@@ -1,5 +1,4 @@
-import { Effect } from "effect"
-import * as v from "valibot"
+import { Effect, Predicate, Schema } from "effect"
 import { getErrorMessage } from "../log.ts"
 
 export const TimeIntervalCode = {
@@ -15,31 +14,29 @@ export type TimeIntervalCode = (typeof TimeIntervalCode)[keyof typeof TimeInterv
 const NEW_PERFORMANCE_QUERY =
   "query GoalInvestedBalanceGraphDataPoints($goalId: ID!, $timeIntervalCode: String!) {\n  balanceGraphDataPoints: clGoalBalanceGraphDataPoints(\n    goalId: $goalId\n    timeIntervalCode: $timeIntervalCode\n  ) {\n    date\n    unrealizedCostBasisAmount\n    unrealizedGainOrLossAmount\n    realizedCostBasisAmount\n    realizedGainOrLossAmount\n    sharesCostBasisAmount\n    sharesValuationAmount\n    pendingFulfillmentReinvestmentDepositsCostBasisAmount\n    pendingFulfillmentReinvestmentDepositsAmount\n    withdrawnAmount\n    __typename\n  }\n}"
 
-const newPerformanceSchema = v.object({
-  data: v.object({
-    balanceGraphDataPoints: v.array(
-      v.object({
-        date: v.pipe(v.string(), v.isoDate()),
-        unrealizedCostBasisAmount: v.number(),
-        unrealizedGainOrLossAmount: v.number(),
-        realizedCostBasisAmount: v.number(),
-        realizedGainOrLossAmount: v.number(),
-        sharesCostBasisAmount: v.number(),
-        sharesValuationAmount: v.number(),
-        pendingFulfillmentReinvestmentDepositsCostBasisAmount: v.number(),
-        pendingFulfillmentReinvestmentDepositsAmount: v.number(),
-        withdrawnAmount: v.number(),
-      }),
-    ),
+const goalPerformancePointSchema = Schema.Struct({
+  date: Schema.String.pipe(Schema.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}$/))),
+  unrealizedCostBasisAmount: Schema.Number,
+  unrealizedGainOrLossAmount: Schema.Number,
+  realizedCostBasisAmount: Schema.Number,
+  realizedGainOrLossAmount: Schema.Number,
+  sharesCostBasisAmount: Schema.Number,
+  sharesValuationAmount: Schema.Number,
+  pendingFulfillmentReinvestmentDepositsCostBasisAmount: Schema.Number,
+  pendingFulfillmentReinvestmentDepositsAmount: Schema.Number,
+  withdrawnAmount: Schema.Number,
+})
+
+const goalPerformanceDataResponseSchema = Schema.Struct({
+  data: Schema.Struct({
+    balanceGraphDataPoints: Schema.Array(goalPerformancePointSchema),
   }),
 })
 
-export type GoalPerformanceData = v.InferOutput<typeof newPerformanceSchema>["data"]
+export type GoalPerformanceData = (typeof goalPerformanceDataResponseSchema.Type)["data"]
 
-export function parseGoalPerformanceResponseBody(
-  body: string,
-): Effect.Effect<GoalPerformanceData, Error> {
-  return Effect.gen(function* () {
+export const parseGoalPerformanceResponseBody = Effect.fn("parseGoalPerformanceResponseBody")(
+  function* (body: string): Effect.fn.Return<GoalPerformanceData, Error> {
     const parsedJson = yield* Effect.try({
       // oxlint-disable-next-line typescript/consistent-type-assertions
       try: () => JSON.parse(body) as unknown,
@@ -49,19 +46,27 @@ export function parseGoalPerformanceResponseBody(
         }),
     })
 
-    const parsedData = v.safeParse(newPerformanceSchema, parsedJson)
-    if (!parsedData.success) {
+    if (Predicate.isObject(parsedJson) && "errors" in parsedJson) {
       return yield* Effect.fail(
-        new Error(`Failed to validate goal performance data: ${getValidationFailure(parsedJson)}`),
+        new Error("Failed to validate goal performance data: GraphQL response contains errors"),
       )
     }
 
-    return parsedData.output.data
-  })
-}
+    return yield* Schema.decodeUnknownEffect(goalPerformanceDataResponseSchema)(parsedJson).pipe(
+      Effect.map((response) => response.data),
+      Effect.mapError(
+        (cause) =>
+          new Error(
+            `Failed to validate goal performance data: ${getValidationFailure(parsedJson)}`,
+            { cause },
+          ),
+      ),
+    )
+  },
+)
 
 function getValidationFailure(parsedJson: unknown): string {
-  if (!isRecord(parsedJson)) {
+  if (!Predicate.isObject(parsedJson)) {
     return "response is not an object"
   }
 
@@ -70,10 +75,6 @@ function getValidationFailure(parsedJson: unknown): string {
   }
 
   return "response does not match the Goal Performance Data schema"
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
 }
 
 export function createGoalPerformanceRequest(


### PR DESCRIPTION
Refs #314

## Summary

- Replace Valibot Goal Performance Data validation with Effect Schema.Struct models.
- Derive GoalPerformanceData from the wire schema and decode parsed JSON with Schema.decodeUnknownEffect.
- Keep JSON parsing and schema mismatch failures in the existing Error cause consumed by MalformedGoalPerformanceData.
- Preserve ISO wire dates and explicitly classify GraphQL errors payloads despite open Effect structs.
- Add regression coverage for GraphQL errors and non-finite wire amounts.

## Validation

- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm fallow:audit

This is the bottom layer of the #314 stack; #324 depends on it.
