### PR TITLE
feat(actual): deepen synchronization with Effect

### DIFF
--- a/.agents/friction-log/20260811070643-fallow-audit-emits/friction.md
+++ b/.agents/friction-log/20260811070643-fallow-audit-emits/friction.md
@@ -1,0 +1,26 @@
+---
+title: 'Fallow audit emits invalid glob warnings for package keys'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+`pnpm fallow:audit` completes without unrelated configuration warnings.
+
+## Current Behavior
+
+The audit completes successfully but emits repeated warnings that `pkg.dependencies?.['@actual-app/api']` and the analogous `devDependencies` pattern are invalid glob ranges.
+
+## Possible Solution
+
+Update the Fallow entry patterns for package keys so the Actual dependency keys parse without warnings.
+
+## Minimal Reproducible Example
+
+1. Run `pnpm fallow:audit` in the repository.
+2. Observe the invalid range warnings before the audit summary.
+3. Observe that the audit still passes.
+
+## Context
+
+Discovered while implementing issue #286 on 2026-08-11. The warning is repository-local tooling noise and does not affect the Actual synchronization implementation.

--- a/docs/adr/0005-actual-synchronization-effect-module.md
+++ b/docs/adr/0005-actual-synchronization-effect-module.md
@@ -1,0 +1,55 @@
+# Actual synchronization is a scoped Effect workflow
+
+Actual synchronization exposes one application-facing operation:
+`ActualSynchronization.synchronize(snapshot)`. The process entrypoint keeps its
+existing `main(config, snapshot)` shape and only provides the configuration and
+live layers needed by that service.
+
+The Actual SDK singleton is an adapter behind `ActualClientFactory`. Each
+Synchronization Attempt acquires the client in an Effect `Scope` and releases
+it exactly once through `shutdown`, including failure and interruption paths.
+Filesystem reset and the `/health` request are separate adapters so tests can
+replace production filesystem and network behavior without touching the
+workflow.
+
+The retryable unit is the complete Synchronization Attempt:
+
+```text
+reset → health check → initialize → download budget → read state → plan
+      → apply mutations → sync → shutdown
+```
+
+Every retry acquires a fresh client and re-derives the Reconciliation Plan from
+freshly downloaded state. Imported ids make a mutation whose response was lost
+safe to reconcile on the next attempt.
+
+Expected Actual failures are tagged errors. The adapters preserve the original
+cause and compute a `retryable` field from stable Actual error codes or HTTP
+status classes. The orchestration layer never classifies failures by message.
+Effect `Schedule` supplies the five-attempt cap, capped exponential backoff,
+jitter, Clock/Random integration, and retry logging. Current-date lookup uses
+Effect `DateTime` so workflow tests can control it with `TestClock`.
+
+## Status
+
+accepted
+
+## Considered Options
+
+- **Manual recursive retry around the SDK singleton** — rejected: it kept
+  lifecycle, retry policy, and failure classification coupled and reused a
+  potentially dirty singleton across attempts.
+- **A single shared Actual error with an operation field** — rejected: the
+  domain convention calls for discoverable failure variants at meaningful
+  operation boundaries.
+- **Passing production dependencies as ordinary function arguments** —
+  rejected: Effect services and Layers keep the public synchronization seam
+  small while making deterministic workflow adapters explicit.
+
+## Consequences
+
+- The Actual workflow can be tested end-to-end through one service method.
+- Shutdown, retry limits, backoff, and health-check timeout behavior are
+  observable without a live Actual server.
+- The SDK remains an external singleton, but its lifetime is bounded to one
+  attempt and never leaks into the reconciliation policy.

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -1,0 +1,291 @@
+import { Duration, Effect, Fiber, Result, Schedule } from "effect"
+import { TestClock } from "effect/testing"
+import { expect, test } from "vitest"
+import { ActualConfigService, ActualSynchronization } from "./actual.ts"
+import {
+  ActualBudgetDownloadFailure,
+  ActualInitializationFailure,
+  ActualTransactionCreationFailure,
+} from "./actual/actual-error.ts"
+import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
+import { ActualFileSystem } from "./actual/actual-file-system.ts"
+import { ActualHealthCheck } from "./actual/actual-health-check.ts"
+import { ActualRetryPolicy } from "./actual/retry-policy.ts"
+import type { ActualError } from "./actual/actual-error.ts"
+import type { ActualConfig } from "./env.ts"
+import type { PerformanceSnapshot } from "./performance-snapshot.ts"
+
+const CONFIG: ActualConfig = {
+  serverUrl: "https://actual.example.test/",
+  password: "secret",
+  syncId: "sync-id",
+  fintualAccount: "account-id",
+  startingDate: "2026-01-01",
+  payee: "Fintual",
+}
+
+const SNAPSHOT: PerformanceSnapshot = {
+  balance: [
+    {
+      date: Date.parse("2026-01-05T00:00:00Z"),
+      value: 1_100,
+      difference: 50,
+      real_difference: 12.49,
+    },
+  ],
+  deposits: [
+    {
+      date: Date.parse("2026-01-05T00:00:00Z"),
+      value: 1_000,
+      difference: 25,
+    },
+  ],
+}
+
+test("synchronizes through one service and shuts down the Actual session once", async () => {
+  const calls: string[] = []
+  const client = scriptedClient(calls)
+
+  await Effect.runPromise(synchronizationProgram([client], calls))
+
+  expect(calls).toEqual([
+    "reset",
+    "health",
+    "download",
+    "transactions",
+    "payees",
+    "create:2026-01-05",
+    "sync",
+    "shutdown",
+  ])
+})
+
+test("retries a failed mutation as a fresh Synchronization Attempt", async () => {
+  const calls: string[] = []
+  const importedTransaction = {
+    id: "created-after-timeout",
+    date: "2026-01-05",
+    notes: "Variation",
+    payee: "payee-id",
+    imported_id: "fintual-variation:2026-01-05",
+  }
+  const secondAttemptTransactions: Array<typeof importedTransaction> = []
+  const firstAttempt = scriptedClient(calls, {
+    create: (_accountId, transaction) => {
+      calls.push(`create:${transaction.date}`)
+      secondAttemptTransactions.push(importedTransaction)
+      return Effect.fail(
+        new ActualTransactionCreationFailure({
+          cause: { code: "network-failure" },
+          retryable: true,
+        }),
+      )
+    },
+  })
+  const secondAttempt = scriptedClient(calls, {
+    transactions: secondAttemptTransactions,
+  })
+
+  await Effect.runPromise(
+    synchronizationProgram([firstAttempt, secondAttempt], calls, { retries: 1 }),
+  )
+
+  expect(calls).toEqual([
+    "reset",
+    "health",
+    "download",
+    "transactions",
+    "payees",
+    "create:2026-01-05",
+    "shutdown",
+    "reset",
+    "health",
+    "download",
+    "transactions",
+    "payees",
+    "update:created-after-timeout",
+    "sync",
+    "shutdown",
+  ])
+})
+
+test("does not retry a non-retryable Actual failure", async () => {
+  const calls: string[] = []
+  const client: ActualClient = {
+    ...scriptedClient(calls),
+    downloadBudget: () =>
+      Effect.gen(function* () {
+        calls.push("download")
+        return yield* new ActualBudgetDownloadFailure({
+          cause: { code: "budget-not-found" },
+          retryable: false,
+        })
+      }),
+  }
+
+  await expect(
+    Effect.runPromise(synchronizationProgram([client], calls, { retries: 3 })),
+  ).rejects.toMatchObject({
+    _tag: "ActualBudgetDownloadFailure",
+    retryable: false,
+  })
+  expect(calls).toEqual(["reset", "health", "download", "shutdown"])
+})
+
+test("health checks normalize the server URL and classify HTTP failures", async () => {
+  const urls: string[] = []
+  const fetchRequest: typeof globalThis.fetch = async (input) => {
+    urls.push(typeof input === "string" ? input : input instanceof URL ? input.href : input.url)
+    return new Response("", { status: 503 })
+  }
+  const program = Effect.gen(function* () {
+    const healthCheck = yield* ActualHealthCheck
+    yield* healthCheck.check("https://actual.example.test/")
+  }).pipe(Effect.provide(ActualHealthCheck.layer(fetchRequest)))
+
+  await expect(Effect.runPromise(program)).rejects.toMatchObject({
+    _tag: "ActualHealthCheckFailure",
+    status: 503,
+    retryable: true,
+    url: "https://actual.example.test/health",
+  })
+  expect(urls).toEqual(["https://actual.example.test/health"])
+})
+
+test("health-check timeout is controlled by the Effect Clock", async () => {
+  const fetchRequest: typeof globalThis.fetch = async () => new Promise<Response>(() => {})
+  const healthCheck = Effect.gen(function* () {
+    const service = yield* ActualHealthCheck
+    yield* service.check("https://actual.example.test")
+  }).pipe(Effect.provide(ActualHealthCheck.layer(fetchRequest)))
+  const program = Effect.gen(function* () {
+    const fiber = yield* Effect.forkChild(healthCheck)
+    yield* TestClock.adjust(10_000)
+    const result = yield* Effect.result(Fiber.join(fiber))
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toMatchObject({
+        _tag: "ActualHealthCheckFailure",
+        retryable: true,
+      })
+    }
+  }).pipe(Effect.provide(TestClock.layer()))
+
+  await Effect.runPromise(program)
+})
+
+test("uses the Effect Clock for the transaction end date", async () => {
+  const calls: string[] = []
+  const endingDates: string[] = []
+  const client = scriptedClient(calls, {
+    onTransactions: (_startDate, endDate) => endingDates.push(endDate),
+  })
+  const synchronization = synchronizationProgram([client], calls)
+  const program = Effect.gen(function* () {
+    yield* TestClock.setTime(Date.parse("2026-02-03T12:00:00Z"))
+    yield* synchronization
+  }).pipe(Effect.provide(TestClock.layer()))
+
+  await Effect.runPromise(program)
+
+  expect(endingDates).toEqual(["2026-02-03"])
+})
+
+test("shuts down the scoped Actual session when the workflow is interrupted", async () => {
+  const calls: string[] = []
+  const client = scriptedClient(calls, {
+    download: () =>
+      Effect.gen(function* () {
+        calls.push("download")
+        yield* Effect.never
+      }),
+  })
+  const program = Effect.gen(function* () {
+    const fiber = yield* Effect.forkChild(synchronizationProgram([client], calls))
+    yield* Effect.yieldNow
+    yield* Fiber.interrupt(fiber)
+  })
+
+  await Effect.runPromise(program)
+
+  expect(calls).toEqual(["reset", "health", "download", "shutdown"])
+})
+
+function synchronizationProgram(
+  clients: ReadonlyArray<ActualClient>,
+  calls: string[],
+  options: { retries?: number } = {},
+) {
+  const schedule = Schedule.max([
+    Schedule.recurs(options.retries ?? 0).pipe(Schedule.map(() => Duration.zero)),
+    Schedule.spaced(Duration.zero),
+  ]).pipe(Schedule.setInputType<ActualError>())
+  const clientQueue = [...clients]
+
+  return Effect.gen(function* () {
+    const service = yield* ActualSynchronization
+    yield* service.synchronize(SNAPSHOT)
+  }).pipe(
+    Effect.provide(ActualSynchronization.layer),
+    Effect.provideService(ActualConfigService, CONFIG),
+    Effect.provideService(ActualClientFactory, {
+      acquire: () => {
+        const client = clientQueue.shift()
+        return client
+          ? Effect.succeed(client)
+          : Effect.fail(
+              new ActualInitializationFailure({
+                cause: new Error("test client queue exhausted"),
+                retryable: false,
+              }),
+            )
+      },
+    }),
+    Effect.provideService(ActualFileSystem, {
+      reset: () => Effect.sync(() => calls.push("reset")),
+    }),
+    Effect.provideService(ActualHealthCheck, {
+      check: () => Effect.sync(() => calls.push("health")),
+    }),
+    Effect.provideService(ActualRetryPolicy, { schedule }),
+  )
+}
+
+function scriptedClient(
+  calls: string[],
+  options: {
+    transactions?: ReadonlyArray<{
+      id: string
+      date?: string
+      notes?: string
+      payee?: string | null
+      imported_id?: string
+    }>
+    create?: ActualClient["createTransaction"]
+    download?: ActualClient["downloadBudget"]
+    onTransactions?: (startDate: string, endDate: string) => void
+  } = {},
+): ActualClient {
+  return {
+    downloadBudget: options.download ?? (() => Effect.sync(() => calls.push("download"))),
+    getTransactions: (_accountId, startDate, endDate) =>
+      Effect.sync(() => {
+        calls.push("transactions")
+        options.onTransactions?.(startDate, endDate)
+        return options.transactions ?? []
+      }),
+    getPayees: () =>
+      Effect.sync(() => {
+        calls.push("payees")
+        return [{ id: "payee-id", name: "Fintual" }]
+      }),
+    createTransaction:
+      options.create ??
+      ((_accountId, transaction) => Effect.sync(() => calls.push(`create:${transaction.date}`))),
+    updateTransaction: (id) => Effect.sync(() => calls.push(`update:${id}`)),
+    deleteTransaction: (id) => Effect.sync(() => calls.push(`delete:${id}`)),
+    sync: () => Effect.sync(() => calls.push("sync")),
+    shutdown: () => Effect.sync(() => calls.push("shutdown")),
+  }
+}

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -1,6 +1,20 @@
 import { Duration, Effect, Fiber, Result, Schedule } from "effect"
 import { TestClock } from "effect/testing"
-import { expect, test } from "vitest"
+import { afterEach, expect, test, vi } from "vitest"
+
+const actualApiMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  downloadBudget: vi.fn(),
+  getTransactions: vi.fn(),
+  getPayees: vi.fn(),
+  addTransactions: vi.fn(),
+  updateTransaction: vi.fn(),
+  deleteTransaction: vi.fn(),
+  sync: vi.fn(),
+  shutdown: vi.fn(),
+}))
+
+vi.mock("@actual-app/api", () => actualApiMock)
 import { ActualConfigService, ActualSynchronization } from "./actual.ts"
 import {
   ActualBudgetDownloadFailure,
@@ -14,6 +28,10 @@ import { ActualRetryPolicy } from "./actual/retry-policy.ts"
 import type { ActualError } from "./actual/actual-error.ts"
 import type { ActualConfig } from "./env.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
 
 const CONFIG: ActualConfig = {
   serverUrl: "https://actual.example.test/",
@@ -130,6 +148,28 @@ test("does not retry a non-retryable Actual failure", async () => {
     retryable: false,
   })
   expect(calls).toEqual(["reset", "health", "download", "shutdown"])
+})
+
+test("the live Actual adapter preserves stable SDK network codes", async () => {
+  actualApiMock.init.mockResolvedValue({})
+  actualApiMock.downloadBudget.mockRejectedValue({ code: "network-failure" })
+
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const factory = yield* ActualClientFactory
+      const client = yield* factory.acquire(CONFIG)
+      return yield* Effect.result(client.downloadBudget(CONFIG.syncId))
+    }).pipe(Effect.provide(ActualClientFactory.live)),
+  )
+
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isFailure(result)) {
+    expect(result.failure).toMatchObject({
+      _tag: "ActualBudgetDownloadFailure",
+      cause: { code: "network-failure" },
+      retryable: true,
+    })
+  }
 })
 
 test("health checks normalize the server URL and classify HTTP failures", async () => {

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -1,266 +1,213 @@
-import * as fs from "node:fs"
-import * as api from "@actual-app/api"
-import { Duration, Effect } from "effect"
+import { Context, DateTime, Duration, Effect, Layer, Option, Schedule } from "effect"
 import type { ActualConfig } from "./env.ts"
-import { getErrorMessage, toError } from "./log.ts"
+import { getErrorMessage } from "./log.ts"
+import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
+import { ActualInvalidStartingDate } from "./actual/actual-error.ts"
+import type { ActualError, ActualPayeesReadFailure } from "./actual/actual-error.ts"
+import { ActualFileSystem } from "./actual/actual-file-system.ts"
+import { ActualHealthCheck } from "./actual/actual-health-check.ts"
+import { ActualRetryPolicy } from "./actual/retry-policy.ts"
 import { planReconciliation } from "./actual/reconciliation-policy.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
 
-const ACTUAL_DATA_DIR = "./tmp/actual-data"
-const MAX_SYNC_ATTEMPTS = 5
-const INITIAL_RETRY_DELAY_MS = 5000
-const MAX_RETRY_DELAY_MS = 60000
-const RETRY_JITTER_RATIO = 0.2
-
-type ActualInitConfig = Parameters<typeof api.init>[0]
+export type { ActualError } from "./actual/actual-error.ts"
 
 interface SyncCounts {
-  created: number
-  updated: number
-  deletedDuplicates: number
+  readonly created: number
+  readonly updated: number
+  readonly deletedDuplicates: number
+}
+
+export class ActualConfigService extends Context.Service<ActualConfigService, ActualConfig>()(
+  "ActualConfig",
+) {}
+
+export class ActualSynchronization extends Context.Service<
+  ActualSynchronization,
+  {
+    readonly synchronize: (snapshot: PerformanceSnapshot) => Effect.Effect<void, ActualError>
+  }
+>()("ActualSynchronization") {
+  static readonly layer = Layer.effect(
+    ActualSynchronization,
+    Effect.gen(function* () {
+      const config = yield* ActualConfigService
+      const clientFactory = yield* ActualClientFactory
+      const fileSystem = yield* ActualFileSystem
+      const healthCheck = yield* ActualHealthCheck
+      const retryPolicy = yield* ActualRetryPolicy
+
+      const synchronize = Effect.fn("ActualSynchronization.synchronize")(function* (
+        snapshot: PerformanceSnapshot,
+      ) {
+        const syncCounts = yield* runActualSyncWithRetry(
+          config,
+          snapshot,
+          clientFactory,
+          fileSystem,
+          healthCheck,
+          retryPolicy.schedule,
+        )
+        yield* Effect.logInfo(
+          `Actual sync finished. Created ${syncCounts.created} transactions, updated ${syncCounts.updated}, and deleted ${syncCounts.deletedDuplicates} duplicates.`,
+        )
+      })
+
+      return ActualSynchronization.of({ synchronize })
+    }),
+  )
+
+  static readonly live = this.layer.pipe(
+    Layer.provide(ActualClientFactory.live),
+    Layer.provide(ActualFileSystem.live),
+    Layer.provide(ActualHealthCheck.layer((input, init) => globalThis.fetch(input, init))),
+    Layer.provide(ActualRetryPolicy.live),
+  )
+}
+
+const runActualSyncWithRetry = Effect.fn("ActualSynchronization.withRetry")(function* (
+  config: ActualConfig,
+  snapshot: PerformanceSnapshot,
+  clientFactory: ActualClientFactory["Service"],
+  fileSystem: ActualFileSystem["Service"],
+  healthCheck: ActualHealthCheck["Service"],
+  retrySchedule: Schedule.Schedule<Duration.Duration, ActualError>,
+): Effect.fn.Return<SyncCounts, ActualError> {
+  const schedule = retrySchedule.pipe(
+    Schedule.while(({ input }) => input.retryable),
+    Schedule.tap(({ input, duration, attempt }) =>
+      Effect.logWarning(
+        `Actual sync attempt ${attempt} failed with a retryable error: ${getErrorMessage(input)}. Retrying in ${Math.round(Duration.toMillis(duration) / 1000)}s.`,
+      ),
+    ),
+  )
+
+  return yield* runActualSyncAttempt(config, snapshot, clientFactory, fileSystem, healthCheck).pipe(
+    Effect.retry(schedule),
+  )
+})
+
+const runActualSyncAttempt = Effect.fn("ActualSynchronization.attempt")(function* (
+  config: ActualConfig,
+  snapshot: PerformanceSnapshot,
+  clientFactory: ActualClientFactory["Service"],
+  fileSystem: ActualFileSystem["Service"],
+  healthCheck: ActualHealthCheck["Service"],
+): Effect.fn.Return<SyncCounts, ActualError> {
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      yield* fileSystem.reset()
+      yield* healthCheck.check(config.serverUrl)
+
+      const client = yield* Effect.acquireRelease(clientFactory.acquire(config), closeActualClient)
+
+      yield* client.downloadBudget(config.syncId)
+      return yield* syncDailyVariationTransactions(client, config, snapshot)
+    }),
+  )
+})
+
+const syncDailyVariationTransactions = Effect.fn(
+  "ActualSynchronization.syncDailyVariationTransactions",
+)(function* (
+  client: ActualClient,
+  config: ActualConfig,
+  snapshot: PerformanceSnapshot,
+): Effect.fn.Return<SyncCounts, ActualError> {
+  const endingDate = DateTime.formatIsoDateUtc(yield* DateTime.now)
+  const startingDate = DateTime.make(config.startingDate)
+
+  if (Option.isNone(startingDate)) {
+    return yield* new ActualInvalidStartingDate({
+      startingDate: config.startingDate,
+      retryable: false,
+    })
+  }
+
+  const startingTimestamp = DateTime.toEpochMillis(startingDate.value)
+  const balanceEntries = snapshot.balance.filter((entry) => entry.date >= startingTimestamp)
+  const transactions = yield* client.getTransactions(
+    config.fintualAccount,
+    config.startingDate,
+    endingDate,
+  )
+  const payeeId = yield* resolvePayeeId(client, config.payee)
+  const plan = planReconciliation({
+    balanceEntries,
+    existingTransactions: transactions,
+    payeeId,
+  })
+
+  for (const warning of plan.warnings) {
+    yield* Effect.logWarning(warning)
+  }
+
+  const syncCounts = {
+    created: 0,
+    updated: 0,
+    deletedDuplicates: 0,
+  }
+
+  for (const action of plan.actions) {
+    switch (action.type) {
+      case "create": {
+        yield* client.createTransaction(config.fintualAccount, action.transaction)
+        syncCounts.created += 1
+        break
+      }
+      case "update": {
+        yield* client.updateTransaction(action.id, action.transaction)
+        syncCounts.updated += 1
+        break
+      }
+      case "delete": {
+        yield* client.deleteTransaction(action.id)
+        syncCounts.deletedDuplicates += 1
+        break
+      }
+    }
+  }
+
+  yield* client.sync()
+  return syncCounts
+})
+
+const resolvePayeeId = Effect.fn("ActualSynchronization.resolvePayeeId")(function* (
+  client: ActualClient,
+  configuredPayee: string,
+): Effect.fn.Return<string | undefined, ActualPayeesReadFailure> {
+  const payees = yield* client.getPayees()
+  const payee = payees.find((candidate) => candidate.name === configuredPayee)
+
+  if (!payee) {
+    yield* Effect.logInfo("Configured payee not found")
+    return undefined
+  }
+
+  return payee.id
+})
+
+function closeActualClient(client: ActualClient): Effect.Effect<void> {
+  return client
+    .shutdown()
+    .pipe(
+      Effect.catch((cause) =>
+        Effect.logWarning(`Failed to shutdown Actual API: ${getErrorMessage(cause)}`),
+      ),
+    )
 }
 
 export function main(
   config: ActualConfig,
   snapshot: PerformanceSnapshot,
-): Effect.Effect<void, Error> {
-  return Effect.gen(function* () {
-    const syncCounts = yield* runActualSyncWithRetry(config, snapshot, 1)
-    yield* Effect.logInfo(
-      `Actual sync finished. Created ${syncCounts.created} transactions, updated ${syncCounts.updated}, and deleted ${syncCounts.deletedDuplicates} duplicates.`,
-    )
-  })
-}
-
-function runActualSyncWithRetry(
-  config: ActualConfig,
-  snapshot: PerformanceSnapshot,
-  attempt: number,
-): Effect.Effect<SyncCounts, Error> {
-  return Effect.catch(runActualSyncAttempt(config, snapshot), (cause) => {
-    const shouldRetry = isRetryableActualError(cause) && attempt < MAX_SYNC_ATTEMPTS
-
-    if (!shouldRetry) {
-      return Effect.fail(cause)
-    }
-
-    const retryDelayMs = getRetryDelayMs(attempt)
-    return Effect.gen(function* () {
-      yield* Effect.logWarning(
-        `Actual sync attempt ${attempt} failed with a retryable error: ${getErrorMessage(cause)}. Retrying in ${Math.round(retryDelayMs / 1000)}s.`,
-      )
-      yield* Effect.sleep(Duration.millis(retryDelayMs))
-      return yield* runActualSyncWithRetry(config, snapshot, attempt + 1)
-    })
-  })
-}
-
-function runActualSyncAttempt(
-  config: ActualConfig,
-  snapshot: PerformanceSnapshot,
-): Effect.Effect<SyncCounts, Error> {
-  return Effect.gen(function* () {
-    yield* resetDataDirectory()
-    yield* assertActualServerReachable(config)
-
-    yield* Effect.tryPromise({
-      try: () =>
-        api.init({
-          dataDir: ACTUAL_DATA_DIR,
-          serverURL: config.serverUrl,
-          password: config.password,
-          verbose: false,
-        } satisfies ActualInitConfig),
-      catch: (error) => toError(error, "Failed to initialize Actual API"),
-    })
-
-    return yield* Effect.ensuring(
-      Effect.gen(function* () {
-        yield* Effect.tryPromise({
-          try: () => api.downloadBudget(config.syncId),
-          catch: (error) => toError(error, "Failed to download Actual budget"),
-        })
-        return yield* syncDailyVariationTransactions(config, snapshot)
-      }),
-      Effect.ignore(
-        Effect.tryPromise({
-          try: () => api.shutdown(),
-          catch: (error) => toError(error, "Failed to shutdown Actual API"),
-        }),
-      ),
-    )
-  })
-}
-
-function syncDailyVariationTransactions(
-  config: ActualConfig,
-  snapshot: PerformanceSnapshot,
-): Effect.Effect<SyncCounts, Error> {
-  return Effect.gen(function* () {
-    const endingDate = getTodayIsoDate()
-    const transactions = yield* Effect.tryPromise({
-      try: () => api.getTransactions(config.fintualAccount, config.startingDate, endingDate),
-      catch: (error) => toError(error, "Failed to fetch Actual transactions"),
-    })
-
-    const startingTimestamp = Date.parse(config.startingDate)
-    const balanceEntries = snapshot.balance.filter((entry) => entry.date >= startingTimestamp)
-    const payeeId = yield* getPayeeId(config)
-    const plan = planReconciliation({
-      balanceEntries,
-      existingTransactions: transactions,
-      payeeId,
-    })
-
-    for (const warning of plan.warnings) {
-      yield* Effect.logWarning(warning)
-    }
-
-    const syncCounts: SyncCounts = {
-      created: 0,
-      updated: 0,
-      deletedDuplicates: 0,
-    }
-
-    for (const action of plan.actions) {
-      switch (action.type) {
-        case "create": {
-          yield* Effect.tryPromise({
-            try: () => api.addTransactions(config.fintualAccount, [action.transaction]),
-            catch: (error) => toError(error, "Failed to add Actual transaction"),
-          })
-          syncCounts.created += 1
-          break
-        }
-        case "update": {
-          yield* Effect.tryPromise({
-            try: () => api.updateTransaction(action.id, action.transaction),
-            catch: (error) => toError(error, "Failed to update Actual transaction"),
-          })
-          syncCounts.updated += 1
-          break
-        }
-        case "delete": {
-          yield* Effect.tryPromise({
-            try: () => api.deleteTransaction(action.id),
-            catch: (error) => toError(error, "Failed to delete duplicate Actual transaction"),
-          })
-          syncCounts.deletedDuplicates += 1
-          break
-        }
-      }
-    }
-
-    yield* Effect.tryPromise({
-      try: () => api.sync(),
-      catch: (error) => toError(error, "Failed to sync Actual budget"),
-    })
-
-    return syncCounts
-  })
-}
-
-function resetDataDirectory(): Effect.Effect<void, Error> {
-  return Effect.try({
-    try: () => {
-      fs.rmSync(ACTUAL_DATA_DIR, { recursive: true, force: true })
-      fs.mkdirSync(ACTUAL_DATA_DIR, { recursive: true })
-    },
-    catch: (error) => toError(error, "Failed to reset Actual data directory"),
-  })
-}
-
-function getPayeeId(config: ActualConfig): Effect.Effect<string | undefined, Error> {
-  return Effect.gen(function* () {
-    const payees = yield* Effect.tryPromise({
-      try: () => api.getPayees(),
-      catch: (error) => toError(error, "Failed to fetch Actual payees"),
-    })
-    const payee = payees.find((candidate) => candidate.name === config.payee)
-
-    if (!payee) {
-      yield* Effect.logInfo("Configured payee not found")
-      return undefined
-    }
-
-    return payee.id
-  })
-}
-
-function getTodayIsoDate(): string {
-  return new Date().toISOString().split("T")[0]
-}
-
-function isRetryableActualError(error: unknown): boolean {
-  if (error instanceof Error) {
-    const message = `${error.message}\n${error.stack ?? ""}`.toLowerCase()
-    return (
-      message.includes("network-failure") ||
-      message.includes("econnreset") ||
-      message.includes("econnrefused") ||
-      message.includes("eai_again") ||
-      message.includes("etimedout") ||
-      message.includes("fetch failed") ||
-      message.includes("download-budget")
-    )
-  }
-
-  if (!isRecord(error)) {
-    return false
-  }
-
-  return error.type === "PostError" && error.reason === "network-failure"
-}
-
-function assertActualServerReachable(config: ActualConfig): Effect.Effect<void, Error> {
-  const normalizedBaseUrl = config.serverUrl.endsWith("/")
-    ? config.serverUrl.slice(0, -1)
-    : config.serverUrl
-  const healthUrl = `${normalizedBaseUrl}/health`
-
-  return Effect.gen(function* () {
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 10_000)
-
-    const response = yield* Effect.ensuring(
-      Effect.tryPromise({
-        try: () =>
-          fetch(healthUrl, {
-            method: "GET",
-            signal: controller.signal,
-          }),
-        catch: (error) =>
-          toError(
-            error,
-            (cause) => `Actual server is unreachable at ${healthUrl}: ${getErrorMessage(cause)}`,
-          ),
-      }),
-      Effect.sync(() => clearTimeout(timeout)),
-    )
-
-    if (response.ok) {
-      return
-    }
-
-    return yield* Effect.fail(
-      new Error(
-        `Actual server is unreachable at ${healthUrl}: health endpoint returned HTTP ${response.status}`,
-      ),
-    )
-  })
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
-}
-
-function getRetryDelayMs(attempt: number): number {
-  const exponentialDelayMs = Math.min(
-    INITIAL_RETRY_DELAY_MS * 2 ** (attempt - 1),
-    MAX_RETRY_DELAY_MS,
+): Effect.Effect<void, ActualError> {
+  return runMain(snapshot).pipe(
+    Effect.provide(ActualSynchronization.live),
+    Effect.provideService(ActualConfigService, config),
   )
-  const jitterRangeMs = Math.round(exponentialDelayMs * RETRY_JITTER_RATIO)
-  const jitterOffsetMs = Math.floor(Math.random() * (jitterRangeMs * 2 + 1)) - jitterRangeMs
-
-  return Math.max(1000, exponentialDelayMs + jitterOffsetMs)
 }
+
+const runMain = Effect.fn("Actual.main")(function* (snapshot: PerformanceSnapshot) {
+  const actual = yield* ActualSynchronization
+  yield* actual.synchronize(snapshot)
+})

--- a/src/actual/actual-client.ts
+++ b/src/actual/actual-client.ts
@@ -181,9 +181,5 @@ function isRetryableActualCause(cause: unknown): boolean {
     return false
   }
 
-  return (
-    cause.code === "network-failure" ||
-    cause.reason === "network-failure" ||
-    (cause.type === "PostError" && cause.reason === "network-failure")
-  )
+  return cause.code === "network-failure" || cause.reason === "network-failure"
 }

--- a/src/actual/actual-client.ts
+++ b/src/actual/actual-client.ts
@@ -1,0 +1,189 @@
+import * as api from "@actual-app/api"
+import { Context, Effect, Layer, Predicate } from "effect"
+import type { ActualConfig } from "../env.ts"
+import type {
+  ExistingVariationTransaction,
+  VariationTransactionInput,
+} from "./reconciliation-policy.ts"
+import {
+  ActualBudgetDownloadFailure,
+  ActualDuplicateDeletionFailure,
+  ActualInitializationFailure,
+  ActualPayeesReadFailure,
+  ActualShutdownFailure,
+  ActualSyncFailure,
+  ActualTransactionCreationFailure,
+  ActualTransactionUpdateFailure,
+  ActualTransactionsReadFailure,
+} from "./actual-error.ts"
+
+const ACTUAL_DATA_DIR = "./tmp/actual-data"
+
+type ActualInitConfig = Parameters<typeof api.init>[0]
+
+export interface ActualPayee {
+  readonly id: string
+  readonly name: string
+}
+
+export interface ActualClient {
+  readonly downloadBudget: (syncId: string) => Effect.Effect<void, ActualBudgetDownloadFailure>
+  readonly getTransactions: (
+    accountId: string,
+    startDate: string,
+    endDate: string,
+  ) => Effect.Effect<ReadonlyArray<ExistingVariationTransaction>, ActualTransactionsReadFailure>
+  readonly getPayees: () => Effect.Effect<ReadonlyArray<ActualPayee>, ActualPayeesReadFailure>
+  readonly createTransaction: (
+    accountId: string,
+    transaction: VariationTransactionInput,
+  ) => Effect.Effect<void, ActualTransactionCreationFailure>
+  readonly updateTransaction: (
+    id: string,
+    transaction: VariationTransactionInput,
+  ) => Effect.Effect<void, ActualTransactionUpdateFailure>
+  readonly deleteTransaction: (id: string) => Effect.Effect<void, ActualDuplicateDeletionFailure>
+  readonly sync: () => Effect.Effect<void, ActualSyncFailure>
+  readonly shutdown: () => Effect.Effect<void, ActualShutdownFailure>
+}
+
+export class ActualClientFactory extends Context.Service<
+  ActualClientFactory,
+  {
+    readonly acquire: (
+      config: ActualConfig,
+    ) => Effect.Effect<ActualClient, ActualInitializationFailure>
+  }
+>()("ActualClientFactory") {
+  static readonly live = Layer.succeed(
+    ActualClientFactory,
+    ActualClientFactory.of({
+      acquire: Effect.fn("ActualClientFactory.acquire")(function* (config: ActualConfig) {
+        yield* Effect.tryPromise({
+          try: () =>
+            api.init({
+              dataDir: ACTUAL_DATA_DIR,
+              serverURL: config.serverUrl,
+              password: config.password,
+              verbose: false,
+            } satisfies ActualInitConfig),
+          catch: (cause) =>
+            new ActualInitializationFailure({
+              cause,
+              retryable: isRetryableActualCause(cause),
+            }),
+        })
+
+        return ActualClientLive
+      }),
+    }),
+  )
+}
+
+const ActualClientLive: ActualClient = {
+  downloadBudget: Effect.fn("ActualClient.downloadBudget")(function* (syncId: string) {
+    yield* Effect.tryPromise({
+      try: () => api.downloadBudget(syncId),
+      catch: (cause) =>
+        new ActualBudgetDownloadFailure({
+          cause,
+          retryable: isRetryableActualCause(cause),
+        }),
+    })
+  }),
+
+  getTransactions: Effect.fn("ActualClient.getTransactions")(function* (
+    accountId: string,
+    startDate: string,
+    endDate: string,
+  ) {
+    return yield* Effect.tryPromise({
+      try: () => api.getTransactions(accountId, startDate, endDate),
+      catch: (cause) =>
+        new ActualTransactionsReadFailure({
+          cause,
+          retryable: isRetryableActualCause(cause),
+        }),
+    })
+  }),
+
+  getPayees: Effect.fn("ActualClient.getPayees")(function* () {
+    return yield* Effect.tryPromise({
+      try: () => api.getPayees(),
+      catch: (cause) =>
+        new ActualPayeesReadFailure({
+          cause,
+          retryable: isRetryableActualCause(cause),
+        }),
+    })
+  }),
+
+  createTransaction: Effect.fn("ActualClient.createTransaction")(function* (
+    accountId: string,
+    transaction: VariationTransactionInput,
+  ) {
+    yield* Effect.tryPromise({
+      try: () => api.addTransactions(accountId, [transaction]),
+      catch: (cause) =>
+        new ActualTransactionCreationFailure({
+          cause,
+          retryable: isRetryableActualCause(cause),
+        }),
+    })
+  }),
+
+  updateTransaction: Effect.fn("ActualClient.updateTransaction")(function* (
+    id: string,
+    transaction: VariationTransactionInput,
+  ) {
+    yield* Effect.tryPromise({
+      try: () => api.updateTransaction(id, transaction),
+      catch: (cause) =>
+        new ActualTransactionUpdateFailure({
+          cause,
+          retryable: isRetryableActualCause(cause),
+        }),
+    })
+  }),
+
+  deleteTransaction: Effect.fn("ActualClient.deleteTransaction")(function* (id: string) {
+    yield* Effect.tryPromise({
+      try: () => api.deleteTransaction(id),
+      catch: (cause) =>
+        new ActualDuplicateDeletionFailure({
+          cause,
+          retryable: isRetryableActualCause(cause),
+        }),
+    })
+  }),
+
+  sync: Effect.fn("ActualClient.sync")(function* () {
+    yield* Effect.tryPromise({
+      try: () => api.sync(),
+      catch: (cause) =>
+        new ActualSyncFailure({
+          cause,
+          retryable: isRetryableActualCause(cause),
+        }),
+    })
+  }),
+
+  shutdown: Effect.fn("ActualClient.shutdown")(function* () {
+    yield* Effect.tryPromise({
+      try: () => api.shutdown(),
+      catch: (cause) => new ActualShutdownFailure({ cause, retryable: false }),
+    })
+  }),
+}
+
+function isRetryableActualCause(cause: unknown): boolean {
+  if (!Predicate.isObject(cause)) {
+    return false
+  }
+
+  return (
+    cause.code === "network-failure" ||
+    cause.reason === "network-failure" ||
+    (cause.type === "PostError" && cause.reason === "network-failure")
+  )
+}

--- a/src/actual/actual-error.ts
+++ b/src/actual/actual-error.ts
@@ -1,0 +1,162 @@
+import { Schema } from "effect"
+import { getErrorMessage } from "../log.ts"
+
+export class ActualDataDirectoryFailure extends Schema.TaggedError<ActualDataDirectoryFailure>()(
+  "ActualDataDirectoryFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to reset Actual data directory: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualHealthCheckFailure extends Schema.TaggedError<ActualHealthCheckFailure>()(
+  "ActualHealthCheckFailure",
+  {
+    url: Schema.String,
+    status: Schema.optional(Schema.Number),
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Actual server is unreachable at ${this.url}: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualInitializationFailure extends Schema.TaggedError<ActualInitializationFailure>()(
+  "ActualInitializationFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to initialize Actual API: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualBudgetDownloadFailure extends Schema.TaggedError<ActualBudgetDownloadFailure>()(
+  "ActualBudgetDownloadFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to download Actual budget: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualTransactionsReadFailure extends Schema.TaggedError<ActualTransactionsReadFailure>()(
+  "ActualTransactionsReadFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to fetch Actual transactions: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualPayeesReadFailure extends Schema.TaggedError<ActualPayeesReadFailure>()(
+  "ActualPayeesReadFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to fetch Actual payees: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualTransactionCreationFailure extends Schema.TaggedError<ActualTransactionCreationFailure>()(
+  "ActualTransactionCreationFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to add Actual transaction: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualTransactionUpdateFailure extends Schema.TaggedError<ActualTransactionUpdateFailure>()(
+  "ActualTransactionUpdateFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to update Actual transaction: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualDuplicateDeletionFailure extends Schema.TaggedError<ActualDuplicateDeletionFailure>()(
+  "ActualDuplicateDeletionFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to delete duplicate Actual transaction: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualSyncFailure extends Schema.TaggedError<ActualSyncFailure>()(
+  "ActualSyncFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to sync Actual budget: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualShutdownFailure extends Schema.TaggedError<ActualShutdownFailure>()(
+  "ActualShutdownFailure",
+  {
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Failed to shutdown Actual API: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ActualInvalidStartingDate extends Schema.TaggedError<ActualInvalidStartingDate>()(
+  "ActualInvalidStartingDate",
+  {
+    startingDate: Schema.String,
+    retryable: Schema.Boolean,
+  },
+) {
+  get message(): string {
+    return `Actual starting date is invalid: ${this.startingDate}`
+  }
+}
+
+export type ActualError =
+  | ActualDataDirectoryFailure
+  | ActualHealthCheckFailure
+  | ActualInitializationFailure
+  | ActualBudgetDownloadFailure
+  | ActualTransactionsReadFailure
+  | ActualPayeesReadFailure
+  | ActualTransactionCreationFailure
+  | ActualTransactionUpdateFailure
+  | ActualDuplicateDeletionFailure
+  | ActualSyncFailure
+  | ActualShutdownFailure
+  | ActualInvalidStartingDate

--- a/src/actual/actual-error.ts
+++ b/src/actual/actual-error.ts
@@ -158,5 +158,4 @@ export type ActualError =
   | ActualTransactionUpdateFailure
   | ActualDuplicateDeletionFailure
   | ActualSyncFailure
-  | ActualShutdownFailure
   | ActualInvalidStartingDate

--- a/src/actual/actual-file-system.ts
+++ b/src/actual/actual-file-system.ts
@@ -1,0 +1,27 @@
+import * as fs from "node:fs"
+import { Context, Effect, Layer } from "effect"
+import { ActualDataDirectoryFailure } from "./actual-error.ts"
+
+const ACTUAL_DATA_DIR = "./tmp/actual-data"
+
+export class ActualFileSystem extends Context.Service<
+  ActualFileSystem,
+  {
+    readonly reset: () => Effect.Effect<void, ActualDataDirectoryFailure>
+  }
+>()("ActualFileSystem") {
+  static readonly live = Layer.succeed(
+    ActualFileSystem,
+    ActualFileSystem.of({
+      reset: Effect.fn("ActualFileSystem.reset")(function* () {
+        yield* Effect.try({
+          try: () => {
+            fs.rmSync(ACTUAL_DATA_DIR, { recursive: true, force: true })
+            fs.mkdirSync(ACTUAL_DATA_DIR, { recursive: true })
+          },
+          catch: (cause) => new ActualDataDirectoryFailure({ cause, retryable: false }),
+        })
+      }),
+    }),
+  )
+}

--- a/src/actual/actual-health-check.ts
+++ b/src/actual/actual-health-check.ts
@@ -1,0 +1,68 @@
+import { Context, Effect, Layer } from "effect"
+import { ActualHealthCheckFailure } from "./actual-error.ts"
+
+const HEALTH_CHECK_TIMEOUT_MS = 10_000
+
+export class ActualHealthCheck extends Context.Service<
+  ActualHealthCheck,
+  {
+    readonly check: (serverUrl: string) => Effect.Effect<void, ActualHealthCheckFailure>
+  }
+>()("ActualHealthCheck") {
+  static readonly layer = (fetchRequest: typeof globalThis.fetch) =>
+    Layer.succeed(
+      ActualHealthCheck,
+      ActualHealthCheck.of({
+        check: Effect.fn("ActualHealthCheck.check")(function* (serverUrl: string) {
+          const healthUrl = getHealthUrl(serverUrl)
+          const response = yield* Effect.tryPromise({
+            try: (signal) =>
+              fetchRequest(healthUrl, {
+                method: "GET",
+                signal,
+              }),
+            catch: (cause) =>
+              new ActualHealthCheckFailure({
+                url: healthUrl,
+                cause,
+                retryable: true,
+              }),
+          }).pipe(
+            Effect.timeoutOrElse({
+              duration: HEALTH_CHECK_TIMEOUT_MS,
+              orElse: () =>
+                Effect.fail(
+                  new ActualHealthCheckFailure({
+                    url: healthUrl,
+                    cause: new Error(
+                      `health endpoint timed out after ${HEALTH_CHECK_TIMEOUT_MS}ms`,
+                    ),
+                    retryable: true,
+                  }),
+                ),
+            }),
+          )
+
+          if (response.ok) {
+            return
+          }
+
+          return yield* new ActualHealthCheckFailure({
+            url: healthUrl,
+            status: response.status,
+            cause: new Error(`health endpoint returned HTTP ${response.status}`),
+            retryable: isRetryableStatus(response.status),
+          })
+        }),
+      }),
+    )
+}
+
+function getHealthUrl(serverUrl: string): string {
+  const normalizedBaseUrl = serverUrl.endsWith("/") ? serverUrl.slice(0, -1) : serverUrl
+  return `${normalizedBaseUrl}/health`
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500
+}

--- a/src/actual/retry-policy.ts
+++ b/src/actual/retry-policy.ts
@@ -13,11 +13,7 @@ const actualRetrySchedule: ActualRetrySchedule = Schedule.max([
     Schedule.spaced(Duration.millis(MAX_RETRY_DELAY_MS)),
   ]),
   Schedule.recurs(MAX_SYNC_ATTEMPTS - 1),
-]).pipe(
-  Schedule.jittered,
-  Schedule.setInputType<ActualError>(),
-  Schedule.while(({ input }) => input.retryable),
-)
+]).pipe(Schedule.jittered, Schedule.setInputType<ActualError>())
 
 export class ActualRetryPolicy extends Context.Service<
   ActualRetryPolicy,

--- a/src/actual/retry-policy.ts
+++ b/src/actual/retry-policy.ts
@@ -1,0 +1,32 @@
+import { Context, Duration, Layer, Schedule } from "effect"
+import type { ActualError } from "./actual-error.ts"
+
+const MAX_SYNC_ATTEMPTS = 5
+const INITIAL_RETRY_DELAY_MS = 5_000
+const MAX_RETRY_DELAY_MS = 60_000
+
+type ActualRetrySchedule = Schedule.Schedule<Duration.Duration, ActualError>
+
+const actualRetrySchedule: ActualRetrySchedule = Schedule.max([
+  Schedule.min([
+    Schedule.exponential(Duration.millis(INITIAL_RETRY_DELAY_MS)),
+    Schedule.spaced(Duration.millis(MAX_RETRY_DELAY_MS)),
+  ]),
+  Schedule.recurs(MAX_SYNC_ATTEMPTS - 1),
+]).pipe(
+  Schedule.jittered,
+  Schedule.setInputType<ActualError>(),
+  Schedule.while(({ input }) => input.retryable),
+)
+
+export class ActualRetryPolicy extends Context.Service<
+  ActualRetryPolicy,
+  {
+    readonly schedule: ActualRetrySchedule
+  }
+>()("ActualRetryPolicy") {
+  static readonly live = Layer.succeed(
+    ActualRetryPolicy,
+    ActualRetryPolicy.of({ schedule: actualRetrySchedule }),
+  )
+}


### PR DESCRIPTION
## Summary

- replaces the manual Actual sync workflow with `ActualSynchronization.synchronize(snapshot)`
- scopes the Actual SDK singleton per Synchronization Attempt and guarantees shutdown on failure/interruption
- adds typed Actual failures with adapter-level retryability, deterministic filesystem/health/client seams, and a Schedule-based retry policy
- re-derives the plan from fresh Actual state on every retry and uses Effect `DateTime` for the transaction end date
- records the accepted architecture in ADR 0005 and logs the unrelated Fallow warning friction

## Design

The public job compatibility seam remains `main(config, snapshot)`. The service layer owns reset → health → init → download → plan → mutate → sync, while `ActualClientFactory`, `ActualFileSystem`, and `ActualHealthCheck` are replaceable test seams. Actual SDK failures preserve their original causes and use stable error codes/status classes rather than message matching.

## Verification

- `pnpm test` — 11 files, 80 tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm fallow:audit`

Closes #286
