### PR TITLE
feat: carry runtime secrets as redacted values

### DIFF
--- a/.agents/friction-log/20260811142356-oxlint-rejects-intentional/friction.md
+++ b/.agents/friction-log/20260811142356-oxlint-rejects-intentional/friction.md
@@ -1,0 +1,19 @@
+---
+title: 'oxlint rejects intentional String(Redacted) behavior assertions'
+severity: 'minor'
+---
+
+## Expected Behavior
+Tests should be able to assert Effect Redacted values render as the documented <redacted> placeholder.
+
+## Current Behavior
+The lint hook flags String(redacted) with typescript/no-base-to-string even though Effect documents String() as the safe placeholder rendering.
+
+## Possible Solution
+Recognize Redacted values in the no-base-to-string rule, or document the targeted disable needed for this API.
+
+## Minimal Reproducible Example
+Run the repository lint hook on a test containing String(Redacted.make("secret")).
+
+## Context
+Tests need targeted oxlint-disable comments to cover the redaction rendering contract.

--- a/docs/adr/0004-redaction-at-the-logging-render-edge.md
+++ b/docs/adr/0004-redaction-at-the-logging-render-edge.md
@@ -19,3 +19,7 @@ accepted
 - All Effect logs cross one redacting render edge before reaching process output.
 - `src/log.ts` remains the policy module and keeps its current configuration API; #285 does not introduce a new configuration service.
 - `once.ts` uses `NodeRuntime.runMain`, preserving the runtime's standard exit behavior while reporting unhandled failures through the logger.
+
+## Amendment (2026-08-11)
+
+Issue #315 changes what the existing logging policy receives from runtime configuration. Credentials are decoded as `Redacted` values and are no longer copied into the redaction registry during startup. The owning adapter calls `revealSecret` at the external boundary; that helper reveals the value for the request and registers the plaintext with `src/log.ts` so the render edge continues to redact it. `configureSensitiveValues` remains the configuration entry point for non-secret identifiers and addresses.

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Fiber, Result, Schedule } from "effect"
+import { Duration, Effect, Fiber, Redacted, Result, Schedule } from "effect"
 import { TestClock } from "effect/testing"
 import { afterEach, expect, test, vi } from "vitest"
 
@@ -35,7 +35,7 @@ afterEach(() => {
 
 const CONFIG: ActualConfig = {
   serverUrl: "https://actual.example.test/",
-  password: "secret",
+  password: Redacted.make("secret"),
   syncId: "sync-id",
   fintualAccount: "account-id",
   startingDate: "2026-01-01",
@@ -163,6 +163,7 @@ test("the live Actual adapter preserves stable SDK network codes", async () => {
   )
 
   expect(Result.isFailure(result)).toBe(true)
+  expect(actualApiMock.init).toHaveBeenCalledWith(expect.objectContaining({ password: "secret" }))
   if (Result.isFailure(result)) {
     expect(result.failure).toMatchObject({
       _tag: "ActualBudgetDownloadFailure",

--- a/src/actual/actual-client.ts
+++ b/src/actual/actual-client.ts
@@ -1,6 +1,7 @@
 import * as api from "@actual-app/api"
 import { Context, Effect, Layer, Predicate } from "effect"
 import type { ActualConfig } from "../env.ts"
+import { revealSecret } from "../log.ts"
 import type {
   ExistingVariationTransaction,
   VariationTransactionInput,
@@ -64,7 +65,7 @@ export class ActualClientFactory extends Context.Service<
             api.init({
               dataDir: ACTUAL_DATA_DIR,
               serverURL: config.serverUrl,
-              password: config.password,
+              password: revealSecret(config.password),
               verbose: false,
             } satisfies ActualInitConfig),
           catch: (cause) =>

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -94,6 +94,35 @@ test("reports all missing required runtime values", async () => {
   }
 })
 
+test("treats unquoted empty required values as missing", async () => {
+  const result = await Effect.runPromise(
+    Effect.result(
+      resolveRuntimeConfig({
+        ...requiredEnvironment(),
+        ACTUAL_SERVER_URL: "",
+      }),
+    ),
+  )
+
+  expect(result._tag).toBe("Failure")
+  if (Result.isFailure(result)) {
+    expect(result.failure.message).toContain("ACTUAL_SERVER_URL")
+  }
+})
+
+test("uses defaults when optional non-Gmail values are unquoted empty strings", async () => {
+  const configuration = await Effect.runPromise(
+    resolveRuntimeConfig({
+      ...requiredEnvironment(),
+      ACTUAL_PAYEE: "",
+      GMAIL_IMAP_PORT: "",
+    }),
+  )
+
+  expect(configuration.actual.payee).toBe("Fintual")
+  expect(configuration.fintual.email2FA).toBeNull()
+})
+
 test("rejects partially configured email 2FA credentials", async () => {
   const result = await Effect.runPromise(
     Effect.result(

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -115,12 +115,14 @@ test("uses defaults when optional non-Gmail values are unquoted empty strings", 
     resolveRuntimeConfig({
       ...requiredEnvironment(),
       ACTUAL_PAYEE: "",
+      GMAIL_USER_EMAIL: "mailbox@example.com",
+      GMAIL_APP_PASSWORD: "app password",
       GMAIL_IMAP_PORT: "",
     }),
   )
 
   expect(configuration.actual.payee).toBe("Fintual")
-  expect(configuration.fintual.email2FA).toBeNull()
+  expect(configuration.fintual.email2FA?.port).toBe(993)
 })
 
 test("rejects partially configured email 2FA credentials", async () => {

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,6 +1,6 @@
-import { Effect, Result } from "effect"
+import { Effect, Redacted, Result } from "effect"
 import { expect, test } from "vitest"
-import { resolveRuntimeConfig } from "./env.ts"
+import { resolveRuntimeConfig, RuntimeConfigError } from "./env.ts"
 
 function requiredEnvironment(): Record<string, string> {
   return {
@@ -17,22 +17,25 @@ function requiredEnvironment(): Record<string, string> {
 test("normalizes runtime values and applies defaults once for every domain", async () => {
   const configuration = await Effect.runPromise(resolveRuntimeConfig(requiredEnvironment()))
 
-  expect(configuration).toEqual({
-    actual: {
-      serverUrl: "https://actual.example.test",
-      password: "actual password",
-      syncId: "sync-id",
-      fintualAccount: "account-id",
-      startingDate: "2024-03-01",
-      payee: "Fintual",
-    },
-    fintual: {
-      email: "investor@example.com",
-      password: "fintual password",
-      goalId: "goal-id",
-      email2FA: null,
-    },
+  expect(configuration.actual).toMatchObject({
+    serverUrl: "https://actual.example.test",
+    syncId: "sync-id",
+    fintualAccount: "account-id",
+    startingDate: "2024-03-01",
+    payee: "Fintual",
   })
+  expect(configuration.fintual).toMatchObject({
+    email: "investor@example.com",
+    goalId: "goal-id",
+    email2FA: null,
+  })
+  // Redacted intentionally exposes a safe placeholder through String().
+  // oxlint-disable-next-line typescript/no-base-to-string
+  expect(String(configuration.actual.password)).toBe("<redacted>")
+  expect(Redacted.value(configuration.actual.password)).toBe("actual password")
+  // oxlint-disable-next-line typescript/no-base-to-string
+  expect(String(configuration.fintual.password)).toBe("<redacted>")
+  expect(Redacted.value(configuration.fintual.password)).toBe("fintual password")
 })
 
 test("uses legacy starting date and enables email 2FA when both credentials are present", async () => {
@@ -52,14 +55,19 @@ test("uses legacy starting date and enables email 2FA when both credentials are 
 
   expect(configuration.actual.startingDate).toBe("2025-01-02")
   expect(configuration.actual.payee).toBe("Investments")
-  expect(configuration.fintual.email2FA).toEqual({
-    userEmail: "mailbox@example.com",
-    appPassword: "app password",
-    host: "mail.example.com",
-    port: 1993,
-    debug: true,
-    sender: "security@example.com",
-  })
+  expect(configuration.fintual.email2FA).not.toBeNull()
+  if (configuration.fintual.email2FA) {
+    expect(configuration.fintual.email2FA).toMatchObject({
+      userEmail: "mailbox@example.com",
+      host: "mail.example.com",
+      port: 1993,
+      debug: true,
+      sender: "security@example.com",
+    })
+    // oxlint-disable-next-line typescript/no-base-to-string
+    expect(String(configuration.fintual.email2FA.appPassword)).toBe("<redacted>")
+    expect(Redacted.value(configuration.fintual.email2FA.appPassword)).toBe("app password")
+  }
 })
 
 test("preserves quoted-empty values instead of falling back to defaults", async () => {
@@ -80,6 +88,8 @@ test("reports all missing required runtime values", async () => {
 
   expect(result._tag).toBe("Failure")
   if (Result.isFailure(result)) {
+    expect(result.failure).toBeInstanceOf(RuntimeConfigError)
+    expect(result.failure.cause).toBeDefined()
     expect(result.failure.message).toContain("ACTUAL_SERVER_URL")
   }
 })
@@ -96,7 +106,41 @@ test("rejects partially configured email 2FA credentials", async () => {
 
   expect(result._tag).toBe("Failure")
   if (Result.isFailure(result)) {
+    expect(result.failure).toBeInstanceOf(RuntimeConfigError)
     expect(result.failure.message).toBe("Missing environment variables: GMAIL_APP_PASSWORD")
+  }
+})
+
+test("rejects a Gmail app password without its user email", async () => {
+  const result = await Effect.runPromise(
+    Effect.result(
+      resolveRuntimeConfig({
+        ...requiredEnvironment(),
+        GMAIL_APP_PASSWORD: "app password",
+      }),
+    ),
+  )
+
+  expect(result._tag).toBe("Failure")
+  if (Result.isFailure(result)) {
+    expect(result.failure).toBeInstanceOf(RuntimeConfigError)
+    expect(result.failure.message).toBe("Missing environment variables: GMAIL_USER_EMAIL")
+  }
+})
+
+test("preserves explicitly supplied empty Gmail credentials as present values", async () => {
+  const configuration = await Effect.runPromise(
+    resolveRuntimeConfig({
+      ...requiredEnvironment(),
+      GMAIL_USER_EMAIL: "",
+      GMAIL_APP_PASSWORD: "",
+    }),
+  )
+
+  expect(configuration.fintual.email2FA).not.toBeNull()
+  if (configuration.fintual.email2FA) {
+    expect(configuration.fintual.email2FA.userEmail).toBe("")
+    expect(Redacted.value(configuration.fintual.email2FA.appPassword)).toBe("")
   }
 })
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -51,7 +51,9 @@ export function resolveRuntimeConfig(
     const provider = ConfigProvider.fromUnknown(
       Object.fromEntries(
         Object.entries(environment).flatMap(([name, value]) =>
-          value === undefined ? [] : [[name, normalizeEnvValue(value)]],
+          value === undefined || (value === "" && !isGmailCredential(name))
+            ? []
+            : [[name, normalizeEnvValue(value)]],
         ),
       ),
       { preserveEmptyStrings: true },
@@ -160,6 +162,10 @@ function resolveEmail2FAConfig(
 function missingEmail2FACredential(name: string): Effect.Effect<never, RuntimeConfigError> {
   const cause = new Error(`Missing environment variables: ${name}`)
   return Effect.fail(new RuntimeConfigError({ message: cause.message, cause }))
+}
+
+function isGmailCredential(name: string): boolean {
+  return name === "GMAIL_USER_EMAIL" || name === "GMAIL_APP_PASSWORD"
 }
 
 function normalizeEnvValue(value: string): string {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,8 +1,16 @@
-import { Config, ConfigProvider, Context, Effect, Option } from "effect"
+import { Config, ConfigProvider, Context, Effect, Option, Redacted, Schema } from "effect"
+
+export class RuntimeConfigError extends Schema.TaggedError<RuntimeConfigError>()(
+  "RuntimeConfigError",
+  {
+    message: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {}
 
 export interface ActualConfig {
   serverUrl: string
-  password: string
+  password: Redacted.Redacted<string>
   syncId: string
   fintualAccount: string
   startingDate: string
@@ -11,7 +19,7 @@ export interface ActualConfig {
 
 export interface Email2FAConfig {
   userEmail: string
-  appPassword: string
+  appPassword: Redacted.Redacted<string>
   host: string
   port: number
   debug: boolean
@@ -20,7 +28,7 @@ export interface Email2FAConfig {
 
 export interface FintualConfig {
   email: string
-  password: string
+  password: Redacted.Redacted<string>
   goalId: string
   email2FA: Email2FAConfig | null
 }
@@ -38,23 +46,31 @@ export type Environment = Readonly<Record<string, string | undefined>>
 
 export function resolveRuntimeConfig(
   environment: Environment,
-): Effect.Effect<RuntimeConfig, Error> {
+): Effect.Effect<RuntimeConfig, RuntimeConfigError> {
   return Effect.gen(function* () {
     const provider = ConfigProvider.fromUnknown(
       Object.fromEntries(
         Object.entries(environment).flatMap(([name, value]) =>
-          value ? [[name, normalizeEnvValue(value)]] : [],
+          value === undefined ? [] : [[name, normalizeEnvValue(value)]],
         ),
       ),
       { preserveEmptyStrings: true },
     )
     const values = yield* runtimeValueConfig.pipe(
       Effect.provideService(ConfigProvider.ConfigProvider, provider),
-      Effect.mapError((cause) => new Error(cause.message)),
+      Effect.mapError(
+        (cause) =>
+          new RuntimeConfigError({
+            message: cause.message,
+            cause,
+          }),
+      ),
     )
-    const gmailUserEmail = Option.getOrElse(values.gmailUserEmail, () => "")
-    const gmailAppPassword = Option.getOrElse(values.gmailAppPassword, () => "")
-    const email2FA = yield* resolveEmail2FAConfig(provider, gmailUserEmail, gmailAppPassword)
+    const email2FA = yield* resolveEmail2FAConfig(
+      provider,
+      values.gmailUserEmail,
+      values.gmailAppPassword,
+    )
 
     return {
       actual: {
@@ -77,7 +93,7 @@ export function resolveRuntimeConfig(
 
 const runtimeValueConfig = Config.all({
   actualServerUrl: Config.string("ACTUAL_SERVER_URL"),
-  actualPassword: Config.string("ACTUAL_PASSWORD"),
+  actualPassword: Config.redacted("ACTUAL_PASSWORD"),
   actualSyncId: Config.string("ACTUAL_SYNC_ID"),
   actualFintualAccount: Config.string("ACTUAL_FINTUAL_ACCOUNT"),
   actualStartingDate: Config.string("ACTUAL_STARTING_DATE").pipe(
@@ -86,10 +102,10 @@ const runtimeValueConfig = Config.all({
   ),
   actualPayee: Config.string("ACTUAL_PAYEE").pipe(Config.withDefault("Fintual")),
   fintualUserEmail: Config.string("FINTUAL_USER_EMAIL"),
-  fintualUserPassword: Config.string("FINTUAL_USER_PASSWORD"),
+  fintualUserPassword: Config.redacted("FINTUAL_USER_PASSWORD"),
   fintualGoalId: Config.string("FINTUAL_GOAL_ID"),
   gmailUserEmail: Config.option(Config.string("GMAIL_USER_EMAIL")),
-  gmailAppPassword: Config.option(Config.string("GMAIL_APP_PASSWORD")),
+  gmailAppPassword: Config.option(Config.redacted("GMAIL_APP_PASSWORD")),
 })
 
 const email2FAValueConfig = Config.all({
@@ -106,30 +122,44 @@ const email2FAValueConfig = Config.all({
 
 function resolveEmail2FAConfig(
   provider: ConfigProvider.ConfigProvider,
-  userEmail: string,
-  appPassword: string,
-): Effect.Effect<Email2FAConfig | null, Error> {
-  if (!userEmail && !appPassword) {
+  userEmail: Option.Option<string>,
+  appPassword: Option.Option<Redacted.Redacted<string>>,
+): Effect.Effect<Email2FAConfig | null, RuntimeConfigError> {
+  if (Option.isNone(userEmail) && Option.isNone(appPassword)) {
     return Effect.succeed(null)
   }
 
-  const missingName = userEmail ? "GMAIL_APP_PASSWORD" : "GMAIL_USER_EMAIL"
-  if (!userEmail || !appPassword) {
-    return Effect.fail(new Error(`Missing environment variables: ${missingName}`))
+  if (Option.isNone(userEmail)) {
+    return missingEmail2FACredential("GMAIL_USER_EMAIL")
+  }
+
+  if (Option.isNone(appPassword)) {
+    return missingEmail2FACredential("GMAIL_APP_PASSWORD")
   }
 
   return email2FAValueConfig.pipe(
     Effect.provideService(ConfigProvider.ConfigProvider, provider),
-    Effect.mapError((cause) => new Error(cause.message)),
+    Effect.mapError(
+      (cause) =>
+        new RuntimeConfigError({
+          message: cause.message,
+          cause,
+        }),
+    ),
     Effect.map((values) => ({
-      userEmail,
-      appPassword,
+      userEmail: userEmail.value,
+      appPassword: appPassword.value,
       host: values.gmailImapHost,
       port: values.gmailImapPort,
       debug: values.gmailImapDebug,
       sender: values.fintual2FASender,
     })),
   )
+}
+
+function missingEmail2FACredential(name: string): Effect.Effect<never, RuntimeConfigError> {
+  const cause = new Error(`Missing environment variables: ${name}`)
+  return Effect.fail(new RuntimeConfigError({ message: cause.message, cause }))
 }
 
 function normalizeEnvValue(value: string): string {

--- a/src/fintual/email-2fa-client.ts
+++ b/src/fintual/email-2fa-client.ts
@@ -1,7 +1,7 @@
 import { Effect, Predicate, Schema } from "effect"
 import { ImapFlow, type SearchObject } from "imapflow"
 import type { Email2FAConfig } from "../env.ts"
-import { getErrorMessage, toError } from "../log.ts"
+import { getErrorMessage, revealSecret, toError } from "../log.ts"
 
 export interface ImapMailboxLock {
   release(): void
@@ -122,7 +122,7 @@ export function createImapClient(config: Email2FAConfig): ImapClient {
       secure: true,
       auth: {
         user: config.userEmail,
-        pass: config.appPassword,
+        pass: revealSecret(config.appPassword),
       },
       logger: false,
     }),

--- a/src/fintual/email-2fa/retrieve.test.ts
+++ b/src/fintual/email-2fa/retrieve.test.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Exit, Fiber, Option } from "effect"
+import { Cause, Effect, Exit, Fiber, Option, Redacted } from "effect"
 import { TestClock } from "effect/testing"
 import { describe, expect, test } from "vitest"
 import type { SearchObject } from "imapflow"
@@ -23,7 +23,7 @@ const AFTER_TIMESTAMP = new Date("2026-07-14T10:30:00")
 
 const NON_GMAIL_CONFIG: Email2FAConfig = {
   userEmail: "investor@example.com",
-  appPassword: "app-password",
+  appPassword: Redacted.make("app-password"),
   host: "imap.example.com",
   port: 993,
   debug: false,

--- a/src/fintual/performance.test.ts
+++ b/src/fintual/performance.test.ts
@@ -1,6 +1,6 @@
-import { Effect } from "effect"
+import { Effect, Redacted } from "effect"
 import { describe, expect, test } from "vitest"
-import { FintualConfigService } from "../env.ts"
+import { FintualConfigService, type FintualConfig } from "../env.ts"
 import { SnapshotWriter, type PerformanceSnapshot } from "../performance-snapshot.ts"
 import { FetchService } from "./authenticated-ingestion.ts"
 import { Email2FAService } from "./email-2fa.ts"
@@ -8,13 +8,13 @@ import { Email2FACode, Operational, TimedOut } from "./email-2fa/retrieve.ts"
 import { SnapshotWriteFailure } from "./fintual-error.ts"
 import { FintualPerformance } from "./performance.ts"
 
-const CONFIG = {
+const CONFIG: FintualConfig = {
   email: "investor@example.com",
-  password: "secret-password",
+  password: Redacted.make("secret-password"),
   goalId: "goal-123",
   email2FA: {
     userEmail: "inbox@example.com",
-    appPassword: "app-password",
+    appPassword: Redacted.make("app-password"),
     host: "imap.example.com",
     port: 993,
     debug: false,
@@ -25,7 +25,7 @@ const CONFIG = {
 interface TestOverrides {
   get2FACode?: Email2FAService["Service"]["get2FACode"]
   write?: SnapshotWriter["Service"]["write"]
-  config?: typeof CONFIG | (Omit<typeof CONFIG, "email2FA"> & { email2FA: null })
+  config?: FintualConfig
 }
 
 function performanceProgram(script: FetchScript, overrides: TestOverrides = {}) {
@@ -66,6 +66,7 @@ test("returns a validated Performance Snapshot after direct login", async () => 
   })
   expect(written).toEqual([snapshot])
   expect(script.requests).toHaveLength(4)
+  expect(requestBody(script.requests[1])).toContain('"password":"secret-password"')
   expect(requestBody(script.requests[2])).toMatch(/"timeIntervalCode":"last_six_months"/)
   expect(requestBody(script.requests[3])).toMatch(/"timeIntervalCode":"last_month"/)
 })
@@ -91,6 +92,8 @@ test("completes email 2FA before it requests Goal Performance Data", async () =>
 
   expect(snapshot.balance).toHaveLength(1)
   expect(codeRequests).toBe(1)
+  expect(requestBody(script.requests[1])).toContain('"password":"secret-password"')
+  expect(requestBody(script.requests[2])).toContain('"password":"secret-password"')
   expect(requestBody(script.requests[2])).toMatch(/"code":"123456"/)
   expect(script.requests[3]?.url ?? "").toMatch(/\/gql\/$/)
 })

--- a/src/fintual/performance.ts
+++ b/src/fintual/performance.ts
@@ -1,6 +1,6 @@
 import { Context, DateTime, Effect, Layer } from "effect"
 import { FintualConfigService, type FintualConfig } from "../env.ts"
-import { getErrorMessage } from "../log.ts"
+import { getErrorMessage, revealSecret } from "../log.ts"
 import {
   SnapshotWriter,
   validatePerformanceSnapshot,
@@ -123,7 +123,7 @@ const authenticate = Effect.fn("authenticate")(function* (
         "Content-Type": "application/json",
         Referer: `${FINTUAL_ORIGIN}/f/sign-in/`,
       },
-      body: JSON.stringify({ email: config.email, password: config.password }),
+      body: JSON.stringify({ email: config.email, password: revealSecret(config.password) }),
     },
     "Fintual login",
   )
@@ -174,7 +174,11 @@ const authenticate = Effect.fn("authenticate")(function* (
         "Content-Type": "application/json",
         Referer: `${FINTUAL_ORIGIN}/f/sign-in/`,
       },
-      body: JSON.stringify({ email: config.email, password: config.password, code }),
+      body: JSON.stringify({
+        email: config.email,
+        password: revealSecret(config.password),
+        code,
+      }),
     },
     EMAIL_2FA_STAGE,
   )

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,9 +1,11 @@
 import { Effect } from "effect"
 import { main as mainActual } from "./actual.ts"
+import type { ActualError } from "./actual.ts"
 import { FintualConfigService, type RuntimeConfig } from "./env.ts"
+import type { FintualError } from "./fintual/fintual-error.ts"
 import { FintualPerformance } from "./fintual/performance.ts"
 
-export function runJob(config: RuntimeConfig): Effect.Effect<void, Error> {
+export function runJob(config: RuntimeConfig): Effect.Effect<void, ActualError | FintualError> {
   return Effect.gen(function* () {
     yield* Effect.logInfo("Running job...")
     const snapshot = yield* Effect.gen(function* () {

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,20 +1,28 @@
 import { inspect } from "node:util"
+import { Redacted } from "effect"
 import type { RuntimeConfig } from "./env.ts"
 
-let configuredRedactionSecrets: string[] = []
+let configuredRedactionSecrets = new Set<string>()
 
 export function configureSensitiveValues(config: RuntimeConfig): void {
-  configuredRedactionSecrets = [
-    config.actual.password,
-    config.actual.serverUrl,
-    config.actual.syncId,
-    config.actual.fintualAccount,
-    config.fintual.email,
-    config.fintual.password,
-    config.fintual.goalId,
-    config.fintual.email2FA?.userEmail,
-    config.fintual.email2FA?.appPassword,
-  ].filter((value): value is string => Boolean(value))
+  configuredRedactionSecrets = new Set(
+    [
+      config.actual.serverUrl,
+      config.actual.syncId,
+      config.actual.fintualAccount,
+      config.fintual.email,
+      config.fintual.goalId,
+      config.fintual.email2FA?.userEmail,
+    ].filter((value): value is string => Boolean(value)),
+  )
+}
+
+export function revealSecret(secret: Redacted.Redacted<string>): string {
+  const value = Redacted.value(secret)
+  if (value) {
+    configuredRedactionSecrets.add(value)
+  }
+  return value
 }
 
 export function getErrorMessage(error: unknown): string {

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -1,7 +1,7 @@
-import { Cause, Console, Effect, Logger } from "effect"
+import { Cause, Console, Effect, Logger, Redacted } from "effect"
 import { describe, expect, it } from "vitest"
 import type { RuntimeConfig } from "./env.ts"
-import { configureSensitiveValues } from "./log.ts"
+import { configureSensitiveValues, redactSensitiveText, revealSecret } from "./log.ts"
 import { redactingLogger, reportUnhandledFailure } from "./once.ts"
 
 const secret = "hunter2-super-secret"
@@ -9,7 +9,7 @@ const secret = "hunter2-super-secret"
 const runtimeConfig: RuntimeConfig = {
   actual: {
     serverUrl: "http://localhost:5006",
-    password: secret,
+    password: Redacted.make(secret),
     syncId: "sync-1",
     fintualAccount: "fintual-account",
     startingDate: "2024-03-01",
@@ -17,10 +17,15 @@ const runtimeConfig: RuntimeConfig = {
   },
   fintual: {
     email: "user@example.com",
-    password: "fintual-pass",
+    password: Redacted.make("fintual-pass"),
     goalId: "goal-42",
     email2FA: null,
   },
+}
+
+function configureLoggingSecrets(): void {
+  configureSensitiveValues(runtimeConfig)
+  revealSecret(runtimeConfig.actual.password)
 }
 
 function captureConsole(lines: Array<string>): Console.Console {
@@ -47,9 +52,18 @@ function captureConsole(lines: Array<string>): Console.Console {
   }
 }
 
+it("registers redacted credentials when an adapter reveals them", () => {
+  configureSensitiveValues(runtimeConfig)
+  expect(redactSensitiveText(secret)).toBe(secret)
+
+  revealSecret(runtimeConfig.actual.password)
+
+  expect(redactSensitiveText(secret)).toBe("[redacted]")
+})
+
 describe("redactingLogger", () => {
   it("renders timestamped, level-prefixed lines with sensitive values redacted", async () => {
-    configureSensitiveValues(runtimeConfig)
+    configureLoggingSecrets()
     const lines: Array<string> = []
     const program = Effect.gen(function* () {
       yield* Effect.logInfo(`Connecting with password ${secret}`)
@@ -74,7 +88,7 @@ describe("redactingLogger", () => {
   })
 
   it("redacts annotation values", async () => {
-    configureSensitiveValues(runtimeConfig)
+    configureLoggingSecrets()
     const lines: Array<string> = []
     const program = Effect.gen(function* () {
       yield* Effect.logInfo("creating goal").pipe(Effect.annotateLogs({ goalId: "goal-42" }))
@@ -94,7 +108,7 @@ describe("redactingLogger", () => {
   })
 
   it("redacts secrets split across message parts", async () => {
-    configureSensitiveValues(runtimeConfig)
+    configureLoggingSecrets()
     const lines: Array<string> = []
     const program = Effect.gen(function* () {
       yield* Effect.logInfo("password is", secret, "on", "goal-42")
@@ -116,7 +130,7 @@ describe("redactingLogger", () => {
 
 describe("reportUnhandledFailure", () => {
   it("reports non-interrupt failures through the redacting logger", async () => {
-    configureSensitiveValues(runtimeConfig)
+    configureLoggingSecrets()
     const lines: Array<string> = []
     const program = Effect.fail(new Error(`unexpected ${secret}`)).pipe(
       Effect.tapCause(reportUnhandledFailure),
@@ -136,7 +150,7 @@ describe("reportUnhandledFailure", () => {
   })
 
   it("stays silent for interrupt-only causes", async () => {
-    configureSensitiveValues(runtimeConfig)
+    configureLoggingSecrets()
     const lines: Array<string> = []
     const program = Effect.interrupt.pipe(
       Effect.tapCause(reportUnhandledFailure),

--- a/src/once.ts
+++ b/src/once.ts
@@ -2,19 +2,23 @@ import { pathToFileURL } from "node:url"
 import { NodeRuntime } from "@effect/platform-node"
 import { config as loadDotEnv } from "dotenv"
 import { Array as EffectArray, Cause, Effect, Formatter, Logger, References } from "effect"
-import { resolveRuntimeConfig } from "./env.ts"
+import { resolveRuntimeConfig, type RuntimeConfigError } from "./env.ts"
+import type { ActualError } from "./actual.ts"
+import type { FintualError } from "./fintual/fintual-error.ts"
 import { runJob } from "./job.ts"
 import { configureSensitiveValues, redactSensitiveText } from "./log.ts"
 
 loadDotEnv()
 
-const main: Effect.Effect<void, Error> = Effect.gen(function* () {
-  const runtimeConfig = yield* resolveRuntimeConfig(process.env)
-  configureSensitiveValues(runtimeConfig)
-  yield* Effect.logInfo("Running task once...")
-  yield* runJob(runtimeConfig)
-  yield* Effect.logInfo("Task completed.")
-})
+const main: Effect.Effect<void, RuntimeConfigError | ActualError | FintualError> = Effect.gen(
+  function* () {
+    const runtimeConfig = yield* resolveRuntimeConfig(process.env)
+    configureSensitiveValues(runtimeConfig)
+    yield* Effect.logInfo("Running task once...")
+    yield* runJob(runtimeConfig)
+    yield* Effect.logInfo("Task completed.")
+  },
+)
 
 export const redactingLogger = Logger.withLeveledConsole(
   Logger.make(({ cause, date, fiber, logLevel, message }) => {


### PR DESCRIPTION
## Summary

- decode Actual, Fintual, and Gmail app credentials as Effect Redacted values
- preserve optional Gmail credential presence and expose typed RuntimeConfigError failures
- reveal credentials only at the Actual, Fintual, and IMAP adapter boundaries while registering them with the redacting logger
- preserve the Actual and Fintual typed failure unions through runJob and amend the redaction ADR

Fixes #315

## Verification

- pnpm typecheck
- pnpm test
- pnpm lint
- pnpm format:check
- pnpm fallow:audit