### PR TITLE
refactor: name Effect workflows and runtime utilities

### DIFF
--- a/.agents/friction-log/20260811145903-fallow-audit-flags/friction.md
+++ b/.agents/friction-log/20260811145903-fallow-audit-flags/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Fallow audit flags a public Environment type after Effect.fn refactoring'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The audit should recognize a public type that remains the parameter type of an exported function.
+
+## Current Behavior
+
+After resolveRuntimeConfig is converted to a named Effect.fn workflow, pnpm fallow:audit reports the exported Environment type as unused even though resolveRuntimeConfig still accepts it publicly.
+
+## Possible Solution
+
+Improve Fallow type-use analysis for function parameters wrapped by Effect.fn, or document the intentional test reference needed to preserve the public contract.
+
+## Minimal Reproducible Example
+
+Convert resolveRuntimeConfig from an exported function returning Effect.gen to an exported Effect.fn and run pnpm fallow:audit.
+
+## Context
+
+Observed while implementing issue 316 from origin/main at ce7800f.

--- a/.agents/friction-log/20260811145903-fallow-audit-rejects/friction.md
+++ b/.agents/friction-log/20260811145903-fallow-audit-rejects/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Fallow audit rejects valid dependency entry patterns'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The Fallow audit should parse the repository dependency entry patterns without warnings.
+
+## Current Behavior
+
+pnpm fallow:audit emits repeated warnings that the configured patterns pkg.dependencies?.[at-actual-app-api] and pkg.devDependencies?.[at-actual-app-api] are invalid globs, even though the audit continues.
+
+## Possible Solution
+
+Update the Fallow configuration to use syntax accepted by the current Fallow version.
+
+## Minimal Reproducible Example
+
+Run pnpm fallow:audit from a clean checkout of origin/main.
+
+## Context
+
+Observed while verifying issue 316 on origin/main at ce7800f.

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -187,15 +187,17 @@ const resolvePayeeId = Effect.fn("ActualSynchronization.resolvePayeeId")(functio
   return payee.id
 })
 
-function closeActualClient(client: ActualClient): Effect.Effect<void> {
-  return client
+const closeActualClient = Effect.fn("ActualSynchronization.closeClient")(function* (
+  client: ActualClient,
+): Effect.fn.Return<void> {
+  yield* client
     .shutdown()
     .pipe(
       Effect.catch((cause) =>
         Effect.logWarning(`Failed to shutdown Actual API: ${getErrorMessage(cause)}`),
       ),
     )
-}
+})
 
 export function main(
   config: ActualConfig,

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,8 +1,8 @@
 import { Effect, Redacted, Result } from "effect"
 import { expect, test } from "vitest"
-import { resolveRuntimeConfig, RuntimeConfigError } from "./env.ts"
+import { resolveRuntimeConfig, RuntimeConfigError, type Environment } from "./env.ts"
 
-function requiredEnvironment(): Record<string, string> {
+function requiredEnvironment(): Environment {
   return {
     ACTUAL_SERVER_URL: " https://actual.example.test ",
     ACTUAL_PASSWORD: " 'actual password' ",

--- a/src/env.ts
+++ b/src/env.ts
@@ -44,54 +44,52 @@ export interface RuntimeConfig {
 
 export type Environment = Readonly<Record<string, string | undefined>>
 
-export function resolveRuntimeConfig(
+export const resolveRuntimeConfig = Effect.fn("RuntimeConfig.resolveRuntimeConfig")(function* (
   environment: Environment,
-): Effect.Effect<RuntimeConfig, RuntimeConfigError> {
-  return Effect.gen(function* () {
-    const provider = ConfigProvider.fromUnknown(
-      Object.fromEntries(
-        Object.entries(environment).flatMap(([name, value]) =>
-          value === undefined || (value === "" && !isGmailCredential(name))
-            ? []
-            : [[name, normalizeEnvValue(value)]],
-        ),
+): Effect.fn.Return<RuntimeConfig, RuntimeConfigError> {
+  const provider = ConfigProvider.fromUnknown(
+    Object.fromEntries(
+      Object.entries(environment).flatMap(([name, value]) =>
+        value === undefined || (value === "" && !isGmailCredential(name))
+          ? []
+          : [[name, normalizeEnvValue(value)]],
       ),
-      { preserveEmptyStrings: true },
-    )
-    const values = yield* runtimeValueConfig.pipe(
-      Effect.provideService(ConfigProvider.ConfigProvider, provider),
-      Effect.mapError(
-        (cause) =>
-          new RuntimeConfigError({
-            message: cause.message,
-            cause,
-          }),
-      ),
-    )
-    const email2FA = yield* resolveEmail2FAConfig(
-      provider,
-      values.gmailUserEmail,
-      values.gmailAppPassword,
-    )
+    ),
+    { preserveEmptyStrings: true },
+  )
+  const values = yield* runtimeValueConfig.pipe(
+    Effect.provideService(ConfigProvider.ConfigProvider, provider),
+    Effect.mapError(
+      (cause) =>
+        new RuntimeConfigError({
+          message: cause.message,
+          cause,
+        }),
+    ),
+  )
+  const email2FA = yield* resolveEmail2FAConfig(
+    provider,
+    values.gmailUserEmail,
+    values.gmailAppPassword,
+  )
 
-    return {
-      actual: {
-        serverUrl: values.actualServerUrl,
-        password: values.actualPassword,
-        syncId: values.actualSyncId,
-        fintualAccount: values.actualFintualAccount,
-        startingDate: values.actualStartingDate,
-        payee: values.actualPayee,
-      },
-      fintual: {
-        email: values.fintualUserEmail,
-        password: values.fintualUserPassword,
-        goalId: values.fintualGoalId,
-        email2FA,
-      },
-    }
-  })
-}
+  return {
+    actual: {
+      serverUrl: values.actualServerUrl,
+      password: values.actualPassword,
+      syncId: values.actualSyncId,
+      fintualAccount: values.actualFintualAccount,
+      startingDate: values.actualStartingDate,
+      payee: values.actualPayee,
+    },
+    fintual: {
+      email: values.fintualUserEmail,
+      password: values.fintualUserPassword,
+      goalId: values.fintualGoalId,
+      email2FA,
+    },
+  }
+})
 
 const runtimeValueConfig = Config.all({
   actualServerUrl: Config.string("ACTUAL_SERVER_URL"),
@@ -122,24 +120,24 @@ const email2FAValueConfig = Config.all({
   ),
 })
 
-function resolveEmail2FAConfig(
+const resolveEmail2FAConfig = Effect.fn("RuntimeConfig.resolveEmail2FAConfig")(function* (
   provider: ConfigProvider.ConfigProvider,
   userEmail: Option.Option<string>,
   appPassword: Option.Option<Redacted.Redacted<string>>,
-): Effect.Effect<Email2FAConfig | null, RuntimeConfigError> {
+): Effect.fn.Return<Email2FAConfig | null, RuntimeConfigError> {
   if (Option.isNone(userEmail) && Option.isNone(appPassword)) {
-    return Effect.succeed(null)
+    return null
   }
 
   if (Option.isNone(userEmail)) {
-    return missingEmail2FACredential("GMAIL_USER_EMAIL")
+    return yield* missingEmail2FACredential("GMAIL_USER_EMAIL")
   }
 
   if (Option.isNone(appPassword)) {
-    return missingEmail2FACredential("GMAIL_APP_PASSWORD")
+    return yield* missingEmail2FACredential("GMAIL_APP_PASSWORD")
   }
 
-  return email2FAValueConfig.pipe(
+  return yield* email2FAValueConfig.pipe(
     Effect.provideService(ConfigProvider.ConfigProvider, provider),
     Effect.mapError(
       (cause) =>
@@ -157,7 +155,7 @@ function resolveEmail2FAConfig(
       sender: values.fintual2FASender,
     })),
   )
-}
+})
 
 function missingEmail2FACredential(name: string): Effect.Effect<never, RuntimeConfigError> {
   const cause = new Error(`Missing environment variables: ${name}`)

--- a/src/fintual/email-2fa-client.ts
+++ b/src/fintual/email-2fa-client.ts
@@ -49,69 +49,90 @@ export class ImapFlowClient implements ImapClient {
     return this.raw.usable
   }
 
-  connect(): Effect.Effect<void, Error> {
-    return Effect.tryPromise({
-      try: () => this.raw.connect(),
-      catch: (error) => toError(error, "Failed to connect to Gmail IMAP"),
-    })
-  }
+  readonly connect = Effect.fn("Email2FA.ImapFlowClient.connect")(
+    { self: this },
+    function* (this: ImapFlowClient): Effect.fn.Return<void, Error> {
+      yield* Effect.tryPromise({
+        try: () => this.raw.connect(),
+        catch: (error) => toError(error, "Failed to connect to Gmail IMAP"),
+      })
+    },
+  )
 
-  getMailboxLock(path: string): Effect.Effect<ImapMailboxLock, Error | MissingMailbox> {
-    return Effect.tryPromise({
-      try: () => this.raw.getMailboxLock(path),
-      catch: (cause) =>
-        Predicate.isObject(cause) && cause.mailboxMissing === true
-          ? new MissingMailbox({ path, cause })
-          : new Error(`Failed to lock Gmail IMAP mailbox ${path}: ${getErrorMessage(cause)}`, {
-              cause,
-            }),
-    })
-  }
+  readonly getMailboxLock = Effect.fn("Email2FA.ImapFlowClient.getMailboxLock")(
+    { self: this },
+    function* (
+      this: ImapFlowClient,
+      path: string,
+    ): Effect.fn.Return<ImapMailboxLock, Error | MissingMailbox> {
+      return yield* Effect.tryPromise({
+        try: () => this.raw.getMailboxLock(path),
+        catch: (cause) =>
+          Predicate.isObject(cause) && cause.mailboxMissing === true
+            ? new MissingMailbox({ path, cause })
+            : new Error(`Failed to lock Gmail IMAP mailbox ${path}: ${getErrorMessage(cause)}`, {
+                cause,
+              }),
+      })
+    },
+  )
 
-  search(query: SearchObject): Effect.Effect<number[] | false, Error | MissingServerExtension> {
-    return Effect.tryPromise({
-      try: () => this.raw.search(query, { uid: true }),
-      catch: (cause) => {
-        // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
-        const originalError = cause as { code?: string } | undefined
-        if (originalError?.code === "MissingServerExtension") {
-          return new MissingServerExtension({ cause })
-        }
-        return new Error(`Failed to search Gmail IMAP mailbox: ${getErrorMessage(cause)}`, {
-          cause,
-        })
-      },
-    })
-  }
+  readonly search = Effect.fn("Email2FA.ImapFlowClient.search")(
+    { self: this },
+    function* (
+      this: ImapFlowClient,
+      query: SearchObject,
+    ): Effect.fn.Return<number[] | false, Error | MissingServerExtension> {
+      return yield* Effect.tryPromise({
+        try: () => this.raw.search(query, { uid: true }),
+        catch: (cause) => {
+          // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+          const originalError = cause as { code?: string } | undefined
+          if (originalError?.code === "MissingServerExtension") {
+            return new MissingServerExtension({ cause })
+          }
+          return new Error(`Failed to search Gmail IMAP mailbox: ${getErrorMessage(cause)}`, {
+            cause,
+          })
+        },
+      })
+    },
+  )
 
-  fetchOne(uid: number): Effect.Effect<ImapMessage | null, Error> {
-    return Effect.map(
-      Effect.tryPromise({
-        try: () =>
-          this.raw.fetchOne(
-            String(uid),
-            { source: true, envelope: true, internalDate: true },
-            { uid: true },
-          ),
-        catch: (error) => toError(error, "Failed to fetch Gmail IMAP message"),
-      }),
-      (message) =>
-        message
-          ? {
-              source: message.source,
-              envelope: message.envelope ? { subject: message.envelope.subject } : undefined,
-              internalDate: message.internalDate,
-            }
-          : null,
-    )
-  }
+  readonly fetchOne = Effect.fn("Email2FA.ImapFlowClient.fetchOne")(
+    { self: this },
+    function* (this: ImapFlowClient, uid: number): Effect.fn.Return<ImapMessage | null, Error> {
+      return yield* Effect.map(
+        Effect.tryPromise({
+          try: () =>
+            this.raw.fetchOne(
+              String(uid),
+              { source: true, envelope: true, internalDate: true },
+              { uid: true },
+            ),
+          catch: (error) => toError(error, "Failed to fetch Gmail IMAP message"),
+        }),
+        (message) =>
+          message
+            ? {
+                source: message.source,
+                envelope: message.envelope ? { subject: message.envelope.subject } : undefined,
+                internalDate: message.internalDate,
+              }
+            : null,
+      )
+    },
+  )
 
-  logout(): Effect.Effect<void, Error> {
-    return Effect.tryPromise({
-      try: () => this.raw.logout(),
-      catch: (error) => toError(error, "Failed to close IMAP connection cleanly"),
-    })
-  }
+  readonly logout = Effect.fn("Email2FA.ImapFlowClient.logout")(
+    { self: this },
+    function* (this: ImapFlowClient): Effect.fn.Return<void, Error> {
+      yield* Effect.tryPromise({
+        try: () => this.raw.logout(),
+        catch: (error) => toError(error, "Failed to close IMAP connection cleanly"),
+      })
+    },
+  )
 }
 
 export function createImapClient(config: Email2FAConfig): ImapClient {

--- a/src/fintual/email-2fa/email-2fa-policy.ts
+++ b/src/fintual/email-2fa/email-2fa-policy.ts
@@ -33,28 +33,26 @@ export function buildEmail2FASearchQueries(
   return queries
 }
 
-export function selectEmail2FACode(
+export const selectEmail2FACode = Effect.fn("Email2FA.selectEmail2FACode")(function* (
   candidates: Iterable<Email2FACandidate>,
   afterTimestamp: Date,
-): Effect.Effect<string | null, Error> {
-  return Effect.gen(function* () {
-    for (const candidate of candidates) {
-      if (candidate.receivedAt && candidate.receivedAt < afterTimestamp) {
-        continue
-      }
-
-      const sources = yield* collectMessageSources(candidate)
-      for (const source of sources) {
-        const code = extractCodeFromText(source)
-        if (code) {
-          return code
-        }
-      }
+): Effect.fn.Return<string | null, Error> {
+  for (const candidate of candidates) {
+    if (candidate.receivedAt && candidate.receivedAt < afterTimestamp) {
+      continue
     }
 
-    return null
-  })
-}
+    const sources = yield* collectMessageSources(candidate)
+    for (const source of sources) {
+      const code = extractCodeFromText(source)
+      if (code) {
+        return code
+      }
+    }
+  }
+
+  return null
+})
 
 export function isGmailImapHost(host: string): boolean {
   const normalized = host.trim().toLowerCase()
@@ -69,30 +67,30 @@ function formatGmailAfterDate(date: Date): string {
   return `${yyyy}/${mm}/${dd}`
 }
 
-function collectMessageSources(candidate: Email2FACandidate): Effect.Effect<string[], Error> {
-  return Effect.gen(function* () {
-    const sources: string[] = []
-    if (candidate.envelopeSubject) {
-      sources.push(candidate.envelopeSubject)
-    }
+const collectMessageSources = Effect.fn("Email2FA.collectMessageSources")(function* (
+  candidate: Email2FACandidate,
+): Effect.fn.Return<string[], Error> {
+  const sources: string[] = []
+  if (candidate.envelopeSubject) {
+    sources.push(candidate.envelopeSubject)
+  }
 
-    const parsedMessage = yield* Effect.tryPromise({
-      try: () => simpleParser(Buffer.from(candidate.source)),
-      catch: (error) => toError(error, "Failed to parse Gmail IMAP message"),
-    })
-    if (parsedMessage.subject) {
-      sources.push(parsedMessage.subject)
-    }
-    if (parsedMessage.text) {
-      sources.push(parsedMessage.text)
-    }
-    if (parsedMessage.html) {
-      sources.push(String(parsedMessage.html))
-    }
-
-    return sources
+  const parsedMessage = yield* Effect.tryPromise({
+    try: () => simpleParser(Buffer.from(candidate.source)),
+    catch: (error) => toError(error, "Failed to parse Gmail IMAP message"),
   })
-}
+  if (parsedMessage.subject) {
+    sources.push(parsedMessage.subject)
+  }
+  if (parsedMessage.text) {
+    sources.push(parsedMessage.text)
+  }
+  if (parsedMessage.html) {
+    sources.push(String(parsedMessage.html))
+  }
+
+  return sources
+})
 
 function decodeQuotedPrintable(value: string): string {
   return (

--- a/src/fintual/email-2fa/retrieve.ts
+++ b/src/fintual/email-2fa/retrieve.ts
@@ -119,15 +119,17 @@ const connectImapClient = Effect.fn("Email2FA.connectImapClient")(function* (
   return imapClient
 })
 
-function closeImapClient(imapClient: ImapClient): Effect.Effect<void, never> {
+const closeImapClient = Effect.fn("Email2FA.closeImapClient")(function* (
+  imapClient: ImapClient,
+): Effect.fn.Return<void> {
   if (!imapClient.usable) {
-    return Effect.void
+    return
   }
 
-  return Effect.catch(imapClient.logout(), (cause) =>
+  yield* Effect.catch(imapClient.logout(), (cause) =>
     Effect.logWarning(`Failed to close IMAP connection cleanly: ${getErrorMessage(cause)}`),
   )
-}
+})
 
 const logPollWait = Effect.fn("Email2FA.logPollWait")(function* (
   startedAt: number,

--- a/src/fintual/email-2fa/retrieve.ts
+++ b/src/fintual/email-2fa/retrieve.ts
@@ -56,17 +56,17 @@ export const ImapClientFactoryLive = Layer.succeed(ImapClientFactory, {
 
 const toOperational = (cause: unknown): Operational => new Operational({ cause })
 
-export function retrieveEmail2FACode(
+export const retrieveEmail2FACode = Effect.fn("Email2FA.retrieveEmail2FACode")(function* (
   config: Email2FAConfig,
   options: Email2FAOptions,
-): Effect.Effect<Email2FACode, TimedOut | Operational, ImapClientFactory> {
+): Effect.fn.Return<Email2FACode, TimedOut | Operational, ImapClientFactory> {
   const {
     afterTimestamp,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
   } = options
 
-  return Effect.scoped(
+  return yield* Effect.scoped(
     Effect.gen(function* () {
       yield* Effect.logInfo("Connecting to Gmail IMAP for automatic 2FA retrieval...")
       const clientFactory = yield* ImapClientFactory
@@ -108,18 +108,16 @@ export function retrieveEmail2FACode(
         : Effect.void,
     ),
   )
-}
+})
 
-function connectImapClient(
+const connectImapClient = Effect.fn("Email2FA.connectImapClient")(function* (
   clientFactory: ImapClientFactory["Service"],
   config: Email2FAConfig,
-): Effect.Effect<ImapClient, Error> {
-  return Effect.gen(function* () {
-    const imapClient = clientFactory.create(config)
-    yield* imapClient.connect()
-    return imapClient
-  })
-}
+): Effect.fn.Return<ImapClient, Error> {
+  const imapClient = clientFactory.create(config)
+  yield* imapClient.connect()
+  return imapClient
+})
 
 function closeImapClient(imapClient: ImapClient): Effect.Effect<void, never> {
   if (!imapClient.usable) {
@@ -131,37 +129,35 @@ function closeImapClient(imapClient: ImapClient): Effect.Effect<void, never> {
   )
 }
 
-function logPollWait(startedAt: number): Effect.Effect<void> {
-  return Effect.gen(function* () {
-    const now = yield* Clock.currentTimeMillis
-    const elapsedSeconds = Math.round((now - startedAt) / 1000)
-    yield* Effect.logDebug(`Waiting for 2FA email... (${elapsedSeconds}s elapsed)`)
-  })
-}
+const logPollWait = Effect.fn("Email2FA.logPollWait")(function* (
+  startedAt: number,
+): Effect.fn.Return<void> {
+  const now = yield* Clock.currentTimeMillis
+  const elapsedSeconds = Math.round((now - startedAt) / 1000)
+  yield* Effect.logDebug(`Waiting for 2FA email... (${elapsedSeconds}s elapsed)`)
+})
 
-function pollForCode(
+const pollForCode = Effect.fn("Email2FA.pollForCode")(function* (
   config: Email2FAConfig,
   imapClient: ImapClient,
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
-): Effect.Effect<Option.Option<Email2FACode>, Error> {
-  return Effect.gen(function* () {
-    for (const mailboxPath of imapSearchMailboxes(config)) {
-      const code = yield* searchMailbox(
-        config,
-        imapClient,
-        mailboxPath,
-        afterTimestamp,
-        seenMessageKeys,
-      )
-      if (Option.isSome(code)) {
-        return code
-      }
+): Effect.fn.Return<Option.Option<Email2FACode>, Error> {
+  for (const mailboxPath of imapSearchMailboxes(config)) {
+    const code = yield* searchMailbox(
+      config,
+      imapClient,
+      mailboxPath,
+      afterTimestamp,
+      seenMessageKeys,
+    )
+    if (Option.isSome(code)) {
+      return code
     }
+  }
 
-    return Option.none()
-  })
-}
+  return Option.none()
+})
 
 function imapSearchMailboxes(config: Email2FAConfig): string[] {
   if (isGmailImapHost(config.host)) {
@@ -170,123 +166,115 @@ function imapSearchMailboxes(config: Email2FAConfig): string[] {
   return ["INBOX"]
 }
 
-function searchMailbox(
+const searchMailbox = Effect.fn("Email2FA.searchMailbox")(function* (
   config: Email2FAConfig,
   imapClient: ImapClient,
   mailboxPath: string,
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
-): Effect.Effect<Option.Option<Email2FACode>, Error> {
-  return Effect.gen(function* () {
-    const lock = yield* Effect.catchTag(
-      imapClient.getMailboxLock(mailboxPath),
-      "MissingMailbox",
-      () =>
-        config.debug
-          ? Effect.as(Effect.log(`Gmail IMAP: skip missing mailbox ${mailboxPath}`), undefined)
-          : Effect.succeed(undefined),
-    )
-    if (!lock) {
-      return Option.none()
-    }
+): Effect.fn.Return<Option.Option<Email2FACode>, Error> {
+  const lock = yield* Effect.catchTag(
+    imapClient.getMailboxLock(mailboxPath),
+    "MissingMailbox",
+    () =>
+      config.debug
+        ? Effect.as(Effect.log(`Gmail IMAP: skip missing mailbox ${mailboxPath}`), undefined)
+        : Effect.succeed(undefined),
+  )
+  if (!lock) {
+    return Option.none()
+  }
 
-    return yield* Effect.ensuring(
-      searchLockedMailbox(config, imapClient, mailboxPath, afterTimestamp, seenMessageKeys),
-      Effect.sync(() => lock.release()),
-    )
-  })
-}
+  return yield* Effect.ensuring(
+    searchLockedMailbox(config, imapClient, mailboxPath, afterTimestamp, seenMessageKeys),
+    Effect.sync(() => lock.release()),
+  )
+})
 
-function searchLockedMailbox(
+const searchLockedMailbox = Effect.fn("Email2FA.searchLockedMailbox")(function* (
   config: Email2FAConfig,
   imapClient: ImapClient,
   mailboxPath: string,
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
-): Effect.Effect<Option.Option<Email2FACode>, Error> {
-  return Effect.gen(function* () {
-    const messageUids = yield* runMailboxSearch(config, imapClient, afterTimestamp)
-    if (config.debug) {
-      yield* Effect.log(
-        `Gmail IMAP: ${mailboxPath} search -> ${messageUids === false ? "no match" : `${messageUids.length} uid(s)`}`,
-      )
-    }
-    if (!messageUids) {
-      return Option.none()
-    }
-
-    return yield* extractCodeFromMailboxUids(
-      imapClient,
-      mailboxPath,
-      messageUids,
-      afterTimestamp,
-      seenMessageKeys,
+): Effect.fn.Return<Option.Option<Email2FACode>, Error> {
+  const messageUids = yield* runMailboxSearch(config, imapClient, afterTimestamp)
+  if (config.debug) {
+    yield* Effect.log(
+      `Gmail IMAP: ${mailboxPath} search -> ${messageUids === false ? "no match" : `${messageUids.length} uid(s)`}`,
     )
-  })
-}
+  }
+  if (!messageUids) {
+    return Option.none()
+  }
 
-function runMailboxSearch(
+  return yield* extractCodeFromMailboxUids(
+    imapClient,
+    mailboxPath,
+    messageUids,
+    afterTimestamp,
+    seenMessageKeys,
+  )
+})
+
+const runMailboxSearch = Effect.fn("Email2FA.runMailboxSearch")(function* (
   config: Email2FAConfig,
   imapClient: ImapClient,
   afterTimestamp: Date,
-): Effect.Effect<number[] | false, Error> {
+): Effect.fn.Return<number[] | false, Error> {
   const queries = buildEmail2FASearchQueries(config, afterTimestamp)
 
-  return Effect.gen(function* () {
-    for (const query of queries) {
-      const messageUids = yield* Effect.catchIf(
-        imapClient.search(query),
-        (cause): cause is MissingServerExtension => cause instanceof MissingServerExtension,
-        () => Effect.succeed(false as const),
-      )
-      if (messageUids && messageUids.length > 0) {
-        return messageUids
-      }
+  for (const query of queries) {
+    const messageUids = yield* Effect.catchIf(
+      imapClient.search(query),
+      (cause): cause is MissingServerExtension => cause instanceof MissingServerExtension,
+      () => Effect.succeed(false as const),
+    )
+    if (messageUids && messageUids.length > 0) {
+      return messageUids
     }
+  }
 
-    return false
-  })
-}
+  return false
+})
 
-function extractCodeFromMailboxUids(
+const extractCodeFromMailboxUids = Effect.fn("Email2FA.extractCodeFromMailboxUids")(function* (
   imapClient: ImapClient,
   mailboxPath: string,
   messageUids: number[],
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
-): Effect.Effect<Option.Option<Email2FACode>, Error> {
+): Effect.fn.Return<Option.Option<Email2FACode>, Error> {
   const recentUids = messageUids.slice(-MAX_RESULTS).reverse()
 
-  return Effect.gen(function* () {
-    const candidates: Email2FACandidate[] = []
-    for (const uid of recentUids) {
-      const key = messageSeenKey(mailboxPath, uid)
-      if (seenMessageKeys.has(key)) {
-        continue
-      }
-
-      const message = yield* Effect.catch(imapClient.fetchOne(uid), () => Effect.succeed(null))
-      if (!message || !message.source) {
-        continue
-      }
-      seenMessageKeys.add(key)
-
-      const internalDate =
-        typeof message.internalDate === "string"
-          ? new Date(message.internalDate)
-          : message.internalDate
-      candidates.push({
-        source: message.source,
-        envelopeSubject: message.envelope?.subject,
-        receivedAt: internalDate,
-      })
+  const candidates: Email2FACandidate[] = []
+  for (const uid of recentUids) {
+    const key = messageSeenKey(mailboxPath, uid)
+    if (seenMessageKeys.has(key)) {
+      continue
     }
 
-    return yield* selectEmail2FACode(candidates, afterTimestamp).pipe(
-      Effect.map((code) => (code ? Option.some(Email2FACode.make(code)) : Option.none())),
-    )
-  })
-}
+    const message = yield* Effect.catch(imapClient.fetchOne(uid), () => Effect.succeed(null))
+    if (!message || !message.source) {
+      continue
+    }
+    seenMessageKeys.add(key)
+
+    const internalDate =
+      typeof message.internalDate === "string"
+        ? new Date(message.internalDate)
+        : message.internalDate
+    candidates.push({
+      source: message.source,
+      envelopeSubject: message.envelope?.subject,
+      receivedAt: internalDate,
+    })
+  }
+
+  return yield* selectEmail2FACode(candidates, afterTimestamp).pipe(
+    Effect.map((code) => (code ? Option.some(Email2FACode.make(code)) : Option.none())),
+  )
+})
 
 function messageSeenKey(mailboxPath: string, uid: number): string {
   return `${mailboxPath}:${uid}`

--- a/src/fintual/new-performance.ts
+++ b/src/fintual/new-performance.ts
@@ -63,35 +63,34 @@ const goalPerformanceDataResponseSchema = Schema.Struct({
 
 export type GoalPerformanceData = (typeof goalPerformanceDataResponseSchema.Type)["data"]
 
-export const parseGoalPerformanceResponseBody = Effect.fn("parseGoalPerformanceResponseBody")(
-  function* (body: string): Effect.fn.Return<GoalPerformanceData, Error> {
-    const parsedJson = yield* Effect.try({
-      // oxlint-disable-next-line typescript/consistent-type-assertions
-      try: () => JSON.parse(body) as unknown,
-      catch: (cause) =>
-        new Error(`Failed to parse goal performance response body: ${getErrorMessage(cause)}`, {
+export const parseGoalPerformanceResponseBody = Effect.fn(
+  "FintualPerformance.parseGoalPerformanceResponseBody",
+)(function* (body: string): Effect.fn.Return<GoalPerformanceData, Error> {
+  const parsedJson = yield* Effect.try({
+    // oxlint-disable-next-line typescript/consistent-type-assertions
+    try: () => JSON.parse(body) as unknown,
+    catch: (cause) =>
+      new Error(`Failed to parse goal performance response body: ${getErrorMessage(cause)}`, {
+        cause,
+      }),
+  })
+
+  if (Predicate.isObject(parsedJson) && "errors" in parsedJson) {
+    return yield* Effect.fail(
+      new Error("Failed to validate goal performance data: GraphQL response contains errors"),
+    )
+  }
+
+  return yield* Schema.decodeUnknownEffect(goalPerformanceDataResponseSchema)(parsedJson).pipe(
+    Effect.map((response) => response.data),
+    Effect.mapError(
+      (cause) =>
+        new Error(`Failed to validate goal performance data: ${getValidationFailure(parsedJson)}`, {
           cause,
         }),
-    })
-
-    if (Predicate.isObject(parsedJson) && "errors" in parsedJson) {
-      return yield* Effect.fail(
-        new Error("Failed to validate goal performance data: GraphQL response contains errors"),
-      )
-    }
-
-    return yield* Schema.decodeUnknownEffect(goalPerformanceDataResponseSchema)(parsedJson).pipe(
-      Effect.map((response) => response.data),
-      Effect.mapError(
-        (cause) =>
-          new Error(
-            `Failed to validate goal performance data: ${getValidationFailure(parsedJson)}`,
-            { cause },
-          ),
-      ),
-    )
-  },
-)
+    ),
+  )
+})
 
 function getValidationFailure(parsedJson: unknown): string {
   if (!Predicate.isObject(parsedJson)) {

--- a/src/fintual/performance.ts
+++ b/src/fintual/performance.ts
@@ -92,24 +92,24 @@ export class FintualPerformance extends Context.Service<
   )
 }
 
-function loadSignInPage(session: FetchService["Service"]): Effect.Effect<void, FintualError> {
-  return Effect.gen(function* () {
-    const response = yield* session.request(
-      "/f/sign-in/",
-      {
-        redirect: "follow",
-        headers: {
-          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        },
+const loadSignInPage = Effect.fn("FintualPerformance.loadSignInPage")(function* (
+  session: FetchService["Service"],
+): Effect.fn.Return<void, FintualError> {
+  const response = yield* session.request(
+    "/f/sign-in/",
+    {
+      redirect: "follow",
+      headers: {
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       },
-      "Fintual sign-in page",
-    )
+    },
+    "Fintual sign-in page",
+  )
 
-    yield* readResponseBody(response, "Fintual sign-in page")
-  })
-}
+  yield* readResponseBody(response, "Fintual sign-in page")
+})
 
-const authenticate = Effect.fn("authenticate")(function* (
+const authenticate = Effect.fn("FintualPerformance.authenticate")(function* (
   session: FetchService["Service"],
   email2FAService: Email2FAService["Service"],
   config: FintualConfig,
@@ -189,15 +189,15 @@ const authenticate = Effect.fn("authenticate")(function* (
   }
 })
 
-function fetchGoalPerformanceData(
-  session: FetchService["Service"],
-  goalId: string,
-  timeInterval: GoalPerformanceTimeInterval,
-  purpose: "reference" | "recent",
-): Effect.Effect<GoalPerformanceData, FintualError> {
-  const stage = `Fintual ${purpose} Goal Performance Data`
+const fetchGoalPerformanceData = Effect.fn("FintualPerformance.fetchGoalPerformanceData")(
+  function* (
+    session: FetchService["Service"],
+    goalId: string,
+    timeInterval: GoalPerformanceTimeInterval,
+    purpose: "reference" | "recent",
+  ): Effect.fn.Return<GoalPerformanceData, FintualError> {
+    const stage = `Fintual ${purpose} Goal Performance Data`
 
-  return Effect.gen(function* () {
     const response = yield* session.request(
       "/gql/",
       {
@@ -221,11 +221,14 @@ function fetchGoalPerformanceData(
       parseGoalPerformanceResponseBody(body),
       (cause) => new MalformedGoalPerformanceData({ purpose, cause }),
     )
-  })
-}
+  },
+)
 
-function readResponseBody(response: Response, stage: string): Effect.Effect<string, FintualError> {
-  return Effect.mapError(
+const readResponseBody = Effect.fn("FintualPerformance.readResponseBody")(function* (
+  response: Response,
+  stage: string,
+): Effect.fn.Return<string, FintualError> {
+  return yield* Effect.mapError(
     Effect.tryPromise({
       try: () => response.text(),
       catch: (cause) =>
@@ -233,7 +236,7 @@ function readResponseBody(response: Response, stage: string): Effect.Effect<stri
     }),
     (cause) => new HttpTransportFailure({ stage, cause }),
   )
-}
+})
 
 function failUnexpectedStatus(stage: string, status: number): Effect.Effect<never, FintualError> {
   return Effect.fail(new UnexpectedHttpStatus({ stage, status }))

--- a/src/job.ts
+++ b/src/job.ts
@@ -5,17 +5,17 @@ import { FintualConfigService, type RuntimeConfig } from "./env.ts"
 import type { FintualError } from "./fintual/fintual-error.ts"
 import { FintualPerformance } from "./fintual/performance.ts"
 
-export function runJob(config: RuntimeConfig): Effect.Effect<void, ActualError | FintualError> {
-  return Effect.gen(function* () {
-    yield* Effect.logInfo("Running job...")
-    const snapshot = yield* Effect.gen(function* () {
-      const service = yield* FintualPerformance
-      return yield* service.fetchPerformanceSnapshot()
-    }).pipe(
-      Effect.provide(FintualPerformance.live),
-      Effect.provideService(FintualConfigService, config.fintual),
-    )
-    yield* mainActual(config.actual, snapshot)
-    yield* Effect.logInfo("Job finished.")
-  })
-}
+export const runJob = Effect.fn("Job.runJob")(function* (
+  config: RuntimeConfig,
+): Effect.fn.Return<void, ActualError | FintualError> {
+  yield* Effect.logInfo("Running job...")
+  const snapshot = yield* Effect.gen(function* () {
+    const service = yield* FintualPerformance
+    return yield* service.fetchPerformanceSnapshot()
+  }).pipe(
+    Effect.provide(FintualPerformance.live),
+    Effect.provideService(FintualConfigService, config.fintual),
+  )
+  yield* mainActual(config.actual, snapshot)
+  yield* Effect.logInfo("Job finished.")
+})

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,5 @@
 import { inspect } from "node:util"
-import { Redacted } from "effect"
+import { Predicate, Redacted } from "effect"
 import type { RuntimeConfig } from "./env.ts"
 
 let configuredRedactionSecrets = new Set<string>()
@@ -30,7 +30,7 @@ export function getErrorMessage(error: unknown): string {
     return redactSensitiveText(error.message)
   }
 
-  if (isRecord(error)) {
+  if (Predicate.isObject(error)) {
     const structuredMessage = getStructuredErrorMessage(error)
     if (structuredMessage) {
       return redactSensitiveText(structuredMessage)
@@ -85,8 +85,4 @@ function getStructuredErrorMessage(error: Record<string, unknown>): string {
   }
 
   return parts.join(": ")
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
 }

--- a/src/once.ts
+++ b/src/once.ts
@@ -10,15 +10,16 @@ import { configureSensitiveValues, redactSensitiveText } from "./log.ts"
 
 loadDotEnv()
 
-const main: Effect.Effect<void, RuntimeConfigError | ActualError | FintualError> = Effect.gen(
-  function* () {
-    const runtimeConfig = yield* resolveRuntimeConfig(process.env)
-    configureSensitiveValues(runtimeConfig)
-    yield* Effect.logInfo("Running task once...")
-    yield* runJob(runtimeConfig)
-    yield* Effect.logInfo("Task completed.")
-  },
-)
+const main = Effect.fn("Once.main")(function* (): Effect.fn.Return<
+  void,
+  RuntimeConfigError | ActualError | FintualError
+> {
+  const runtimeConfig = yield* resolveRuntimeConfig(process.env)
+  configureSensitiveValues(runtimeConfig)
+  yield* Effect.logInfo("Running task once...")
+  yield* runJob(runtimeConfig)
+  yield* Effect.logInfo("Task completed.")
+})
 
 export const redactingLogger = Logger.withLeveledConsole(
   Logger.make(({ cause, date, fiber, logLevel, message }) => {
@@ -58,7 +59,7 @@ function isMainModule(): boolean {
 
 if (isMainModule()) {
   NodeRuntime.runMain(
-    main.pipe(
+    main().pipe(
       Effect.tapCause(reportUnhandledFailure),
       Effect.provide(Logger.layer([redactingLogger])),
     ),

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -52,7 +52,7 @@ const performanceSnapshotSchema = Schema.Struct({
 
 export type PerformanceSnapshot = typeof performanceSnapshotSchema.Type
 
-export const validatePerformanceSnapshot = Effect.fn("validatePerformanceSnapshot")(function* (
+export const validatePerformanceSnapshot = Effect.fn("PerformanceSnapshot.validate")(function* (
   snapshot: unknown,
 ): Effect.fn.Return<PerformanceSnapshot, PerformanceSnapshotValidationError> {
   return yield* Schema.decodeUnknownEffect(performanceSnapshotSchema)(snapshot).pipe(
@@ -65,10 +65,10 @@ export const validatePerformanceSnapshot = Effect.fn("validatePerformanceSnapsho
   )
 })
 
-export function writePerformanceSnapshot(
+export const writePerformanceSnapshot = Effect.fn("PerformanceSnapshot.write")(function* (
   snapshot: PerformanceSnapshot,
-): Effect.Effect<void, Error> {
-  return Effect.andThen(
+): Effect.fn.Return<void, Error> {
+  return yield* Effect.andThen(
     Effect.try({
       try: () => {
         fs.mkdirSync(SNAPSHOT_DATA_DIR, { recursive: true })
@@ -81,4 +81,4 @@ export function writePerformanceSnapshot(
     }),
     () => Effect.logInfo(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`),
   )
-}
+})


### PR DESCRIPTION
## Summary

- Name runtime configuration, job, entrypoint, Fintual, snapshot, email 2FA, IMAP adapter, and Actual cleanup workflows with stable domain-qualified Effect.fn spans.
- Replace the remaining project-local record guard with Effect Predicate.isObject.
- Preserve the existing Clock/DateTime and typed error contracts while keeping native Date only at external IMAP or pure reconciliation boundaries.
- Retain public Environment coverage and record the Fallow audit friction encountered during the cleanup.

Closes #316

## Verification

- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm fallow:audit

Fallow reports no issues; it still prints two pre-existing invalid dependency-pattern warnings, which are recorded in the friction log.