### PR TITLE
test: migrate Effect workflows to Effect Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"packageManager": "pnpm@11.20.0",
 	"type": "module",
 	"devDependencies": {
+		"@effect/vitest": "4.0.0-beta.106",
 		"@types/mailparser": "3.4.6",
 		"@types/node": "24.13.3",
 		"fallow": "3.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
         specifier: 3.9.15
         version: 3.9.15
     devDependencies:
+      '@effect/vitest':
+        specifier: 4.0.0-beta.106
+        version: 4.0.0-beta.106(effect@4.0.0-beta.106)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)))
       '@types/mailparser':
         specifier: 3.4.6
         version: 3.4.6
@@ -79,6 +82,12 @@ packages:
     peerDependencies:
       effect: ^4.0.0-beta.106
       ioredis: '>=5.7.0 <6.0.0'
+
+  '@effect/vitest@4.0.0-beta.106':
+    resolution: {integrity: sha512-0w799orFqjFNlKh9GrnzMIJLn2/uPaVu8qmT3hJKkYxS46tUS9ZbfjeYNsd1BddvY+3sdS/vXVpnTE64z6+QaQ==}
+    peerDependencies:
+      effect: ^4.0.0-beta.106
+      vitest: '>=4.1.0 <5.0.0'
 
   '@fallow-cli/darwin-arm64@3.14.0':
     resolution: {integrity: sha512-seaix3OqADcq90PkPOOPrN8Jl7QZDGjFziHA85Ikp+lGSHVjJ2IMyGh/QKLhvi9Q6Ha3Y//F0+PFFGNd0Gi4mw==}
@@ -1530,6 +1539,11 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@effect/vitest@4.0.0-beta.106(effect@4.0.0-beta.106)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)))':
+    dependencies:
+      effect: 4.0.0-beta.106
+      vitest: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3))
 
   '@fallow-cli/darwin-arm64@3.14.0':
     optional: true

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -1,6 +1,7 @@
+import { it } from "@effect/vitest"
 import { Duration, Effect, Fiber, Redacted, Result, Schedule } from "effect"
 import { TestClock } from "effect/testing"
-import { afterEach, expect, test, vi } from "vitest"
+import { afterEach, expect, vi } from "vitest"
 
 const actualApiMock = vi.hoisted(() => ({
   init: vi.fn(),
@@ -60,146 +61,156 @@ const SNAPSHOT: PerformanceSnapshot = {
   ],
 }
 
-test("synchronizes through one service and shuts down the Actual session once", async () => {
-  const calls: string[] = []
-  const client = scriptedClient(calls)
+it.effect("synchronizes through one service and shuts down the Actual session once", () =>
+  Effect.gen(function* () {
+    const calls: string[] = []
+    const client = scriptedClient(calls)
 
-  await Effect.runPromise(synchronizationProgram([client], calls))
+    yield* synchronizationProgram([client], calls)
 
-  expect(calls).toEqual([
-    "reset",
-    "health",
-    "download",
-    "transactions",
-    "payees",
-    "create:2026-01-05",
-    "sync",
-    "shutdown",
-  ])
-})
+    expect(calls).toEqual([
+      "reset",
+      "health",
+      "download",
+      "transactions",
+      "payees",
+      "create:2026-01-05",
+      "sync",
+      "shutdown",
+    ])
+  }),
+)
 
-test("retries a failed mutation as a fresh Synchronization Attempt", async () => {
-  const calls: string[] = []
-  const importedTransaction = {
-    id: "created-after-timeout",
-    date: "2026-01-05",
-    notes: "Variation",
-    payee: "payee-id",
-    imported_id: "fintual-variation:2026-01-05",
-  }
-  const secondAttemptTransactions: Array<typeof importedTransaction> = []
-  const firstAttempt = scriptedClient(calls, {
-    create: (_accountId, transaction) => {
-      calls.push(`create:${transaction.date}`)
-      secondAttemptTransactions.push(importedTransaction)
-      return Effect.fail(
-        new ActualTransactionCreationFailure({
-          cause: { code: "network-failure" },
-          retryable: true,
-        }),
-      )
-    },
-  })
-  const secondAttempt = scriptedClient(calls, {
-    transactions: secondAttemptTransactions,
-  })
-
-  await Effect.runPromise(
-    synchronizationProgram([firstAttempt, secondAttempt], calls, { retries: 1 }),
-  )
-
-  expect(calls).toEqual([
-    "reset",
-    "health",
-    "download",
-    "transactions",
-    "payees",
-    "create:2026-01-05",
-    "shutdown",
-    "reset",
-    "health",
-    "download",
-    "transactions",
-    "payees",
-    "update:created-after-timeout",
-    "sync",
-    "shutdown",
-  ])
-})
-
-test("does not retry a non-retryable Actual failure", async () => {
-  const calls: string[] = []
-  const client: ActualClient = {
-    ...scriptedClient(calls),
-    downloadBudget: () =>
-      Effect.gen(function* () {
-        calls.push("download")
-        return yield* new ActualBudgetDownloadFailure({
-          cause: { code: "budget-not-found" },
-          retryable: false,
-        })
-      }),
-  }
-
-  await expect(
-    Effect.runPromise(synchronizationProgram([client], calls, { retries: 3 })),
-  ).rejects.toMatchObject({
-    _tag: "ActualBudgetDownloadFailure",
-    retryable: false,
-  })
-  expect(calls).toEqual(["reset", "health", "download", "shutdown"])
-})
-
-test("the live Actual adapter preserves stable SDK network codes", async () => {
-  actualApiMock.init.mockResolvedValue({})
-  actualApiMock.downloadBudget.mockRejectedValue({ code: "network-failure" })
-
-  const result = await Effect.runPromise(
-    Effect.gen(function* () {
-      const factory = yield* ActualClientFactory
-      const client = yield* factory.acquire(CONFIG)
-      return yield* Effect.result(client.downloadBudget(CONFIG.syncId))
-    }).pipe(Effect.provide(ActualClientFactory.live)),
-  )
-
-  expect(Result.isFailure(result)).toBe(true)
-  expect(actualApiMock.init).toHaveBeenCalledWith(expect.objectContaining({ password: "secret" }))
-  if (Result.isFailure(result)) {
-    expect(result.failure).toMatchObject({
-      _tag: "ActualBudgetDownloadFailure",
-      cause: { code: "network-failure" },
-      retryable: true,
+it.effect("retries a failed mutation as a fresh Synchronization Attempt", () =>
+  Effect.gen(function* () {
+    const calls: string[] = []
+    const importedTransaction = {
+      id: "created-after-timeout",
+      date: "2026-01-05",
+      notes: "Variation",
+      payee: "payee-id",
+      imported_id: "fintual-variation:2026-01-05",
+    }
+    const secondAttemptTransactions: Array<typeof importedTransaction> = []
+    const firstAttempt = scriptedClient(calls, {
+      create: (_accountId, transaction) => {
+        calls.push(`create:${transaction.date}`)
+        secondAttemptTransactions.push(importedTransaction)
+        return Effect.fail(
+          new ActualTransactionCreationFailure({
+            cause: { code: "network-failure" },
+            retryable: true,
+          }),
+        )
+      },
     })
-  }
-})
+    const secondAttempt = scriptedClient(calls, {
+      transactions: secondAttemptTransactions,
+    })
 
-test("health checks normalize the server URL and classify HTTP failures", async () => {
-  const urls: string[] = []
-  const fetchRequest: typeof globalThis.fetch = async (input) => {
-    urls.push(typeof input === "string" ? input : input instanceof URL ? input.href : input.url)
-    return new Response("", { status: 503 })
-  }
-  const program = Effect.gen(function* () {
-    const healthCheck = yield* ActualHealthCheck
-    yield* healthCheck.check("https://actual.example.test/")
-  }).pipe(Effect.provide(ActualHealthCheck.layer(fetchRequest)))
+    yield* synchronizationProgram([firstAttempt, secondAttempt], calls, { retries: 1 })
 
-  await expect(Effect.runPromise(program)).rejects.toMatchObject({
-    _tag: "ActualHealthCheckFailure",
-    status: 503,
-    retryable: true,
-    url: "https://actual.example.test/health",
-  })
-  expect(urls).toEqual(["https://actual.example.test/health"])
-})
+    expect(calls).toEqual([
+      "reset",
+      "health",
+      "download",
+      "transactions",
+      "payees",
+      "create:2026-01-05",
+      "shutdown",
+      "reset",
+      "health",
+      "download",
+      "transactions",
+      "payees",
+      "update:created-after-timeout",
+      "sync",
+      "shutdown",
+    ])
+  }),
+)
 
-test("health-check timeout is controlled by the Effect Clock", async () => {
-  const fetchRequest: typeof globalThis.fetch = async () => new Promise<Response>(() => {})
-  const healthCheck = Effect.gen(function* () {
-    const service = yield* ActualHealthCheck
-    yield* service.check("https://actual.example.test")
-  }).pipe(Effect.provide(ActualHealthCheck.layer(fetchRequest)))
-  const program = Effect.gen(function* () {
+it.effect("does not retry a non-retryable Actual failure", () =>
+  Effect.gen(function* () {
+    const calls: string[] = []
+    const client: ActualClient = {
+      ...scriptedClient(calls),
+      downloadBudget: () =>
+        Effect.gen(function* () {
+          calls.push("download")
+          return yield* new ActualBudgetDownloadFailure({
+            cause: { code: "budget-not-found" },
+            retryable: false,
+          })
+        }),
+    }
+
+    const error = yield* Effect.flip(synchronizationProgram([client], calls, { retries: 3 }))
+
+    expect(error).toMatchObject({
+      _tag: "ActualBudgetDownloadFailure",
+      retryable: false,
+    })
+    expect(calls).toEqual(["reset", "health", "download", "shutdown"])
+  }),
+)
+
+it.effect("the live Actual adapter preserves stable SDK network codes", () =>
+  Effect.gen(function* () {
+    actualApiMock.init.mockResolvedValue({})
+    actualApiMock.downloadBudget.mockRejectedValue({ code: "network-failure" })
+
+    const result = yield* Effect.result(
+      Effect.gen(function* () {
+        const factory = yield* ActualClientFactory
+        const client = yield* factory.acquire(CONFIG)
+        return yield* client.downloadBudget(CONFIG.syncId)
+      }).pipe(Effect.provide(ActualClientFactory.live)),
+    )
+
+    expect(Result.isFailure(result)).toBe(true)
+    expect(actualApiMock.init).toHaveBeenCalledWith(expect.objectContaining({ password: "secret" }))
+    if (Result.isFailure(result)) {
+      expect(result.failure).toMatchObject({
+        _tag: "ActualBudgetDownloadFailure",
+        cause: { code: "network-failure" },
+        retryable: true,
+      })
+    }
+  }),
+)
+
+it.effect("health checks normalize the server URL and classify HTTP failures", () =>
+  Effect.gen(function* () {
+    const urls: string[] = []
+    const fetchRequest: typeof globalThis.fetch = async (input) => {
+      urls.push(typeof input === "string" ? input : input instanceof URL ? input.href : input.url)
+      return new Response("", { status: 503 })
+    }
+    const program = Effect.gen(function* () {
+      const healthCheck = yield* ActualHealthCheck
+      yield* healthCheck.check("https://actual.example.test/")
+    }).pipe(Effect.provide(ActualHealthCheck.layer(fetchRequest)))
+
+    const error = yield* Effect.flip(program)
+
+    expect(error).toMatchObject({
+      _tag: "ActualHealthCheckFailure",
+      status: 503,
+      retryable: true,
+      url: "https://actual.example.test/health",
+    })
+    expect(urls).toEqual(["https://actual.example.test/health"])
+  }),
+)
+
+it.effect("health-check timeout is controlled by the Effect Clock", () =>
+  Effect.gen(function* () {
+    const fetchRequest: typeof globalThis.fetch = async () => new Promise<Response>(() => {})
+    const healthCheck = Effect.gen(function* () {
+      const service = yield* ActualHealthCheck
+      yield* service.check("https://actual.example.test")
+    }).pipe(Effect.provide(ActualHealthCheck.layer(fetchRequest)))
     const fiber = yield* Effect.forkChild(healthCheck)
     yield* TestClock.adjust(10_000)
     const result = yield* Effect.result(Fiber.join(fiber))
@@ -211,47 +222,41 @@ test("health-check timeout is controlled by the Effect Clock", async () => {
         retryable: true,
       })
     }
-  }).pipe(Effect.provide(TestClock.layer()))
+  }),
+)
 
-  await Effect.runPromise(program)
-})
+it.effect("uses the Effect Clock for the transaction end date", () =>
+  Effect.gen(function* () {
+    const calls: string[] = []
+    const endingDates: string[] = []
+    const client = scriptedClient(calls, {
+      onTransactions: (_startDate, endDate) => endingDates.push(endDate),
+    })
 
-test("uses the Effect Clock for the transaction end date", async () => {
-  const calls: string[] = []
-  const endingDates: string[] = []
-  const client = scriptedClient(calls, {
-    onTransactions: (_startDate, endDate) => endingDates.push(endDate),
-  })
-  const synchronization = synchronizationProgram([client], calls)
-  const program = Effect.gen(function* () {
     yield* TestClock.setTime(Date.parse("2026-02-03T12:00:00Z"))
-    yield* synchronization
-  }).pipe(Effect.provide(TestClock.layer()))
+    yield* synchronizationProgram([client], calls)
 
-  await Effect.runPromise(program)
+    expect(endingDates).toEqual(["2026-02-03"])
+  }),
+)
 
-  expect(endingDates).toEqual(["2026-02-03"])
-})
-
-test("shuts down the scoped Actual session when the workflow is interrupted", async () => {
-  const calls: string[] = []
-  const client = scriptedClient(calls, {
-    download: () =>
-      Effect.gen(function* () {
-        calls.push("download")
-        yield* Effect.never
-      }),
-  })
-  const program = Effect.gen(function* () {
+it.effect("shuts down the scoped Actual session when the workflow is interrupted", () =>
+  Effect.gen(function* () {
+    const calls: string[] = []
+    const client = scriptedClient(calls, {
+      download: () =>
+        Effect.gen(function* () {
+          calls.push("download")
+          yield* Effect.never
+        }),
+    })
     const fiber = yield* Effect.forkChild(synchronizationProgram([client], calls))
     yield* Effect.yieldNow
     yield* Fiber.interrupt(fiber)
-  })
 
-  await Effect.runPromise(program)
-
-  expect(calls).toEqual(["reset", "health", "download", "shutdown"])
-})
+    expect(calls).toEqual(["reset", "health", "download", "shutdown"])
+  }),
+)
 
 function synchronizationProgram(
   clients: ReadonlyArray<ActualClient>,

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,5 +1,6 @@
+import { it } from "@effect/vitest"
 import { Effect, Redacted, Result } from "effect"
-import { expect, test } from "vitest"
+import { expect } from "vitest"
 import { resolveRuntimeConfig, RuntimeConfigError, type Environment } from "./env.ts"
 
 function requiredEnvironment(): Environment {
@@ -14,33 +15,35 @@ function requiredEnvironment(): Environment {
   }
 }
 
-test("normalizes runtime values and applies defaults once for every domain", async () => {
-  const configuration = await Effect.runPromise(resolveRuntimeConfig(requiredEnvironment()))
+it.effect("normalizes runtime values and applies defaults once for every domain", () =>
+  Effect.gen(function* () {
+    const configuration = yield* resolveRuntimeConfig(requiredEnvironment())
 
-  expect(configuration.actual).toMatchObject({
-    serverUrl: "https://actual.example.test",
-    syncId: "sync-id",
-    fintualAccount: "account-id",
-    startingDate: "2024-03-01",
-    payee: "Fintual",
-  })
-  expect(configuration.fintual).toMatchObject({
-    email: "investor@example.com",
-    goalId: "goal-id",
-    email2FA: null,
-  })
-  // Redacted intentionally exposes a safe placeholder through String().
-  // oxlint-disable-next-line typescript/no-base-to-string
-  expect(String(configuration.actual.password)).toBe("<redacted>")
-  expect(Redacted.value(configuration.actual.password)).toBe("actual password")
-  // oxlint-disable-next-line typescript/no-base-to-string
-  expect(String(configuration.fintual.password)).toBe("<redacted>")
-  expect(Redacted.value(configuration.fintual.password)).toBe("fintual password")
-})
+    expect(configuration.actual).toMatchObject({
+      serverUrl: "https://actual.example.test",
+      syncId: "sync-id",
+      fintualAccount: "account-id",
+      startingDate: "2024-03-01",
+      payee: "Fintual",
+    })
+    expect(configuration.fintual).toMatchObject({
+      email: "investor@example.com",
+      goalId: "goal-id",
+      email2FA: null,
+    })
+    // Redacted intentionally exposes a safe placeholder through String().
+    // oxlint-disable-next-line typescript/no-base-to-string
+    expect(String(configuration.actual.password)).toBe("<redacted>")
+    expect(Redacted.value(configuration.actual.password)).toBe("actual password")
+    // oxlint-disable-next-line typescript/no-base-to-string
+    expect(String(configuration.fintual.password)).toBe("<redacted>")
+    expect(Redacted.value(configuration.fintual.password)).toBe("fintual password")
+  }),
+)
 
-test("uses legacy starting date and enables email 2FA when both credentials are present", async () => {
-  const configuration = await Effect.runPromise(
-    resolveRuntimeConfig({
+it.effect("uses legacy starting date and enables email 2FA when both credentials are present", () =>
+  Effect.gen(function* () {
+    const configuration = yield* resolveRuntimeConfig({
       ...requiredEnvironment(),
       STARTING_DATE: "2025-01-02",
       ACTUAL_PAYEE: "Investments",
@@ -50,156 +53,158 @@ test("uses legacy starting date and enables email 2FA when both credentials are 
       GMAIL_IMAP_PORT: "1993",
       GMAIL_IMAP_DEBUG: "TRUE",
       FINTUAL_2FA_SENDER: "security@example.com",
-    }),
-  )
-
-  expect(configuration.actual.startingDate).toBe("2025-01-02")
-  expect(configuration.actual.payee).toBe("Investments")
-  expect(configuration.fintual.email2FA).not.toBeNull()
-  if (configuration.fintual.email2FA) {
-    expect(configuration.fintual.email2FA).toMatchObject({
-      userEmail: "mailbox@example.com",
-      host: "mail.example.com",
-      port: 1993,
-      debug: true,
-      sender: "security@example.com",
     })
-    // oxlint-disable-next-line typescript/no-base-to-string
-    expect(String(configuration.fintual.email2FA.appPassword)).toBe("<redacted>")
-    expect(Redacted.value(configuration.fintual.email2FA.appPassword)).toBe("app password")
-  }
-})
 
-test("preserves quoted-empty values instead of falling back to defaults", async () => {
-  const configuration = await Effect.runPromise(
-    resolveRuntimeConfig({
+    expect(configuration.actual.startingDate).toBe("2025-01-02")
+    expect(configuration.actual.payee).toBe("Investments")
+    expect(configuration.fintual.email2FA).not.toBeNull()
+    if (configuration.fintual.email2FA) {
+      expect(configuration.fintual.email2FA).toMatchObject({
+        userEmail: "mailbox@example.com",
+        host: "mail.example.com",
+        port: 1993,
+        debug: true,
+        sender: "security@example.com",
+      })
+      // oxlint-disable-next-line typescript/no-base-to-string
+      expect(String(configuration.fintual.email2FA.appPassword)).toBe("<redacted>")
+      expect(Redacted.value(configuration.fintual.email2FA.appPassword)).toBe("app password")
+    }
+  }),
+)
+
+it.effect("preserves quoted-empty values instead of falling back to defaults", () =>
+  Effect.gen(function* () {
+    const configuration = yield* resolveRuntimeConfig({
       ...requiredEnvironment(),
       ACTUAL_PAYEE: "''",
       STARTING_DATE: "''",
-    }),
-  )
+    })
 
-  expect(configuration.actual.payee).toBe("")
-  expect(configuration.actual.startingDate).toBe("")
-})
+    expect(configuration.actual.payee).toBe("")
+    expect(configuration.actual.startingDate).toBe("")
+  }),
+)
 
-test("reports all missing required runtime values", async () => {
-  const result = await Effect.runPromise(Effect.result(resolveRuntimeConfig({})))
+it.effect("reports all missing required runtime values", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.result(resolveRuntimeConfig({}))
 
-  expect(result._tag).toBe("Failure")
-  if (Result.isFailure(result)) {
-    expect(result.failure).toBeInstanceOf(RuntimeConfigError)
-    expect(result.failure.cause).toBeDefined()
-    expect(result.failure.message).toContain("ACTUAL_SERVER_URL")
-  }
-})
+    expect(result._tag).toBe("Failure")
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(RuntimeConfigError)
+      expect(result.failure.cause).toBeDefined()
+      expect(result.failure.message).toContain("ACTUAL_SERVER_URL")
+    }
+  }),
+)
 
-test("treats unquoted empty required values as missing", async () => {
-  const result = await Effect.runPromise(
-    Effect.result(
+it.effect("treats unquoted empty required values as missing", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.result(
       resolveRuntimeConfig({
         ...requiredEnvironment(),
         ACTUAL_SERVER_URL: "",
       }),
-    ),
-  )
+    )
 
-  expect(result._tag).toBe("Failure")
-  if (Result.isFailure(result)) {
-    expect(result.failure.message).toContain("ACTUAL_SERVER_URL")
-  }
-})
+    expect(result._tag).toBe("Failure")
+    if (Result.isFailure(result)) {
+      expect(result.failure.message).toContain("ACTUAL_SERVER_URL")
+    }
+  }),
+)
 
-test("uses defaults when optional non-Gmail values are unquoted empty strings", async () => {
-  const configuration = await Effect.runPromise(
-    resolveRuntimeConfig({
+it.effect("uses defaults when optional non-Gmail values are unquoted empty strings", () =>
+  Effect.gen(function* () {
+    const configuration = yield* resolveRuntimeConfig({
       ...requiredEnvironment(),
       ACTUAL_PAYEE: "",
       GMAIL_USER_EMAIL: "mailbox@example.com",
       GMAIL_APP_PASSWORD: "app password",
       GMAIL_IMAP_PORT: "",
-    }),
-  )
+    })
 
-  expect(configuration.actual.payee).toBe("Fintual")
-  expect(configuration.fintual.email2FA?.port).toBe(993)
-})
+    expect(configuration.actual.payee).toBe("Fintual")
+    expect(configuration.fintual.email2FA?.port).toBe(993)
+  }),
+)
 
-test("rejects partially configured email 2FA credentials", async () => {
-  const result = await Effect.runPromise(
-    Effect.result(
+it.effect("rejects partially configured email 2FA credentials", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.result(
       resolveRuntimeConfig({
         ...requiredEnvironment(),
         GMAIL_USER_EMAIL: "mailbox@example.com",
       }),
-    ),
-  )
+    )
 
-  expect(result._tag).toBe("Failure")
-  if (Result.isFailure(result)) {
-    expect(result.failure).toBeInstanceOf(RuntimeConfigError)
-    expect(result.failure.message).toBe("Missing environment variables: GMAIL_APP_PASSWORD")
-  }
-})
+    expect(result._tag).toBe("Failure")
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(RuntimeConfigError)
+      expect(result.failure.message).toBe("Missing environment variables: GMAIL_APP_PASSWORD")
+    }
+  }),
+)
 
-test("rejects a Gmail app password without its user email", async () => {
-  const result = await Effect.runPromise(
-    Effect.result(
+it.effect("rejects a Gmail app password without its user email", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.result(
       resolveRuntimeConfig({
         ...requiredEnvironment(),
         GMAIL_APP_PASSWORD: "app password",
       }),
-    ),
-  )
+    )
 
-  expect(result._tag).toBe("Failure")
-  if (Result.isFailure(result)) {
-    expect(result.failure).toBeInstanceOf(RuntimeConfigError)
-    expect(result.failure.message).toBe("Missing environment variables: GMAIL_USER_EMAIL")
-  }
-})
+    expect(result._tag).toBe("Failure")
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(RuntimeConfigError)
+      expect(result.failure.message).toBe("Missing environment variables: GMAIL_USER_EMAIL")
+    }
+  }),
+)
 
-test("preserves explicitly supplied empty Gmail credentials as present values", async () => {
-  const configuration = await Effect.runPromise(
-    resolveRuntimeConfig({
+it.effect("preserves explicitly supplied empty Gmail credentials as present values", () =>
+  Effect.gen(function* () {
+    const configuration = yield* resolveRuntimeConfig({
       ...requiredEnvironment(),
       GMAIL_USER_EMAIL: "",
       GMAIL_APP_PASSWORD: "",
-    }),
-  )
+    })
 
-  expect(configuration.fintual.email2FA).not.toBeNull()
-  if (configuration.fintual.email2FA) {
-    expect(configuration.fintual.email2FA.userEmail).toBe("")
-    expect(Redacted.value(configuration.fintual.email2FA.appPassword)).toBe("")
-  }
-})
+    expect(configuration.fintual.email2FA).not.toBeNull()
+    if (configuration.fintual.email2FA) {
+      expect(configuration.fintual.email2FA.userEmail).toBe("")
+      expect(Redacted.value(configuration.fintual.email2FA.appPassword)).toBe("")
+    }
+  }),
+)
 
-test("rejects an invalid email 2FA port", async () => {
-  const result = await Effect.runPromise(
-    Effect.result(
+it.effect("rejects an invalid email 2FA port", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.result(
       resolveRuntimeConfig({
         ...requiredEnvironment(),
         GMAIL_USER_EMAIL: "mailbox@example.com",
         GMAIL_APP_PASSWORD: "app password",
         GMAIL_IMAP_PORT: "not-a-port",
       }),
-    ),
-  )
+    )
 
-  expect(result._tag).toBe("Failure")
-  if (Result.isFailure(result)) {
-    expect(result.failure.message).toContain("GMAIL_IMAP_PORT")
-  }
-})
+    expect(result._tag).toBe("Failure")
+    if (Result.isFailure(result)) {
+      expect(result.failure.message).toContain("GMAIL_IMAP_PORT")
+    }
+  }),
+)
 
-test("ignores email 2FA settings when automatic retrieval is disabled", async () => {
-  const configuration = await Effect.runPromise(
-    resolveRuntimeConfig({
+it.effect("ignores email 2FA settings when automatic retrieval is disabled", () =>
+  Effect.gen(function* () {
+    const configuration = yield* resolveRuntimeConfig({
       ...requiredEnvironment(),
       GMAIL_IMAP_PORT: "not-a-port",
-    }),
-  )
+    })
 
-  expect(configuration.fintual.email2FA).toBeNull()
-})
+    expect(configuration.fintual.email2FA).toBeNull()
+  }),
+)

--- a/src/fintual/authenticated-ingestion.test.ts
+++ b/src/fintual/authenticated-ingestion.test.ts
@@ -1,63 +1,70 @@
+import { it } from "@effect/vitest"
 import { Effect, Fiber } from "effect"
-import { expect, test } from "vitest"
+import { expect } from "vitest"
 import { FetchService } from "./authenticated-ingestion.ts"
 
-test("aborts the underlying fetch when its request fiber is interrupted", async () => {
-  let observedSignal: AbortSignal | undefined
-  let resolveRequestStarted!: () => void
-  const requestStarted = new Promise<void>((resolve) => {
-    resolveRequestStarted = resolve
-  })
-
-  const fetch: typeof globalThis.fetch = async (_input, init = {}) => {
-    observedSignal = init.signal ?? undefined
-    resolveRequestStarted()
-
-    return new Promise<Response>((_resolve, reject) => {
-      init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true })
+it.effect("aborts the underlying fetch when its request fiber is interrupted", () =>
+  Effect.gen(function* () {
+    let observedSignal: AbortSignal | undefined
+    let resolveRequestStarted!: () => void
+    const requestStarted = new Promise<void>((resolve) => {
+      resolveRequestStarted = resolve
     })
-  }
 
-  const request = Effect.gen(function* () {
-    const service = yield* FetchService
-    yield* service.request("/slow", {}, "Fintual slow request")
-  }).pipe(Effect.provide(FetchService.layer(fetch)))
+    const fetch: typeof globalThis.fetch = async (_input, init = {}) => {
+      observedSignal = init.signal ?? undefined
+      resolveRequestStarted()
 
-  const fiber = Effect.runFork(request)
-  await requestStarted
-  await Effect.runPromise(Fiber.interrupt(fiber))
+      return new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true })
+      })
+    }
 
-  expect(observedSignal).toBeDefined()
-  expect(observedSignal?.aborted).toBe(true)
-})
+    const request = Effect.gen(function* () {
+      const service = yield* FetchService
+      yield* service.request("/slow", {}, "Fintual slow request")
+    }).pipe(Effect.provide(FetchService.layer(fetch)))
 
-test("fails with HttpTransportFailure when the request deadline aborts fetch", async () => {
-  let observedSignal: AbortSignal | undefined
-  let resolveRequestStarted!: () => void
-  const requestStarted = new Promise<void>((resolve) => {
-    resolveRequestStarted = resolve
-  })
+    const fiber = yield* Effect.forkChild(request)
+    yield* Effect.promise(() => requestStarted)
+    yield* Fiber.interrupt(fiber)
 
-  const fetch: typeof globalThis.fetch = async (_input, init = {}) => {
-    observedSignal = init.signal ?? undefined
-    resolveRequestStarted()
+    expect(observedSignal).toBeDefined()
+    expect(observedSignal?.aborted).toBe(true)
+  }),
+)
 
-    return new Promise<Response>((_resolve, reject) => {
-      init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true })
+it.effect("fails with HttpTransportFailure when the request deadline aborts fetch", () =>
+  Effect.gen(function* () {
+    let observedSignal: AbortSignal | undefined
+    let resolveRequestStarted!: () => void
+    const requestStarted = new Promise<void>((resolve) => {
+      resolveRequestStarted = resolve
     })
-  }
 
-  const request = Effect.gen(function* () {
-    const service = yield* FetchService
-    yield* service.request("/slow", {}, "Fintual deadline")
-  }).pipe(Effect.provide(FetchService.layer(fetch, { requestTimeoutMs: 0 })))
+    const fetch: typeof globalThis.fetch = async (_input, init = {}) => {
+      observedSignal = init.signal ?? undefined
+      resolveRequestStarted()
 
-  const fiber = Effect.runFork(request)
-  await requestStarted
+      return new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true })
+      })
+    }
 
-  await expect(Effect.runPromise(Fiber.join(fiber))).rejects.toMatchObject({
-    _tag: "HttpTransportFailure",
-    stage: "Fintual deadline",
-  })
-  expect(observedSignal?.aborted).toBe(true)
-})
+    const request = Effect.gen(function* () {
+      const service = yield* FetchService
+      yield* service.request("/slow", {}, "Fintual deadline")
+    }).pipe(Effect.provide(FetchService.layer(fetch, { requestTimeoutMs: 0 })))
+
+    const fiber = yield* Effect.forkChild(request)
+    yield* Effect.promise(() => requestStarted)
+
+    const error = yield* Effect.flip(Fiber.join(fiber))
+
+    expect(error).toMatchObject({
+      _tag: "HttpTransportFailure",
+      stage: "Fintual deadline",
+    })
+    expect(observedSignal?.aborted).toBe(true)
+  }),
+)

--- a/src/fintual/email-2fa-client.test.ts
+++ b/src/fintual/email-2fa-client.test.ts
@@ -1,58 +1,65 @@
+import { it } from "@effect/vitest"
 import { Effect } from "effect"
 import { ImapFlow } from "imapflow"
-import { expect, test } from "vitest"
+import { expect } from "vitest"
 import { ImapFlowClient, MissingServerExtension } from "./email-2fa-client.ts"
 
-test("surfaces a MissingServerExtension search rejection as a typed error", async () => {
-  const client = clientWithSearchError(
-    Object.assign(new Error("Server does not support X-GM-EXT-1 extension"), {
-      code: "MissingServerExtension",
-    }),
-  )
+it.effect("surfaces a MissingServerExtension search rejection as a typed error", () =>
+  Effect.gen(function* () {
+    const client = clientWithSearchError(
+      Object.assign(new Error("Server does not support X-GM-EXT-1 extension"), {
+        code: "MissingServerExtension",
+      }),
+    )
 
-  const error = await Effect.runPromise(Effect.flip(client.search({ gmraw: "from:a" })))
+    const error = yield* Effect.flip(client.search({ gmraw: "from:a" }))
 
-  expect(error).toBeInstanceOf(MissingServerExtension)
-})
+    expect(error).toBeInstanceOf(MissingServerExtension)
+  }),
+)
 
-test("surfaces a plain search failure with the preserved message and original cause", async () => {
-  const originalError = new Error("boom")
-  const client = clientWithSearchError(originalError)
+it.effect("surfaces a plain search failure with the preserved message and original cause", () =>
+  Effect.gen(function* () {
+    const originalError = new Error("boom")
+    const client = clientWithSearchError(originalError)
 
-  const error = await Effect.runPromise(Effect.flip(client.search({ gmraw: "from:a" })))
+    const error = yield* Effect.flip(client.search({ gmraw: "from:a" }))
 
-  expect(error).toBeInstanceOf(Error)
-  expect(error).not.toBeInstanceOf(MissingServerExtension)
-  expect(error.message).toBe("Failed to search Gmail IMAP mailbox: boom")
-  expect(error.cause).toBe(originalError)
-})
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBeInstanceOf(MissingServerExtension)
+    expect(error.message).toBe("Failed to search Gmail IMAP mailbox: boom")
+    expect(error.cause).toBe(originalError)
+  }),
+)
 
-test("exposes only the subject from the message envelope across the seam", async () => {
-  const raw = new ImapFlow({
-    host: "imap.example.com",
-    port: 993,
-    secure: true,
-    auth: { user: "user@example.com", pass: "app-password" },
-    logger: false,
-  })
-  raw.fetchOne = async () => ({
-    seq: 1,
-    uid: 123,
-    source: Buffer.from("Subject: Codigo 123456\n\nCodigo: 123456"),
-    envelope: {
-      subject: "Codigo 123456",
-      date: new Date("2026-07-14T10:31:00"),
-      from: [{ address: "security@fintual.com" }],
-      to: [{ address: "user@example.com" }],
-      messageId: "<message-id>",
-    },
-    internalDate: new Date("2026-07-14T10:31:00"),
-  })
+it.effect("exposes only the subject from the message envelope across the seam", () =>
+  Effect.gen(function* () {
+    const raw = new ImapFlow({
+      host: "imap.example.com",
+      port: 993,
+      secure: true,
+      auth: { user: "user@example.com", pass: "app-password" },
+      logger: false,
+    })
+    raw.fetchOne = async () => ({
+      seq: 1,
+      uid: 123,
+      source: Buffer.from("Subject: Codigo 123456\n\nCodigo: 123456"),
+      envelope: {
+        subject: "Codigo 123456",
+        date: new Date("2026-07-14T10:31:00"),
+        from: [{ address: "security@fintual.com" }],
+        to: [{ address: "user@example.com" }],
+        messageId: "<message-id>",
+      },
+      internalDate: new Date("2026-07-14T10:31:00"),
+    })
 
-  const message = await Effect.runPromise(new ImapFlowClient(raw).fetchOne(123))
+    const message = yield* new ImapFlowClient(raw).fetchOne(123)
 
-  expect(message?.envelope).toEqual({ subject: "Codigo 123456" })
-})
+    expect(message?.envelope).toEqual({ subject: "Codigo 123456" })
+  }),
+)
 
 function clientWithSearchError(error: Error): ImapFlowClient {
   const raw = new ImapFlow({

--- a/src/fintual/email-2fa/email-2fa-policy.test.ts
+++ b/src/fintual/email-2fa/email-2fa-policy.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises"
+import { it } from "@effect/vitest"
 import { Effect } from "effect"
 import { expect, test } from "vitest"
 import {
@@ -33,39 +34,43 @@ test("uses only the portable IMAP query outside Gmail", () => {
   ).toEqual([{ from: "security@example.com", since: AFTER_TIMESTAMP }])
 })
 
-test.each([
-  ["plain text", "2fa-plain.eml", "123456"],
-  ["HTML", "2fa-html.eml", "234567"],
-  ["quoted-printable", "2fa-quoted-printable.eml", "345678"],
-])("selects a code from a captured %s message", async (_, fixtureName, expectedCode) => {
-  const candidate = await loadFixture(fixtureName)
+it.effect.each([
+  { label: "plain text", fixtureName: "2fa-plain.eml", expectedCode: "123456" },
+  { label: "HTML", fixtureName: "2fa-html.eml", expectedCode: "234567" },
+  { label: "quoted-printable", fixtureName: "2fa-quoted-printable.eml", expectedCode: "345678" },
+])("selects a code from a captured $label message", ({ fixtureName, expectedCode }) =>
+  Effect.gen(function* () {
+    const candidate = yield* Effect.tryPromise(() => loadFixture(fixtureName))
 
-  const code = await Effect.runPromise(selectEmail2FACode([candidate], AFTER_TIMESTAMP))
+    const code = yield* selectEmail2FACode([candidate], AFTER_TIMESTAMP)
 
-  expect(code).toBe(expectedCode)
-})
+    expect(code).toBe(expectedCode)
+  }),
+)
 
-test("rejects stale and invalid candidates before selecting a fresh code", async () => {
-  const candidates: Email2FACandidate[] = [
-    {
-      source: Buffer.from("Subject: Codigo 456789\n\nCodigo: 456789"),
-      receivedAt: new Date(2026, 6, 14, 10, 29),
-    },
-    {
-      // The parser rejects the all-zero sentinel before considering fresher candidates.
-      source: Buffer.from("Subject: Codigo 000000\n\nCodigo: 000000"),
-      receivedAt: new Date(2026, 6, 14, 10, 31),
-    },
-    {
-      source: Buffer.from("Subject: Codigo 567890\n\nCodigo: 567890"),
-      receivedAt: new Date(2026, 6, 14, 10, 32),
-    },
-  ]
+it.effect("rejects stale and invalid candidates before selecting a fresh code", () =>
+  Effect.gen(function* () {
+    const candidates: Email2FACandidate[] = [
+      {
+        source: Buffer.from("Subject: Codigo 456789\n\nCodigo: 456789"),
+        receivedAt: new Date(2026, 6, 14, 10, 29),
+      },
+      {
+        // The parser rejects the all-zero sentinel before considering fresher candidates.
+        source: Buffer.from("Subject: Codigo 000000\n\nCodigo: 000000"),
+        receivedAt: new Date(2026, 6, 14, 10, 31),
+      },
+      {
+        source: Buffer.from("Subject: Codigo 567890\n\nCodigo: 567890"),
+        receivedAt: new Date(2026, 6, 14, 10, 32),
+      },
+    ]
 
-  const code = await Effect.runPromise(selectEmail2FACode(candidates, AFTER_TIMESTAMP))
+    const code = yield* selectEmail2FACode(candidates, AFTER_TIMESTAMP)
 
-  expect(code).toBe("567890")
-})
+    expect(code).toBe("567890")
+  }),
+)
 
 async function loadFixture(name: string): Promise<Email2FACandidate> {
   const source = await readFile(new URL(`./fixtures/${name}`, import.meta.url))

--- a/src/fintual/email-2fa/retrieve.test.ts
+++ b/src/fintual/email-2fa/retrieve.test.ts
@@ -1,6 +1,7 @@
+import { it } from "@effect/vitest"
 import { Cause, Effect, Exit, Fiber, Option, Redacted } from "effect"
 import { TestClock } from "effect/testing"
-import { describe, expect, test } from "vitest"
+import { describe, expect } from "vitest"
 import type { SearchObject } from "imapflow"
 import type { Email2FAConfig } from "../../env.ts"
 import {
@@ -119,17 +120,15 @@ function runRetrieval(
   options: Email2FAOptions,
   client: ImapClient,
   step: (fiber: Fiber.Fiber<Email2FACode, TimedOut | Operational>) => Effect.Effect<unknown>,
-): Promise<Exit.Exit<Email2FACode, TimedOut | Operational>> {
-  return Effect.runPromise(
-    Effect.gen(function* () {
-      const fiber = yield* retrieveEmail2FACode(config, options).pipe(
-        Effect.provideService(ImapClientFactory, { create: () => client }),
-        Effect.forkChild,
-      )
-      yield* step(fiber)
-      return yield* Fiber.await(fiber)
-    }).pipe(Effect.provide(TestClock.layer())),
-  )
+): Effect.Effect<Exit.Exit<Email2FACode, TimedOut | Operational>> {
+  return Effect.gen(function* () {
+    const fiber = yield* retrieveEmail2FACode(config, options).pipe(
+      Effect.provideService(ImapClientFactory, { create: () => client }),
+      Effect.forkChild,
+    )
+    yield* step(fiber)
+    return yield* Fiber.await(fiber)
+  })
 }
 
 function failureOf(exit: Exit.Exit<Email2FACode, TimedOut | Operational>): TimedOut | Operational {
@@ -144,249 +143,275 @@ function failureOf(exit: Exit.Exit<Email2FACode, TimedOut | Operational>): Timed
 }
 
 describe("retrieveEmail2FACode", () => {
-  test("returns the branded code on the first poll and logs out exactly once", async () => {
-    const fake = createFakeClient({
-      search: () => [123],
-      fetchOne: () => messageWithCode("123456"),
-    })
+  it.effect("returns the branded code on the first poll and logs out exactly once", () =>
+    Effect.gen(function* () {
+      const fake = createFakeClient({
+        search: () => [123],
+        fetchOne: () => messageWithCode("123456"),
+      })
 
-    const exit = await runRetrieval(
-      NON_GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP },
-      fake.client,
-      () => Effect.void,
-    )
+      const exit = yield* runRetrieval(
+        NON_GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP },
+        fake.client,
+        () => Effect.void,
+      )
 
-    expect(Exit.isSuccess(exit)).toBe(true)
-    if (Exit.isSuccess(exit)) {
-      expect(exit.value).toBe(Email2FACode.make("123456"))
-    }
-    expect(fake.ops).toContain("connect")
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
+      expect(Exit.isSuccess(exit)).toBe(true)
+      if (Exit.isSuccess(exit)) {
+        expect(exit.value).toBe(Email2FACode.make("123456"))
+      }
+      expect(fake.ops).toContain("connect")
+      expect(countOps(fake.ops, "logout")).toBe(1)
+    }),
+  )
 
-  test("polls once per poll interval until a code appears", async () => {
-    const fake = createFakeClient({
-      search: (_, searchCount) => (searchCount >= 3 ? [456] : false),
-      fetchOne: () => messageWithCode("654321"),
-    })
+  it.effect("polls once per poll interval until a code appears", () =>
+    Effect.gen(function* () {
+      const fake = createFakeClient({
+        search: (_, searchCount) => (searchCount >= 3 ? [456] : false),
+        fetchOne: () => messageWithCode("654321"),
+      })
 
-    const exit = await runRetrieval(
-      NON_GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
-      fake.client,
-      () => TestClock.adjust("6 seconds"),
-    )
+      const exit = yield* runRetrieval(
+        NON_GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
+        fake.client,
+        () => TestClock.adjust("6 seconds"),
+      )
 
-    expect(Exit.isSuccess(exit)).toBe(true)
-    expect(fake.searchCount()).toBe(3)
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
+      expect(Exit.isSuccess(exit)).toBe(true)
+      expect(fake.searchCount()).toBe(3)
+      expect(countOps(fake.ops, "logout")).toBe(1)
+    }),
+  )
 
-  test("times out after the default 120 second window with TimedOut and a single logout", async () => {
-    const fake = createFakeClient({ search: () => false })
+  it.effect("times out after the default 120 second window with TimedOut and a single logout", () =>
+    Effect.gen(function* () {
+      const fake = createFakeClient({ search: () => false })
 
-    const exit = await runRetrieval(
-      NON_GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP },
-      fake.client,
-      () => TestClock.adjust("2 minutes"),
-    )
+      const exit = yield* runRetrieval(
+        NON_GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP },
+        fake.client,
+        () => TestClock.adjust("2 minutes"),
+      )
 
-    expect(failureOf(exit)).toBeInstanceOf(TimedOut)
-    expect(countOps(fake.ops, "connect")).toBe(1)
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
+      expect(failureOf(exit)).toBeInstanceOf(TimedOut)
+      expect(countOps(fake.ops, "connect")).toBe(1)
+      expect(countOps(fake.ops, "logout")).toBe(1)
+    }),
+  )
 
-  test("surfaces a connect failure as Operational without logging out", async () => {
-    const fake = createFakeClient({
-      connectError: new Error("connection refused"),
-      search: () => false,
-    })
+  it.effect("surfaces a connect failure as Operational without logging out", () =>
+    Effect.gen(function* () {
+      const fake = createFakeClient({
+        connectError: new Error("connection refused"),
+        search: () => false,
+      })
 
-    const exit = await runRetrieval(
-      NON_GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP },
-      fake.client,
-      () => Effect.void,
-    )
+      const exit = yield* runRetrieval(
+        NON_GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP },
+        fake.client,
+        () => Effect.void,
+      )
 
-    expect(failureOf(exit)).toBeInstanceOf(Operational)
-    expect(countOps(fake.ops, "connect")).toBe(1)
-    expect(countOps(fake.ops, "logout")).toBe(0)
-  })
+      expect(failureOf(exit)).toBeInstanceOf(Operational)
+      expect(countOps(fake.ops, "connect")).toBe(1)
+      expect(countOps(fake.ops, "logout")).toBe(0)
+    }),
+  )
 
-  test("logs out exactly once when the retrieval fiber is interrupted", async () => {
-    const fake = createFakeClient({ search: () => false })
+  it.effect("logs out exactly once when the retrieval fiber is interrupted", () =>
+    Effect.gen(function* () {
+      const fake = createFakeClient({ search: () => false })
 
-    const exit = await runRetrieval(
-      NON_GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
-      fake.client,
-      (fiber) =>
-        Effect.gen(function* () {
-          yield* TestClock.adjust("1 second")
-          return yield* Fiber.interrupt(fiber)
-        }),
-    )
+      const exit = yield* runRetrieval(
+        NON_GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
+        fake.client,
+        (fiber) =>
+          Effect.gen(function* () {
+            yield* TestClock.adjust("1 second")
+            return yield* Fiber.interrupt(fiber)
+          }),
+      )
 
-    expect(Exit.isFailure(exit)).toBe(true)
-    expect(countOps(fake.ops, "connect")).toBe(1)
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(countOps(fake.ops, "connect")).toBe(1)
+      expect(countOps(fake.ops, "logout")).toBe(1)
+    }),
+  )
 })
 
 describe("retrieveEmail2FACode recoverability", () => {
-  test("skips a mailbox whose lock fails and keeps searching the remaining mailboxes", async () => {
-    const fake = createFakeClient({
-      lockFailures: new Set(["INBOX"]),
-      search: () => false,
-    })
-
-    const exit = await runRetrieval(
-      GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000, timeoutMs: 5_000 },
-      fake.client,
-      () => TestClock.adjust("5 seconds"),
-    )
-
-    expect(failureOf(exit)).toBeInstanceOf(TimedOut)
-    expect(fake.ops).toContain("lock:[Gmail]/All Mail")
-    expect(fake.ops).toContain("lock:[Gmail]/Spam")
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
-
-  test("surfaces a non-missing mailbox lock failure as Operational", async () => {
-    const fake = createFakeClient({ lockError: new Error("connection dropped") })
-
-    const exit = await runRetrieval(
-      GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP },
-      fake.client,
-      () => Effect.void,
-    )
-
-    expect(failureOf(exit)).toBeInstanceOf(Operational)
-    expect(fake.ops).not.toContain("lock:[Gmail]/All Mail")
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
-
-  test("skips a single message whose fetch fails and still returns the code from a later message", async () => {
-    const fake = createFakeClient({
-      search: () => [111, 222],
-      fetchOne: (uid) => {
-        if (uid === 111) {
-          return new Error("message stream broken")
-        }
-        return messageWithCode("222222")
-      },
-    })
-
-    const exit = await runRetrieval(
-      NON_GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP },
-      fake.client,
-      () => Effect.void,
-    )
-
-    expect(Exit.isSuccess(exit)).toBe(true)
-    if (Exit.isSuccess(exit)) {
-      expect(exit.value).toBe(Email2FACode.make("222222"))
-    }
-    expect(fake.ops).toContain("fetchOne:111")
-    expect(fake.ops).toContain("fetchOne:222")
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
-
-  test("retries a message fetch failure on the next poll", async () => {
-    let fetches = 0
-    const fake = createFakeClient({
-      search: () => [111],
-      fetchOne: () => {
-        fetches += 1
-        return fetches === 1 ? new Error("message stream broken") : messageWithCode("111111")
-      },
-    })
-
-    const exit = await runRetrieval(
-      NON_GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
-      fake.client,
-      () => TestClock.adjust("2 seconds"),
-    )
-
-    expect(Exit.isSuccess(exit)).toBe(true)
-    if (Exit.isSuccess(exit)) {
-      expect(exit.value).toBe(Email2FACode.make("111111"))
-    }
-    expect(countOps(fake.ops, "fetchOne:111")).toBe(2)
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
-
-  test("surfaces a search failure as Operational", async () => {
-    const fake = createFakeClient({ search: () => new Error("IMAP search failed") })
-
-    const exit = await runRetrieval(
-      NON_GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP },
-      fake.client,
-      () => Effect.void,
-    )
-
-    expect(failureOf(exit)).toBeInstanceOf(Operational)
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
-
-  test("pre-classifies a MissingServerExtension search failure and keeps polling", async () => {
-    const fake = createFakeClient({
-      search: (_, searchCount) =>
-        searchCount === 1
-          ? new MissingServerExtension({ cause: new Error("no X-GM-EXT-1") })
-          : [333],
-      fetchOne: () => messageWithCode("333333"),
-    })
-
-    const exit = await runRetrieval(
-      NON_GMAIL_CONFIG,
-      { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
-      fake.client,
-      () => TestClock.adjust("4 seconds"),
-    )
-
-    expect(Exit.isSuccess(exit)).toBe(true)
-    if (Exit.isSuccess(exit)) {
-      expect(exit.value).toBe(Email2FACode.make("333333"))
-    }
-    expect(fake.searchCount()).toBe(2)
-    expect(countOps(fake.ops, "logout")).toBe(1)
-  })
-
-  test("debug only toggles logging and does not change behavior", async () => {
-    const scenario = () =>
-      createFakeClient({
+  it.effect("skips a mailbox whose lock fails and keeps searching the remaining mailboxes", () =>
+    Effect.gen(function* () {
+      const fake = createFakeClient({
         lockFailures: new Set(["INBOX"]),
-        search: (_, searchCount) => (searchCount >= 2 ? [444] : false),
-        fetchOne: () => messageWithCode("444444"),
+        search: () => false,
       })
 
-    const quiet = scenario()
-    const quietExit = await runRetrieval(
-      { ...GMAIL_CONFIG, debug: false },
-      { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
-      quiet.client,
-      () => TestClock.adjust("4 seconds"),
-    )
-    const verbose = scenario()
-    const verboseExit = await runRetrieval(
-      { ...GMAIL_CONFIG, debug: true },
-      { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
-      verbose.client,
-      () => TestClock.adjust("4 seconds"),
-    )
+      const exit = yield* runRetrieval(
+        GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000, timeoutMs: 5_000 },
+        fake.client,
+        () => TestClock.adjust("5 seconds"),
+      )
 
-    expect(quietExit).toEqual(verboseExit)
-    expect(quiet.ops).toEqual(verbose.ops)
-  })
+      expect(failureOf(exit)).toBeInstanceOf(TimedOut)
+      expect(fake.ops).toContain("lock:[Gmail]/All Mail")
+      expect(fake.ops).toContain("lock:[Gmail]/Spam")
+      expect(countOps(fake.ops, "logout")).toBe(1)
+    }),
+  )
+
+  it.effect("surfaces a non-missing mailbox lock failure as Operational", () =>
+    Effect.gen(function* () {
+      const fake = createFakeClient({ lockError: new Error("connection dropped") })
+
+      const exit = yield* runRetrieval(
+        GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP },
+        fake.client,
+        () => Effect.void,
+      )
+
+      expect(failureOf(exit)).toBeInstanceOf(Operational)
+      expect(fake.ops).not.toContain("lock:[Gmail]/All Mail")
+      expect(countOps(fake.ops, "logout")).toBe(1)
+    }),
+  )
+
+  it.effect(
+    "skips a single message whose fetch fails and still returns the code from a later message",
+    () =>
+      Effect.gen(function* () {
+        const fake = createFakeClient({
+          search: () => [111, 222],
+          fetchOne: (uid) => {
+            if (uid === 111) {
+              return new Error("message stream broken")
+            }
+            return messageWithCode("222222")
+          },
+        })
+
+        const exit = yield* runRetrieval(
+          NON_GMAIL_CONFIG,
+          { afterTimestamp: AFTER_TIMESTAMP },
+          fake.client,
+          () => Effect.void,
+        )
+
+        expect(Exit.isSuccess(exit)).toBe(true)
+        if (Exit.isSuccess(exit)) {
+          expect(exit.value).toBe(Email2FACode.make("222222"))
+        }
+        expect(fake.ops).toContain("fetchOne:111")
+        expect(fake.ops).toContain("fetchOne:222")
+        expect(countOps(fake.ops, "logout")).toBe(1)
+      }),
+  )
+
+  it.effect("retries a message fetch failure on the next poll", () =>
+    Effect.gen(function* () {
+      let fetches = 0
+      const fake = createFakeClient({
+        search: () => [111],
+        fetchOne: () => {
+          fetches += 1
+          return fetches === 1 ? new Error("message stream broken") : messageWithCode("111111")
+        },
+      })
+
+      const exit = yield* runRetrieval(
+        NON_GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
+        fake.client,
+        () => TestClock.adjust("2 seconds"),
+      )
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      if (Exit.isSuccess(exit)) {
+        expect(exit.value).toBe(Email2FACode.make("111111"))
+      }
+      expect(countOps(fake.ops, "fetchOne:111")).toBe(2)
+      expect(countOps(fake.ops, "logout")).toBe(1)
+    }),
+  )
+
+  it.effect("surfaces a search failure as Operational", () =>
+    Effect.gen(function* () {
+      const fake = createFakeClient({ search: () => new Error("IMAP search failed") })
+
+      const exit = yield* runRetrieval(
+        NON_GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP },
+        fake.client,
+        () => Effect.void,
+      )
+
+      expect(failureOf(exit)).toBeInstanceOf(Operational)
+      expect(countOps(fake.ops, "logout")).toBe(1)
+    }),
+  )
+
+  it.effect("pre-classifies a MissingServerExtension search failure and keeps polling", () =>
+    Effect.gen(function* () {
+      const fake = createFakeClient({
+        search: (_, searchCount) =>
+          searchCount === 1
+            ? new MissingServerExtension({ cause: new Error("no X-GM-EXT-1") })
+            : [333],
+        fetchOne: () => messageWithCode("333333"),
+      })
+
+      const exit = yield* runRetrieval(
+        NON_GMAIL_CONFIG,
+        { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
+        fake.client,
+        () => TestClock.adjust("4 seconds"),
+      )
+
+      expect(Exit.isSuccess(exit)).toBe(true)
+      if (Exit.isSuccess(exit)) {
+        expect(exit.value).toBe(Email2FACode.make("333333"))
+      }
+      expect(fake.searchCount()).toBe(2)
+      expect(countOps(fake.ops, "logout")).toBe(1)
+    }),
+  )
+
+  it.effect("debug only toggles logging and does not change behavior", () =>
+    Effect.gen(function* () {
+      const scenario = () =>
+        createFakeClient({
+          lockFailures: new Set(["INBOX"]),
+          search: (_, searchCount) => (searchCount >= 2 ? [444] : false),
+          fetchOne: () => messageWithCode("444444"),
+        })
+
+      const quiet = scenario()
+      const quietExit = yield* runRetrieval(
+        { ...GMAIL_CONFIG, debug: false },
+        { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
+        quiet.client,
+        () => TestClock.adjust("4 seconds"),
+      )
+      const verbose = scenario()
+      const verboseExit = yield* runRetrieval(
+        { ...GMAIL_CONFIG, debug: true },
+        { afterTimestamp: AFTER_TIMESTAMP, pollIntervalMs: 2_000 },
+        verbose.client,
+        () => TestClock.adjust("4 seconds"),
+      )
+
+      expect(quietExit).toEqual(verboseExit)
+      expect(quiet.ops).toEqual(verbose.ops)
+    }),
+  )
 })
 
 function messageWithCode(code: string): ImapMessage {

--- a/src/fintual/new-performance.test.ts
+++ b/src/fintual/new-performance.test.ts
@@ -1,3 +1,4 @@
+import { it } from "@effect/vitest"
 import { Effect } from "effect"
 import { expect, test } from "vitest"
 import {
@@ -16,66 +17,79 @@ test("creates a Goal Performance Data request for the selected Fintual interval"
   })
 })
 
-test("parses valid Goal Performance Data", async () => {
-  const result = await Effect.runPromise(
-    parseGoalPerformanceResponseBody(JSON.stringify(goalPerformanceResponse())),
-  )
+it.effect("parses valid Goal Performance Data", () =>
+  Effect.gen(function* () {
+    const result = yield* parseGoalPerformanceResponseBody(
+      JSON.stringify(goalPerformanceResponse()),
+    )
 
-  expect(result.balanceGraphDataPoints).toHaveLength(1)
-  expect(result.balanceGraphDataPoints[0]?.date).toBe("2026-08-01")
-})
-
-test("fails when the Goal Performance Data response is malformed JSON", async () => {
-  await expect(Effect.runPromise(parseGoalPerformanceResponseBody("{"))).rejects.toThrow(
-    "Failed to parse goal performance response body",
-  )
-})
-
-test("fails when the Goal Performance Data response has an invalid shape", async () => {
-  await expect(
-    Effect.runPromise(parseGoalPerformanceResponseBody(JSON.stringify({ data: {} }))),
-  ).rejects.toThrow("response does not match the Goal Performance Data schema")
-})
-
-test.each(["2026-13-45", "2026-02-31", "2025-02-29"])(
-  "fails when a Goal Performance Data date is not a valid ISO date: %s",
-  async (date) => {
-    const response = goalPerformanceResponse()
-    const point = response.data.balanceGraphDataPoints[0]
-    if (!point) {
-      throw new Error("expected a performance point")
-    }
-    point.date = date
-
-    await expect(
-      Effect.runPromise(parseGoalPerformanceResponseBody(JSON.stringify(response))),
-    ).rejects.toThrow("response does not match the Goal Performance Data schema")
-  },
+    expect(result.balanceGraphDataPoints).toHaveLength(1)
+    expect(result.balanceGraphDataPoints[0]?.date).toBe("2026-08-01")
+  }),
 )
 
-test("fails when the GraphQL response contains errors", async () => {
-  const response = {
-    ...goalPerformanceResponse(),
-    errors: [{ message: "request failed" }],
-  }
-  const body = JSON.stringify(response)
+it.effect("fails when the Goal Performance Data response is malformed JSON", () =>
+  Effect.gen(function* () {
+    const error = yield* Effect.flip(parseGoalPerformanceResponseBody("{"))
 
-  await expect(Effect.runPromise(parseGoalPerformanceResponseBody(body))).rejects.toThrow(
-    "GraphQL response contains errors",
-  )
-})
+    expect(error.message).toContain("Failed to parse goal performance response body")
+  }),
+)
 
-test("preserves non-finite wire amounts for snapshot validation", async () => {
-  const response = goalPerformanceResponse()
-  const body = JSON.stringify(response).replace(
-    '"unrealizedCostBasisAmount":100',
-    '"unrealizedCostBasisAmount":1e400',
-  )
+it.effect("fails when the Goal Performance Data response has an invalid shape", () =>
+  Effect.gen(function* () {
+    const error = yield* Effect.flip(parseGoalPerformanceResponseBody(JSON.stringify({ data: {} })))
 
-  const result = await Effect.runPromise(parseGoalPerformanceResponseBody(body))
+    expect(error.message).toContain("response does not match the Goal Performance Data schema")
+  }),
+)
 
-  expect(result.balanceGraphDataPoints[0]?.unrealizedCostBasisAmount).toBe(Number.POSITIVE_INFINITY)
-})
+it.effect.each(["2026-13-45", "2026-02-31", "2025-02-29"])(
+  "fails when a Goal Performance Data date is not a valid ISO date: %s",
+  (date) =>
+    Effect.gen(function* () {
+      const response = goalPerformanceResponse()
+      const point = response.data.balanceGraphDataPoints[0]
+      if (!point) {
+        throw new Error("expected a performance point")
+      }
+      point.date = date
+
+      const error = yield* Effect.flip(parseGoalPerformanceResponseBody(JSON.stringify(response)))
+
+      expect(error.message).toContain("response does not match the Goal Performance Data schema")
+    }),
+)
+
+it.effect("fails when the GraphQL response contains errors", () =>
+  Effect.gen(function* () {
+    const response = {
+      ...goalPerformanceResponse(),
+      errors: [{ message: "request failed" }],
+    }
+    const body = JSON.stringify(response)
+
+    const error = yield* Effect.flip(parseGoalPerformanceResponseBody(body))
+
+    expect(error.message).toContain("GraphQL response contains errors")
+  }),
+)
+
+it.effect("preserves non-finite wire amounts for snapshot validation", () =>
+  Effect.gen(function* () {
+    const response = goalPerformanceResponse()
+    const body = JSON.stringify(response).replace(
+      '"unrealizedCostBasisAmount":100',
+      '"unrealizedCostBasisAmount":1e400',
+    )
+
+    const result = yield* parseGoalPerformanceResponseBody(body)
+
+    expect(result.balanceGraphDataPoints[0]?.unrealizedCostBasisAmount).toBe(
+      Number.POSITIVE_INFINITY,
+    )
+  }),
+)
 
 function goalPerformanceResponse(): {
   data: { balanceGraphDataPoints: Array<Record<string, unknown>> }

--- a/src/fintual/performance.test.ts
+++ b/src/fintual/performance.test.ts
@@ -1,5 +1,6 @@
+import { it } from "@effect/vitest"
 import { Effect, Redacted } from "effect"
-import { describe, expect, test } from "vitest"
+import { describe, expect } from "vitest"
 import { FintualConfigService, type FintualConfig } from "../env.ts"
 import { SnapshotWriter, type PerformanceSnapshot } from "../performance-snapshot.ts"
 import { FetchService } from "./authenticated-ingestion.ts"
@@ -47,64 +48,66 @@ function performanceProgram(script: FetchScript, overrides: TestOverrides = {}) 
   )
 }
 
-test("returns a validated Performance Snapshot after direct login", async () => {
-  const written: PerformanceSnapshot[] = []
-  const script = createFetchScript([
-    response("", 200, "session=sign-in"),
-    response("{}", 200, "auth=direct"),
-    goalPerformanceResponse("2026-01-01", { costBasis: 80, valuation: 100 }, "graph=reference"),
-    goalPerformanceResponse("2026-07-01", { costBasis: 90, valuation: 115 }),
-  ])
+it.effect("returns a validated Performance Snapshot after direct login", () =>
+  Effect.gen(function* () {
+    const written: PerformanceSnapshot[] = []
+    const script = createFetchScript([
+      response("", 200, "session=sign-in"),
+      response("{}", 200, "auth=direct"),
+      goalPerformanceResponse("2026-01-01", { costBasis: 80, valuation: 100 }, "graph=reference"),
+      goalPerformanceResponse("2026-07-01", { costBasis: 90, valuation: 115 }),
+    ])
 
-  const snapshot = await Effect.runPromise(
-    performanceProgram(script, { write: (value) => Effect.sync(() => written.push(value)) }),
-  )
+    const snapshot = yield* performanceProgram(script, {
+      write: (value) => Effect.sync(() => written.push(value)),
+    })
 
-  expect(snapshot).toEqual({
-    balance: [{ date: Date.parse("2026-07-01"), value: 115, difference: 5, real_difference: 5 }],
-    deposits: [{ date: Date.parse("2026-07-01"), value: 90, difference: 10 }],
-  })
-  expect(written).toEqual([snapshot])
-  expect(script.requests).toHaveLength(4)
-  expect(requestBody(script.requests[1])).toContain('"password":"secret-password"')
-  expect(requestBody(script.requests[2])).toMatch(/"timeIntervalCode":"last_six_months"/)
-  expect(requestBody(script.requests[3])).toMatch(/"timeIntervalCode":"last_month"/)
-})
+    expect(snapshot).toEqual({
+      balance: [{ date: Date.parse("2026-07-01"), value: 115, difference: 5, real_difference: 5 }],
+      deposits: [{ date: Date.parse("2026-07-01"), value: 90, difference: 10 }],
+    })
+    expect(written).toEqual([snapshot])
+    expect(script.requests).toHaveLength(4)
+    expect(requestBody(script.requests[1])).toContain('"password":"secret-password"')
+    expect(requestBody(script.requests[2])).toMatch(/"timeIntervalCode":"last_six_months"/)
+    expect(requestBody(script.requests[3])).toMatch(/"timeIntervalCode":"last_month"/)
+  }),
+)
 
-test("completes email 2FA before it requests Goal Performance Data", async () => {
-  const script = createFetchScript([
-    response("", 200, "session=sign-in"),
-    response("{}", 201, "challenge=email"),
-    response("{}", 200, "auth=two-factor"),
-    goalPerformanceResponse("2026-01-01"),
-    goalPerformanceResponse("2026-07-01"),
-  ])
-  let codeRequests = 0
+it.effect("completes email 2FA before it requests Goal Performance Data", () =>
+  Effect.gen(function* () {
+    const script = createFetchScript([
+      response("", 200, "session=sign-in"),
+      response("{}", 201, "challenge=email"),
+      response("{}", 200, "auth=two-factor"),
+      goalPerformanceResponse("2026-01-01"),
+      goalPerformanceResponse("2026-07-01"),
+    ])
+    let codeRequests = 0
 
-  const snapshot = await Effect.runPromise(
-    performanceProgram(script, {
+    const snapshot = yield* performanceProgram(script, {
       get2FACode: () => {
         codeRequests += 1
         return Effect.succeed(Email2FACode.make("123456"))
       },
-    }),
-  )
+    })
 
-  expect(snapshot.balance).toHaveLength(1)
-  expect(codeRequests).toBe(1)
-  expect(requestBody(script.requests[1])).toContain('"password":"secret-password"')
-  expect(requestBody(script.requests[2])).toContain('"password":"secret-password"')
-  expect(requestBody(script.requests[2])).toMatch(/"code":"123456"/)
-  expect(script.requests[3]?.url ?? "").toMatch(/\/gql\/$/)
-})
+    expect(snapshot.balance).toHaveLength(1)
+    expect(codeRequests).toBe(1)
+    expect(requestBody(script.requests[1])).toContain('"password":"secret-password"')
+    expect(requestBody(script.requests[2])).toContain('"password":"secret-password"')
+    expect(requestBody(script.requests[2])).toMatch(/"code":"123456"/)
+    expect(script.requests[3]?.url ?? "").toMatch(/\/gql\/$/)
+  }),
+)
 
 describe("fails when email 2FA cannot produce a code", () => {
-  test("login requires 2FA but Gmail credentials are not configured", async () => {
-    const script = createFetchScript([response(""), response("{}", 201)])
-    let codeRequests = 0
+  it.effect("login requires 2FA but Gmail credentials are not configured", () =>
+    Effect.gen(function* () {
+      const script = createFetchScript([response(""), response("{}", 201)])
+      let codeRequests = 0
 
-    await expect(
-      Effect.runPromise(
+      const error = yield* Effect.flip(
         performanceProgram(script, {
           config: { ...CONFIG, email2FA: null },
           get2FACode: () => {
@@ -112,43 +115,47 @@ describe("fails when email 2FA cannot produce a code", () => {
             return Effect.succeed(Email2FACode.make("123456"))
           },
         }),
-      ),
-    ).rejects.toMatchObject({
-      _tag: "Email2FAFailure",
-      stage: "Fintual email 2FA",
-      message: "Fintual email 2FA: Gmail IMAP credentials not configured",
-    })
-    expect(codeRequests).toBe(0)
-    expect(script.requests).toHaveLength(2)
-  })
+      )
 
-  test("code retrieval times out", async () => {
-    const script = createFetchScript([response(""), response("{}", 201)])
+      expect(error).toMatchObject({
+        _tag: "Email2FAFailure",
+        stage: "Fintual email 2FA",
+        message: "Fintual email 2FA: Gmail IMAP credentials not configured",
+      })
+      expect(codeRequests).toBe(0)
+      expect(script.requests).toHaveLength(2)
+    }),
+  )
 
-    await expect(
-      Effect.runPromise(
+  it.effect("code retrieval times out", () =>
+    Effect.gen(function* () {
+      const script = createFetchScript([response(""), response("{}", 201)])
+
+      const error = yield* Effect.flip(
         performanceProgram(script, {
           get2FACode: () => Effect.fail(new TimedOut()),
         }),
-      ),
-    ).rejects.toMatchObject({
-      _tag: "Email2FAFailure",
-      stage: "Fintual email 2FA",
-      message: "Fintual email 2FA: no code received before timeout",
-    })
-  })
+      )
 
-  test("operational failure preserves its IMAP cause and sign-in stage", async () => {
-    const script = createFetchScript([response(""), response("{}", 201)])
-    const imapCause = new Error("IMAP connection refused")
+      expect(error).toMatchObject({
+        _tag: "Email2FAFailure",
+        stage: "Fintual email 2FA",
+        message: "Fintual email 2FA: no code received before timeout",
+      })
+    }),
+  )
 
-    await expect(
-      Effect.runPromise(
+  it.effect("operational failure preserves its IMAP cause and sign-in stage", () =>
+    Effect.gen(function* () {
+      const script = createFetchScript([response(""), response("{}", 201)])
+      const imapCause = new Error("IMAP connection refused")
+
+      const error = yield* Effect.flip(
         performanceProgram(script, {
           get2FACode: () => Effect.fail(new Operational({ cause: imapCause })),
         }),
-      ),
-    ).rejects.toSatisfy((error) => {
+      )
+
       expect(error).toMatchObject({
         _tag: "Email2FAFailure",
         stage: "Fintual email 2FA",
@@ -157,24 +164,29 @@ describe("fails when email 2FA cannot produce a code", () => {
       if (error instanceof Error) {
         expect(error.cause).toBe(imapCause)
       }
-      return true
+    }),
+  )
+})
+
+it.effect("fails with LoginFailed on a 401 initiate_login response", () =>
+  Effect.gen(function* () {
+    const script = createFetchScript([response(""), response("{}", 401)])
+
+    const error = yield* Effect.flip(performanceProgram(script))
+
+    expect(error).toMatchObject({
+      _tag: "LoginFailed",
+      status: 401,
     })
-  })
-})
+  }),
+)
 
-test("fails with LoginFailed on a 401 initiate_login response", async () => {
-  const script = createFetchScript([response(""), response("{}", 401)])
+it.effect("fails on an unexpected login response without exposing its body", () =>
+  Effect.gen(function* () {
+    const script = createFetchScript([response(""), response("session-token=secret", 418)])
 
-  await expect(Effect.runPromise(performanceProgram(script))).rejects.toMatchObject({
-    _tag: "LoginFailed",
-    status: 401,
-  })
-})
+    const error = yield* Effect.flip(performanceProgram(script))
 
-test("fails on an unexpected login response without exposing its body", async () => {
-  const script = createFetchScript([response(""), response("session-token=secret", 418)])
-
-  await expect(Effect.runPromise(performanceProgram(script))).rejects.toSatisfy((error) => {
     expect(error).toMatchObject({
       _tag: "UnexpectedHttpStatus",
       stage: "Fintual login",
@@ -184,42 +196,51 @@ test("fails on an unexpected login response without exposing its body", async ()
     if (error instanceof Error) {
       expect(error.message).not.toContain("secret")
     }
-    return true
-  })
-})
+  }),
+)
 
 describe("fails atomically when a Goal Performance Data request fails", () => {
-  test("reference request", async () => {
-    const script = createFetchScript([response(""), response("{}"), response("{}", 503)])
+  it.effect("reference request", () =>
+    Effect.gen(function* () {
+      const script = createFetchScript([response(""), response("{}"), response("{}", 503)])
 
-    await expect(Effect.runPromise(performanceProgram(script))).rejects.toMatchObject({
-      _tag: "UnexpectedHttpStatus",
-      stage: "Fintual reference Goal Performance Data",
-      status: 503,
-    })
-    expect(script.requests).toHaveLength(3)
-  })
+      const error = yield* Effect.flip(performanceProgram(script))
 
-  test("recent request", async () => {
-    const script = createFetchScript([
-      response(""),
-      response("{}"),
-      goalPerformanceResponse("2026-01-01"),
-      response("{}", 503),
-    ])
+      expect(error).toMatchObject({
+        _tag: "UnexpectedHttpStatus",
+        stage: "Fintual reference Goal Performance Data",
+        status: 503,
+      })
+      expect(script.requests).toHaveLength(3)
+    }),
+  )
 
-    await expect(Effect.runPromise(performanceProgram(script))).rejects.toMatchObject({
-      _tag: "UnexpectedHttpStatus",
-      stage: "Fintual recent Goal Performance Data",
-      status: 503,
-    })
-  })
+  it.effect("recent request", () =>
+    Effect.gen(function* () {
+      const script = createFetchScript([
+        response(""),
+        response("{}"),
+        goalPerformanceResponse("2026-01-01"),
+        response("{}", 503),
+      ])
+
+      const error = yield* Effect.flip(performanceProgram(script))
+
+      expect(error).toMatchObject({
+        _tag: "UnexpectedHttpStatus",
+        stage: "Fintual recent Goal Performance Data",
+        status: 503,
+      })
+    }),
+  )
 })
 
-test("fails with HttpTransportFailure when a request throws", async () => {
-  const script = createFetchScript([response(""), response("{}")])
+it.effect("fails with HttpTransportFailure when a request throws", () =>
+  Effect.gen(function* () {
+    const script = createFetchScript([response(""), response("{}")])
 
-  await expect(Effect.runPromise(performanceProgram(script))).rejects.toSatisfy((error) => {
+    const error = yield* Effect.flip(performanceProgram(script))
+
     expect(error).toMatchObject({
       _tag: "HttpTransportFailure",
       stage: "Fintual reference Goal Performance Data",
@@ -227,26 +248,31 @@ test("fails with HttpTransportFailure when a request throws", async () => {
     if (error instanceof Error) {
       expect(error.cause).toBeInstanceOf(Error)
     }
-    return true
-  })
-})
+  }),
+)
 
-test("fails with HttpTransportFailure when a response body cannot be read", async () => {
-  const brokenBody = response("")
-  brokenBody.text = () => Promise.reject(new Error("stream broken"))
-  const script = createFetchScript([brokenBody])
+it.effect("fails with HttpTransportFailure when a response body cannot be read", () =>
+  Effect.gen(function* () {
+    const brokenBody = response("")
+    brokenBody.text = () => Promise.reject(new Error("stream broken"))
+    const script = createFetchScript([brokenBody])
 
-  await expect(Effect.runPromise(performanceProgram(script))).rejects.toMatchObject({
-    _tag: "HttpTransportFailure",
-    stage: "Fintual sign-in page",
-  })
-})
+    const error = yield* Effect.flip(performanceProgram(script))
+
+    expect(error).toMatchObject({
+      _tag: "HttpTransportFailure",
+      stage: "Fintual sign-in page",
+    })
+  }),
+)
 
 describe("fails when Goal Performance Data is malformed or invalid", () => {
-  test("malformed JSON", async () => {
-    const script = createFetchScript([response(""), response("{}"), response("{")])
+  it.effect("malformed JSON", () =>
+    Effect.gen(function* () {
+      const script = createFetchScript([response(""), response("{}"), response("{")])
 
-    await expect(Effect.runPromise(performanceProgram(script))).rejects.toSatisfy((error) => {
+      const error = yield* Effect.flip(performanceProgram(script))
+
       expect(error).toMatchObject({
         _tag: "MalformedGoalPerformanceData",
         purpose: "reference",
@@ -254,82 +280,90 @@ describe("fails when Goal Performance Data is malformed or invalid", () => {
       if (error instanceof Error) {
         expect(error.cause).toBeInstanceOf(Error)
       }
-      return true
-    })
-  })
+    }),
+  )
 
-  test("invalid shape", async () => {
+  it.effect("invalid shape", () =>
+    Effect.gen(function* () {
+      const script = createFetchScript([
+        response(""),
+        response("{}"),
+        response(JSON.stringify({ data: {} })),
+      ])
+
+      const error = yield* Effect.flip(performanceProgram(script))
+
+      expect(error).toMatchObject({
+        _tag: "MalformedGoalPerformanceData",
+        purpose: "reference",
+      })
+    }),
+  )
+})
+
+it.effect("fails with MalformedPerformanceSnapshot when the fold output is invalid", () =>
+  Effect.gen(function* () {
     const script = createFetchScript([
       response(""),
       response("{}"),
-      response(JSON.stringify({ data: {} })),
+      goalPerformanceResponse("2026-01-01"),
+      response(JSON.stringify({ data: { balanceGraphDataPoints: [] } })),
     ])
 
-    await expect(Effect.runPromise(performanceProgram(script))).rejects.toMatchObject({
-      _tag: "MalformedGoalPerformanceData",
-      purpose: "reference",
+    const error = yield* Effect.flip(performanceProgram(script))
+
+    expect(error).toMatchObject({
+      _tag: "MalformedPerformanceSnapshot",
     })
-  })
-})
+  }),
+)
 
-test("fails with MalformedPerformanceSnapshot when the fold output is invalid", async () => {
-  const script = createFetchScript([
-    response(""),
-    response("{}"),
-    goalPerformanceResponse("2026-01-01"),
-    response(JSON.stringify({ data: { balanceGraphDataPoints: [] } })),
-  ])
+it.effect("fails with SnapshotWriteFailure when the snapshot cannot be written", () =>
+  Effect.gen(function* () {
+    const script = createFetchScript([
+      response(""),
+      response("{}"),
+      goalPerformanceResponse("2026-01-01"),
+      goalPerformanceResponse("2026-07-01"),
+    ])
 
-  await expect(Effect.runPromise(performanceProgram(script))).rejects.toMatchObject({
-    _tag: "MalformedPerformanceSnapshot",
-  })
-})
-
-test("fails with SnapshotWriteFailure when the snapshot cannot be written", async () => {
-  const script = createFetchScript([
-    response(""),
-    response("{}"),
-    goalPerformanceResponse("2026-01-01"),
-    goalPerformanceResponse("2026-07-01"),
-  ])
-
-  await expect(
-    Effect.runPromise(
+    const error = yield* Effect.flip(
       performanceProgram(script, {
         write: () => Effect.fail(new SnapshotWriteFailure({ cause: new Error("disk full") })),
       }),
-    ),
-  ).rejects.toSatisfy((error) => {
+    )
+
     expect(error).toMatchObject({ _tag: "SnapshotWriteFailure" })
     if (error instanceof Error) {
       expect(error.cause).toBeInstanceOf(Error)
     }
-    return true
-  })
-})
+  }),
+)
 
-test("propagates cookies and browser headers through the ephemeral session", async () => {
-  const script = createFetchScript([
-    response("", 200, "session=sign-in"),
-    response("{}", 200, "auth=direct"),
-    goalPerformanceResponse("2026-01-01", {}, "graph=reference"),
-    goalPerformanceResponse("2026-07-01"),
-  ])
+it.effect("propagates cookies and browser headers through the ephemeral session", () =>
+  Effect.gen(function* () {
+    const script = createFetchScript([
+      response("", 200, "session=sign-in"),
+      response("{}", 200, "auth=direct"),
+      goalPerformanceResponse("2026-01-01", {}, "graph=reference"),
+      goalPerformanceResponse("2026-07-01"),
+    ])
 
-  await Effect.runPromise(performanceProgram(script))
+    yield* performanceProgram(script)
 
-  expect(requestHeaders(script.requests[0]).get("Cookie")).toBeNull()
-  expect(requestHeaders(script.requests[1]).get("Cookie")).toBe("session=sign-in")
-  expect(requestHeaders(script.requests[2]).get("Cookie")).toBe("session=sign-in; auth=direct")
-  expect(requestHeaders(script.requests[3]).get("Cookie")).toBe(
-    "session=sign-in; auth=direct; graph=reference",
-  )
+    expect(requestHeaders(script.requests[0]).get("Cookie")).toBeNull()
+    expect(requestHeaders(script.requests[1]).get("Cookie")).toBe("session=sign-in")
+    expect(requestHeaders(script.requests[2]).get("Cookie")).toBe("session=sign-in; auth=direct")
+    expect(requestHeaders(script.requests[3]).get("Cookie")).toBe(
+      "session=sign-in; auth=direct; graph=reference",
+    )
 
-  for (const request of script.requests) {
-    expect(requestHeaders(request).get("User-Agent") ?? "").toMatch(/Mozilla\/5\.0/)
-    expect(requestHeaders(request).get("Origin")).toBe("https://fintual.cl")
-  }
-})
+    for (const request of script.requests) {
+      expect(requestHeaders(request).get("User-Agent") ?? "").toMatch(/Mozilla\/5\.0/)
+      expect(requestHeaders(request).get("Origin")).toBe("https://fintual.cl")
+    }
+  }),
+)
 
 interface RecordedRequest {
   url: string

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -1,3 +1,4 @@
+import { it as effectIt } from "@effect/vitest"
 import { Cause, Console, Effect, Logger, Redacted } from "effect"
 import { describe, expect, it } from "vitest"
 import type { RuntimeConfig } from "./env.ts"
@@ -62,108 +63,110 @@ it("registers redacted credentials when an adapter reveals them", () => {
 })
 
 describe("redactingLogger", () => {
-  it("renders timestamped, level-prefixed lines with sensitive values redacted", async () => {
-    configureLoggingSecrets()
-    const lines: Array<string> = []
-    const program = Effect.gen(function* () {
-      yield* Effect.logInfo(`Connecting with password ${secret}`)
-      yield* Effect.logError(Cause.fail(new Error(`auth failed with ${secret}`)))
-    })
+  effectIt.effect("renders timestamped, level-prefixed lines with sensitive values redacted", () =>
+    Effect.gen(function* () {
+      configureLoggingSecrets()
+      const lines: Array<string> = []
+      const program = Effect.gen(function* () {
+        yield* Effect.logInfo(`Connecting with password ${secret}`)
+        yield* Effect.logError(Cause.fail(new Error(`auth failed with ${secret}`)))
+      })
 
-    await Effect.runPromise(
-      program.pipe(
+      yield* program.pipe(
         Effect.provide(Logger.layer([redactingLogger])),
         Effect.provideService(Console.Console, captureConsole(lines)),
-      ),
-    )
+      )
 
-    expect(lines).toHaveLength(2)
-    expect(lines[0]).toMatch(
-      /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: Connecting with password \[redacted\]$/,
-    )
-    expect(lines[1]).toMatch(
-      /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] ERROR: Error: auth failed with \[redacted\]/,
-    )
-    expect(lines[1]).not.toContain(secret)
-  })
+      expect(lines).toHaveLength(2)
+      expect(lines[0]).toMatch(
+        /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: Connecting with password \[redacted\]$/,
+      )
+      expect(lines[1]).toMatch(
+        /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] ERROR: Error: auth failed with \[redacted\]/,
+      )
+      expect(lines[1]).not.toContain(secret)
+    }),
+  )
 
-  it("redacts annotation values", async () => {
-    configureLoggingSecrets()
-    const lines: Array<string> = []
-    const program = Effect.gen(function* () {
-      yield* Effect.logInfo("creating goal").pipe(Effect.annotateLogs({ goalId: "goal-42" }))
-    })
+  effectIt.effect("redacts annotation values", () =>
+    Effect.gen(function* () {
+      configureLoggingSecrets()
+      const lines: Array<string> = []
+      const program = Effect.gen(function* () {
+        yield* Effect.logInfo("creating goal").pipe(Effect.annotateLogs({ goalId: "goal-42" }))
+      })
 
-    await Effect.runPromise(
-      program.pipe(
+      yield* program.pipe(
         Effect.provide(Logger.layer([redactingLogger])),
         Effect.provideService(Console.Console, captureConsole(lines)),
-      ),
-    )
+      )
 
-    expect(lines).toHaveLength(1)
-    expect(lines[0]).toMatch(
-      /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: creating goal goalId: \[redacted\]$/,
-    )
-  })
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatch(
+        /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: creating goal goalId: \[redacted\]$/,
+      )
+    }),
+  )
 
-  it("redacts secrets split across message parts", async () => {
-    configureLoggingSecrets()
-    const lines: Array<string> = []
-    const program = Effect.gen(function* () {
-      yield* Effect.logInfo("password is", secret, "on", "goal-42")
-    })
+  effectIt.effect("redacts secrets split across message parts", () =>
+    Effect.gen(function* () {
+      configureLoggingSecrets()
+      const lines: Array<string> = []
+      const program = Effect.gen(function* () {
+        yield* Effect.logInfo("password is", secret, "on", "goal-42")
+      })
 
-    await Effect.runPromise(
-      program.pipe(
+      yield* program.pipe(
         Effect.provide(Logger.layer([redactingLogger])),
         Effect.provideService(Console.Console, captureConsole(lines)),
-      ),
-    )
+      )
 
-    expect(lines).toHaveLength(1)
-    expect(lines[0]).toMatch(
-      /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: password is \[redacted\] on \[redacted\]$/,
-    )
-  })
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatch(
+        /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] INFO: password is \[redacted\] on \[redacted\]$/,
+      )
+    }),
+  )
 })
 
 describe("reportUnhandledFailure", () => {
-  it("reports non-interrupt failures through the redacting logger", async () => {
-    configureLoggingSecrets()
-    const lines: Array<string> = []
-    const program = Effect.fail(new Error(`unexpected ${secret}`)).pipe(
-      Effect.tapCause(reportUnhandledFailure),
-      Effect.catchCause(() => Effect.void),
-    )
+  effectIt.effect("reports non-interrupt failures through the redacting logger", () =>
+    Effect.gen(function* () {
+      configureLoggingSecrets()
+      const lines: Array<string> = []
+      const program = Effect.fail(new Error(`unexpected ${secret}`)).pipe(
+        Effect.tapCause(reportUnhandledFailure),
+        Effect.catchCause(() => Effect.void),
+      )
 
-    await Effect.runPromise(
-      program.pipe(
+      yield* program.pipe(
         Effect.provide(Logger.layer([redactingLogger])),
         Effect.provideService(Console.Console, captureConsole(lines)),
-      ),
-    )
+      )
 
-    expect(lines).toHaveLength(1)
-    expect(lines[0]).toMatch(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\] ERROR: Error: unexpected \[redacted\]/)
-    expect(lines[0]).not.toContain(secret)
-  })
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatch(
+        /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] ERROR: Error: unexpected \[redacted\]/,
+      )
+      expect(lines[0]).not.toContain(secret)
+    }),
+  )
 
-  it("stays silent for interrupt-only causes", async () => {
-    configureLoggingSecrets()
-    const lines: Array<string> = []
-    const program = Effect.interrupt.pipe(
-      Effect.tapCause(reportUnhandledFailure),
-      Effect.catchCause(() => Effect.void),
-    )
+  effectIt.effect("stays silent for interrupt-only causes", () =>
+    Effect.gen(function* () {
+      configureLoggingSecrets()
+      const lines: Array<string> = []
+      const program = Effect.interrupt.pipe(
+        Effect.tapCause(reportUnhandledFailure),
+        Effect.catchCause(() => Effect.void),
+      )
 
-    await Effect.runPromise(
-      program.pipe(
+      yield* program.pipe(
         Effect.provide(Logger.layer([redactingLogger])),
         Effect.provideService(Console.Console, captureConsole(lines)),
-      ),
-    )
+      )
 
-    expect(lines).toHaveLength(0)
-  })
+      expect(lines).toHaveLength(0)
+    }),
+  )
 })

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -1,7 +1,8 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
+import { it } from "@effect/vitest"
 import { Effect } from "effect"
-import { expect, test } from "vitest"
+import { expect } from "vitest"
 import {
   PERFORMANCE_SNAPSHOT_PATH,
   validatePerformanceSnapshot,
@@ -9,95 +10,117 @@ import {
   type PerformanceSnapshot,
 } from "./performance-snapshot.ts"
 
-test("rejects a balance entry with a non-finite date and reports the failing field", async () => {
-  const invalidSnapshot = {
-    ...performanceSnapshot(),
-    balance: [{ date: Number.POSITIVE_INFINITY, value: 1100, difference: 50, real_difference: 50 }],
-  }
+it.effect("rejects a balance entry with a non-finite date and reports the failing field", () =>
+  Effect.gen(function* () {
+    const invalidSnapshot = {
+      ...performanceSnapshot(),
+      balance: [
+        { date: Number.POSITIVE_INFINITY, value: 1100, difference: 50, real_difference: 50 },
+      ],
+    }
 
-  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
-    /Fintual performance snapshot is invalid: .*balance/,
-  )
-})
+    const error = yield* Effect.flip(validatePerformanceSnapshot(invalidSnapshot))
 
-test("rejects a deposit entry with a non-finite value and reports the failing field", async () => {
-  const invalidSnapshot = {
-    ...performanceSnapshot(),
-    deposits: [{ date: 1780264800000, value: Number.NEGATIVE_INFINITY, difference: 50 }],
-  }
+    expect(error.message).toMatch(/Fintual performance snapshot is invalid: .*balance/)
+  }),
+)
 
-  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
-    /Fintual performance snapshot is invalid: .*deposits/,
-  )
-})
+it.effect("rejects a deposit entry with a non-finite value and reports the failing field", () =>
+  Effect.gen(function* () {
+    const invalidSnapshot = {
+      ...performanceSnapshot(),
+      deposits: [{ date: 1780264800000, value: Number.NEGATIVE_INFINITY, difference: 50 }],
+    }
 
-test("rejects when deposits is not an array and reports the failing field", async () => {
-  const invalidSnapshot = {
-    ...performanceSnapshot(),
-    deposits: {},
-  }
+    const error = yield* Effect.flip(validatePerformanceSnapshot(invalidSnapshot))
 
-  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
-    /Fintual performance snapshot is invalid: .*deposits/,
-  )
-})
+    expect(error.message).toMatch(/Fintual performance snapshot is invalid: .*deposits/)
+  }),
+)
 
-test("rejects an empty balance and reports the failing field", async () => {
-  const invalidSnapshot = {
-    ...performanceSnapshot(),
-    balance: [],
-  }
+it.effect("rejects when deposits is not an array and reports the failing field", () =>
+  Effect.gen(function* () {
+    const invalidSnapshot = {
+      ...performanceSnapshot(),
+      deposits: {},
+    }
 
-  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
-    /Fintual performance snapshot is invalid: .*balance/,
-  )
-})
+    const error = yield* Effect.flip(validatePerformanceSnapshot(invalidSnapshot))
 
-test("rejects an empty deposits and reports the failing field", async () => {
-  const invalidSnapshot = {
-    ...performanceSnapshot(),
-    deposits: [],
-  }
+    expect(error.message).toMatch(/Fintual performance snapshot is invalid: .*deposits/)
+  }),
+)
 
-  await expect(Effect.runPromise(validatePerformanceSnapshot(invalidSnapshot))).rejects.toThrow(
-    /Fintual performance snapshot is invalid: .*deposits/,
-  )
-})
+it.effect("rejects an empty balance and reports the failing field", () =>
+  Effect.gen(function* () {
+    const invalidSnapshot = {
+      ...performanceSnapshot(),
+      balance: [],
+    }
 
-test("returns the validated snapshot for valid data", async () => {
-  const snapshot = performanceSnapshot()
+    const error = yield* Effect.flip(validatePerformanceSnapshot(invalidSnapshot))
 
-  await expect(Effect.runPromise(validatePerformanceSnapshot(snapshot))).resolves.toEqual(snapshot)
-})
+    expect(error.message).toMatch(/Fintual performance snapshot is invalid: .*balance/)
+  }),
+)
 
-test("writes a valid Performance Snapshot to the snapshot file", async () => {
-  const originalContents = readFileIfPresent(PERFORMANCE_SNAPSHOT_PATH)
+it.effect("rejects an empty deposits and reports the failing field", () =>
+  Effect.gen(function* () {
+    const invalidSnapshot = {
+      ...performanceSnapshot(),
+      deposits: [],
+    }
 
-  try {
-    await Effect.runPromise(writePerformanceSnapshot(performanceSnapshot()))
+    const error = yield* Effect.flip(validatePerformanceSnapshot(invalidSnapshot))
 
-    const writtenSnapshot: unknown = JSON.parse(fs.readFileSync(PERFORMANCE_SNAPSHOT_PATH, "utf-8"))
-    expect(writtenSnapshot).toEqual(performanceSnapshot())
-  } finally {
-    restoreFile(PERFORMANCE_SNAPSHOT_PATH, originalContents)
-  }
-})
+    expect(error.message).toMatch(/Fintual performance snapshot is invalid: .*deposits/)
+  }),
+)
 
-test("fails when the Performance Snapshot cannot be written", async () => {
-  const snapshotPath = PERFORMANCE_SNAPSHOT_PATH
-  const originalContents = readFileIfPresent(snapshotPath)
-  fs.mkdirSync(path.dirname(snapshotPath), { recursive: true })
+it.effect("returns the validated snapshot for valid data", () =>
+  Effect.gen(function* () {
+    const snapshot = performanceSnapshot()
 
-  try {
-    fs.mkdirSync(snapshotPath, { recursive: true })
-    await expect(
-      Effect.runPromise(writePerformanceSnapshot(performanceSnapshot())),
-    ).rejects.toThrow("Failed to write performance snapshot artifact")
-  } finally {
-    fs.rmSync(snapshotPath, { force: true, recursive: true })
-    restoreFile(snapshotPath, originalContents)
-  }
-})
+    const validated = yield* validatePerformanceSnapshot(snapshot)
+
+    expect(validated).toEqual(snapshot)
+  }),
+)
+
+it.effect("writes a valid Performance Snapshot to the snapshot file", () =>
+  Effect.gen(function* () {
+    const originalContents = readFileIfPresent(PERFORMANCE_SNAPSHOT_PATH)
+
+    try {
+      yield* writePerformanceSnapshot(performanceSnapshot())
+
+      const writtenSnapshot: unknown = JSON.parse(
+        fs.readFileSync(PERFORMANCE_SNAPSHOT_PATH, "utf-8"),
+      )
+      expect(writtenSnapshot).toEqual(performanceSnapshot())
+    } finally {
+      restoreFile(PERFORMANCE_SNAPSHOT_PATH, originalContents)
+    }
+  }),
+)
+
+it.effect("fails when the Performance Snapshot cannot be written", () =>
+  Effect.gen(function* () {
+    const snapshotPath = PERFORMANCE_SNAPSHOT_PATH
+    const originalContents = readFileIfPresent(snapshotPath)
+    fs.mkdirSync(path.dirname(snapshotPath), { recursive: true })
+
+    try {
+      fs.mkdirSync(snapshotPath, { recursive: true })
+      const error = yield* Effect.flip(writePerformanceSnapshot(performanceSnapshot()))
+
+      expect(error.message).toContain("Failed to write performance snapshot artifact")
+    } finally {
+      fs.rmSync(snapshotPath, { force: true, recursive: true })
+      restoreFile(snapshotPath, originalContents)
+    }
+  }),
+)
 
 function readFileIfPresent(filePath: string): string | null {
   if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
## Summary

- add `@effect/vitest` beta.106 and migrate Effect workflow tests to `it.effect`
- preserve pure synchronous Vitest tests and deterministic TestClock/fiber synchronization
- remove manual Effect runtime bridges from migrated suites; keep the intentional `once.test.ts` alias for its Vitest `it` collision

## Verification

- `pnpm test` (12 files, 94 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm fallow:audit`

Refs #317