### PR TITLE
docs: fix AGENTS.md GitHub handle typo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ guide doesn't cover, search through the source code in `node_modules/effect/src`
 
 ### Issue tracker
 
-Issues and specs are tracked in GitHub Issues for `samluk/fintual-api`. See `docs/agents/issue-tracker.md`.
+Issues and specs are tracked in GitHub Issues for `samaluk/fintual-api`. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 


### PR DESCRIPTION
Fixes the AGENTS.md issue-tracker reference from `samluk/fintual-api` to the correct `samaluk/fintual-api`.