### PR TITLE
chore: configure Effect language service for TypeScript 7

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "./node_modules/@effect/tsgo/oxlint-schema.json",
 	"plugins": [
 		"typescript"
 	],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "js/ts.experimental.useTsgo": true,
+  "js/ts.tsdk.path": "./node_modules/typescript/bin",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+  "js/ts.tsdk.additionalLocations": [
+    "./node_modules/typescript/bin"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,23 @@ Friction is logged with Frog (see https://frog.fm). Use `pnpx frog log` to write
 - Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `pnpx frog log`.
 - Do not add global, system, or internal friction.
 - Run `pnpx frog list` first to see what is already known.
+
+<!-- effect-solutions:start -->
+## Effect Best Practices
+
+**IMPORTANT:** Always consult effect-solutions before writing Effect code.
+
+1. Run `effect-solutions list` to see available guides
+2. Run `effect-solutions show <topic>...` for relevant patterns (supports multiple topics)
+3. Search `~/.local/share/effect-solutions/effect` for real implementations
+
+Topics: quick-start, project-setup, tsconfig, basics, services-and-layers, data-modeling, error-handling, config, testing, cli.
+
+Never guess at Effect patterns - check the guide first.
+<!-- effect-solutions:end -->
+
+## Local Effect Source
+
+The Effect v4 repository is cloned to `~/.local/share/effect-solutions/effect` for
+reference. Use this to explore APIs, find usage examples, and understand
+implementation details when the documentation isn't enough.

--- a/fallow-baselines/dead-code.json
+++ b/fallow-baselines/dead-code.json
@@ -7,7 +7,7 @@
       "api-surface",
       "type-coupling"
     ],
-    "project_config_hash": "sha256:76a6319b0f34c1bd0047de6a465336ce482adefc7c2e7c3d7e0f53c5dc3d53f1",
+    "project_config_hash": "sha256:2f7f00a3abcf1a063bfa964e56f8f5b16e00e4ec3e3af93415310c0b8d204c55",
     "backend_family": "typescript-go",
     "completeness": "complete"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"packageManager": "pnpm@11.20.0",
 	"type": "module",
 	"devDependencies": {
+		"@effect/tsgo": "0.36.3",
 		"@effect/vitest": "4.0.0-beta.106",
 		"@types/mailparser": "3.4.6",
 		"@types/node": "24.13.3",
@@ -35,6 +36,7 @@
 		"fallow:fix": "fallow fix --yes",
 		"dev": "node src/once.ts",
 		"once": "node src/once.ts",
-		"capture:har": "sh bin/capture-fintual-har.sh"
+		"capture:har": "sh bin/capture-fintual-har.sh",
+		"prepare": "if [ -x node_modules/.bin/effect-tsgo ]; then effect-tsgo patch --typescript; fi"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
         specifier: 3.9.15
         version: 3.9.15
     devDependencies:
+      '@effect/tsgo':
+        specifier: 0.36.3
+        version: 0.36.3
       '@effect/vitest':
         specifier: 4.0.0-beta.106
         version: 4.0.0-beta.106(effect@4.0.0-beta.106)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)))
@@ -82,6 +85,45 @@ packages:
     peerDependencies:
       effect: ^4.0.0-beta.106
       ioredis: '>=5.7.0 <6.0.0'
+
+  '@effect/tsgo-darwin-arm64@0.36.3':
+    resolution: {integrity: sha512-0tTa44tsL6qVApKtahoMKSFaU5M61rEhmiqFss8M0lDmNmQWv1i366ZEBqAxauBrVgnqW5oa907mXoXhmIJnoQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@effect/tsgo-darwin-x64@0.36.3':
+    resolution: {integrity: sha512-fUpQ1bB1bziS8K0f/jkjvYQF3tfj+nX4T111U+eF1KMnBinGIQkebrkhPrNoui+pgh094UvXz4oIElqB3M5a/A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@effect/tsgo-linux-arm64@0.36.3':
+    resolution: {integrity: sha512-xFqoHov+QnvlxWBnbIFFZAA9bqHKp19G16XMxTlG9x/k5r1h+aHxSKvvg0d3Xw4eYXT5Ia9EpozVm6Fqo/sxEg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@effect/tsgo-linux-arm@0.36.3':
+    resolution: {integrity: sha512-cctKNEVlBCFoI1K0fTQU3+GJyZseCsobYVQTMPKg5ZyTpp6cL9Yb0s3QXGl7iR+QsBWbgKG7iPEUdETnwmqa/A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@effect/tsgo-linux-x64@0.36.3':
+    resolution: {integrity: sha512-waEzltVTecHUF0ye9c/A42MJoLgWua+QbcCqXwkNOUJrqqiM1z4l+C5S9gPT0D7aFYmEC7ubPYnkJS7Nj7S+rg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@effect/tsgo-win32-arm64@0.36.3':
+    resolution: {integrity: sha512-VgghUPRC8C11NY4svWU2vvDGRYJFp7WJ0orZbAEXgeFVC8AExqJiLJNgF9G+oqSVacbb+pWG6PLUmSMpELXncw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@effect/tsgo-win32-x64@0.36.3':
+    resolution: {integrity: sha512-iMFP0+TpGMxaruaGSTI0wN4QgoQQZ2UAWtfU+7cJPIW5DPQptvRu355FoPD/TqUEBHMYlhK3T9yDOfFkWWa22A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@effect/tsgo@0.36.3':
+    resolution: {integrity: sha512-o+wLixwnAla67MMbkcX7Amg7SpTWYv+Vr5jqv2+wAzAe2iwgAqiAxEbQWs4sY2ixngAHnf+X6+d4AEsiPWyRtA==}
+    hasBin: true
 
   '@effect/vitest@4.0.0-beta.106':
     resolution: {integrity: sha512-0w799orFqjFNlKh9GrnzMIJLn2/uPaVu8qmT3hJKkYxS46tUS9ZbfjeYNsd1BddvY+3sdS/vXVpnTE64z6+QaQ==}
@@ -1539,6 +1581,37 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@effect/tsgo-darwin-arm64@0.36.3':
+    optional: true
+
+  '@effect/tsgo-darwin-x64@0.36.3':
+    optional: true
+
+  '@effect/tsgo-linux-arm64@0.36.3':
+    optional: true
+
+  '@effect/tsgo-linux-arm@0.36.3':
+    optional: true
+
+  '@effect/tsgo-linux-x64@0.36.3':
+    optional: true
+
+  '@effect/tsgo-win32-arm64@0.36.3':
+    optional: true
+
+  '@effect/tsgo-win32-x64@0.36.3':
+    optional: true
+
+  '@effect/tsgo@0.36.3':
+    optionalDependencies:
+      '@effect/tsgo-darwin-arm64': 0.36.3
+      '@effect/tsgo-darwin-x64': 0.36.3
+      '@effect/tsgo-linux-arm': 0.36.3
+      '@effect/tsgo-linux-arm64': 0.36.3
+      '@effect/tsgo-linux-x64': 0.36.3
+      '@effect/tsgo-win32-arm64': 0.36.3
+      '@effect/tsgo-win32-x64': 0.36.3
 
   '@effect/vitest@4.0.0-beta.106(effect@4.0.0-beta.106)(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)))':
     dependencies:

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -247,7 +247,7 @@ it.effect("shuts down the scoped Actual session when the workflow is interrupted
       download: () =>
         Effect.gen(function* () {
           calls.push("download")
-          yield* Effect.never
+          return yield* Effect.never
         }),
     })
     const fiber = yield* Effect.forkChild(synchronizationProgram([client], calls))

--- a/src/actual/actual-error.ts
+++ b/src/actual/actual-error.ts
@@ -8,7 +8,7 @@ export class ActualDataDirectoryFailure extends Schema.TaggedError<ActualDataDir
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to reset Actual data directory: ${getErrorMessage(this.cause)}`
   }
 }
@@ -22,7 +22,7 @@ export class ActualHealthCheckFailure extends Schema.TaggedError<ActualHealthChe
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Actual server is unreachable at ${this.url}: ${getErrorMessage(this.cause)}`
   }
 }
@@ -34,7 +34,7 @@ export class ActualInitializationFailure extends Schema.TaggedError<ActualInitia
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to initialize Actual API: ${getErrorMessage(this.cause)}`
   }
 }
@@ -46,7 +46,7 @@ export class ActualBudgetDownloadFailure extends Schema.TaggedError<ActualBudget
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to download Actual budget: ${getErrorMessage(this.cause)}`
   }
 }
@@ -58,7 +58,7 @@ export class ActualTransactionsReadFailure extends Schema.TaggedError<ActualTran
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to fetch Actual transactions: ${getErrorMessage(this.cause)}`
   }
 }
@@ -70,7 +70,7 @@ export class ActualPayeesReadFailure extends Schema.TaggedError<ActualPayeesRead
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to fetch Actual payees: ${getErrorMessage(this.cause)}`
   }
 }
@@ -82,7 +82,7 @@ export class ActualTransactionCreationFailure extends Schema.TaggedError<ActualT
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to add Actual transaction: ${getErrorMessage(this.cause)}`
   }
 }
@@ -94,7 +94,7 @@ export class ActualTransactionUpdateFailure extends Schema.TaggedError<ActualTra
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to update Actual transaction: ${getErrorMessage(this.cause)}`
   }
 }
@@ -106,7 +106,7 @@ export class ActualDuplicateDeletionFailure extends Schema.TaggedError<ActualDup
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to delete duplicate Actual transaction: ${getErrorMessage(this.cause)}`
   }
 }
@@ -118,7 +118,7 @@ export class ActualSyncFailure extends Schema.TaggedError<ActualSyncFailure>()(
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to sync Actual budget: ${getErrorMessage(this.cause)}`
   }
 }
@@ -130,7 +130,7 @@ export class ActualShutdownFailure extends Schema.TaggedError<ActualShutdownFail
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Failed to shutdown Actual API: ${getErrorMessage(this.cause)}`
   }
 }
@@ -142,7 +142,7 @@ export class ActualInvalidStartingDate extends Schema.TaggedError<ActualInvalidS
     retryable: Schema.Boolean,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Actual starting date is invalid: ${this.startingDate}`
   }
 }

--- a/src/fintual/email-2fa-client.ts
+++ b/src/fintual/email-2fa-client.ts
@@ -28,7 +28,7 @@ export class MissingServerExtension extends Schema.TaggedError<MissingServerExte
     cause: Schema.Defect(),
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return getErrorMessage(this.cause)
   }
 }

--- a/src/fintual/email-2fa/retrieve.ts
+++ b/src/fintual/email-2fa/retrieve.ts
@@ -32,7 +32,7 @@ export class TimedOut extends Schema.TaggedError<TimedOut>()("TimedOut", {}) {}
 export class Operational extends Schema.TaggedError<Operational>()("Operational", {
   cause: Schema.Defect(),
 }) {
-  get message(): string {
+  override get message(): string {
     return getErrorMessage(this.cause)
   }
 }

--- a/src/fintual/fintual-error.ts
+++ b/src/fintual/fintual-error.ts
@@ -8,7 +8,7 @@ export class UnexpectedHttpStatus extends Schema.TaggedError<UnexpectedHttpStatu
     status: Schema.Number,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `${this.stage}: unexpected HTTP status ${this.status}`
   }
 }
@@ -20,7 +20,7 @@ export class HttpTransportFailure extends Schema.TaggedError<HttpTransportFailur
     cause: Schema.Defect(),
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return getErrorMessage(this.cause)
   }
 }
@@ -28,7 +28,7 @@ export class HttpTransportFailure extends Schema.TaggedError<HttpTransportFailur
 export class LoginFailed extends Schema.TaggedError<LoginFailed>()("LoginFailed", {
   status: Schema.Number,
 }) {
-  get message(): string {
+  override get message(): string {
     return `Fintual login: unexpected HTTP status ${this.status}`
   }
 }
@@ -40,7 +40,7 @@ export class MalformedGoalPerformanceData extends Schema.TaggedError<MalformedGo
     cause: Schema.Defect(),
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Fintual ${this.purpose} Goal Performance Data: validation failed`
   }
 }
@@ -51,7 +51,7 @@ export class MalformedPerformanceSnapshot extends Schema.TaggedError<MalformedPe
     issues: Schema.String,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Fintual performance snapshot is invalid: ${this.issues}`
   }
 }
@@ -60,7 +60,7 @@ export class Email2FAFailure extends Schema.TaggedError<Email2FAFailure>()("Emai
   stage: Schema.String,
   cause: Schema.Defect(),
 }) {
-  get message(): string {
+  override get message(): string {
     return getErrorMessage(this.cause)
   }
 }
@@ -71,7 +71,7 @@ export class SnapshotWriteFailure extends Schema.TaggedError<SnapshotWriteFailur
     cause: Schema.Defect(),
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return getErrorMessage(this.cause)
   }
 }

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -30,7 +30,7 @@ class PerformanceSnapshotValidationError extends Schema.TaggedError<PerformanceS
     issues: Schema.String,
   },
 ) {
-  get message(): string {
+  override get message(): string {
     return `Fintual performance snapshot is invalid: ${this.issues}`
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "./node_modules/@effect/tsgo/schema.json",
 	"compilerOptions": {
 		"lib": [
 			"ESNext",
@@ -7,19 +8,27 @@
 		"target": "ESNext",
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
-		"allowImportingTsExtensions": true,
+		"moduleDetection": "force",
+		"rewriteRelativeImportExtensions": true,
 		"noEmit": true,
 		"verbatimModuleSyntax": true,
 		"erasableSyntaxOnly": true,
 		"strict": true,
+		"noImplicitOverride": true,
 		"skipLibCheck": true,
 		"noFallthroughCasesInSwitch": true,
-		"noUnusedLocals": false,
-		"noUnusedParameters": false,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
 		"noPropertyAccessFromIndexSignature": false,
 		"skipDefaultLibCheck": true,
 		"types": [
 			"node"
+		],
+		"plugins": [
+			{
+				"name": "@effect/language-service",
+				"ignoreEffectWarningsInTscExitCode": true
+			}
 		]
 	},
 	"include": [


### PR DESCRIPTION
## Summary

Configure the repo to work with Effect tooling under TypeScript 7.

This repo uses TypeScript 7.0.2, so the classic `@effect/language-service` patch path does not apply (it supports TS 5/6 only). Instead, this wires the TS 7-compatible `@effect/tsgo` setup, which provides the same Effect diagnostics, quick fixes, and refactors.

## Changes

- `docs: add Effect setup guidance for agents` - AGENTS.md Effect best practices and local Effect source reference
- `test: preserve definitive exit for interrupted workflow` - use `return yield* Effect.never` for the Effect diagnostic
- `refactor: mark tagged error message getters as overrides` - required by `noImplicitOverride`
- `chore: configure Effect language service for TypeScript 7` - add `@effect/tsgo`, prepare patch, tsconfig plugin and strict compiler options, tsgo Oxlint schema, and VS Code native TS 7 settings
- `chore: refresh Fallow dead-code baseline` - regenerate baseline after the tsconfig change

## Notes

- `exactOptionalPropertyTypes` was deliberately not enabled: it currently requires optional-vs-`undefined` changes in 7 files and should be a separate follow-up.
- Effect warnings and suggestions now show in `tsc` output; warnings are configured not to fail the exit code.

## Verification

Pre-push hooks passed: oxfmt, oxlint, typecheck, 94 tests, and Fallow audit.

Follow-up tracked in #343: remove the Effect warning exit-code suppression after fixing the warnings.