### PR TITLE
fix: remove Effect warning suppression with tagged failures (#343)

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -7,6 +7,9 @@
   "dynamicallyLoaded": [
     "bin/fintual-goal-performance.graphql"
   ],
+  "ignoreDependencies": [
+    "@effect/tsgo"
+  ],
   "typeAware": {
     "enabled": true,
     "require": "complete",

--- a/fallow-baselines/dead-code.json
+++ b/fallow-baselines/dead-code.json
@@ -7,7 +7,7 @@
       "api-surface",
       "type-coupling"
     ],
-    "project_config_hash": "sha256:2f7f00a3abcf1a063bfa964e56f8f5b16e00e4ec3e3af93415310c0b8d204c55",
+    "project_config_hash": "sha256:aa181832bbdc7bcc9c9cdfb2059ea8009dac18cd2912fe8c08aa5110e8e9ed64",
     "backend_family": "typescript-go",
     "completeness": "complete"
   },

--- a/src/fintual/authenticated-ingestion.ts
+++ b/src/fintual/authenticated-ingestion.ts
@@ -59,30 +59,31 @@ class FintualHttpSession {
         headers.set("Cookie", cookieHeader)
       }
 
-      const response = yield* Effect.mapError(
-        Effect.tryPromise({
-          try: (signal) =>
-            this.fetchRequest(`${FINTUAL_ORIGIN}${path}`, {
-              ...init,
-              headers,
-              signal: AbortSignal.any([signal, AbortSignal.timeout(this.requestTimeoutMs)]),
-            }),
-          catch: (cause) =>
-            new Error(`${stage}: request failed: ${getErrorMessage(cause)}`, { cause }),
-        }),
-        (cause) => new HttpTransportFailure({ stage, cause }),
-      )
+      const response = yield* Effect.tryPromise({
+        try: (signal) =>
+          this.fetchRequest(`${FINTUAL_ORIGIN}${path}`, {
+            ...init,
+            headers,
+            signal: AbortSignal.any([signal, AbortSignal.timeout(this.requestTimeoutMs)]),
+          }),
+        catch: (cause) =>
+          new HttpTransportFailure({
+            stage,
+            cause: new Error(`${stage}: request failed: ${getErrorMessage(cause)}`, { cause }),
+          }),
+      })
 
-      yield* Effect.mapError(
-        Effect.try({
-          try: () => mergeSetCookieHeaders(response.headers, this.cookies),
-          catch: (cause) =>
-            new Error(`${stage}: failed to update session cookies: ${getErrorMessage(cause)}`, {
-              cause,
-            }),
-        }),
-        (cause) => new HttpTransportFailure({ stage, cause }),
-      )
+      yield* Effect.try({
+        try: () => mergeSetCookieHeaders(response.headers, this.cookies),
+        catch: (cause) =>
+          new HttpTransportFailure({
+            stage,
+            cause: new Error(
+              `${stage}: failed to update session cookies: ${getErrorMessage(cause)}`,
+              { cause },
+            ),
+          }),
+      })
 
       return response
     },

--- a/src/fintual/email-2fa-client.ts
+++ b/src/fintual/email-2fa-client.ts
@@ -1,7 +1,7 @@
 import { Effect, Predicate, Schema } from "effect"
 import { ImapFlow, type SearchObject } from "imapflow"
 import type { Email2FAConfig } from "../env.ts"
-import { getErrorMessage, revealSecret, toError } from "../log.ts"
+import { getErrorMessage, revealSecret } from "../log.ts"
 
 export interface ImapMailboxLock {
   release(): void
@@ -15,11 +15,15 @@ export interface ImapMessage {
 
 export interface ImapClient {
   readonly usable: boolean
-  connect(): Effect.Effect<void, Error>
-  getMailboxLock(path: string): Effect.Effect<ImapMailboxLock, Error | MissingMailbox>
-  search(query: SearchObject): Effect.Effect<number[] | false, Error | MissingServerExtension>
-  fetchOne(uid: number): Effect.Effect<ImapMessage | null, Error>
-  logout(): Effect.Effect<void, Error>
+  connect(): Effect.Effect<void, ImapOperationFailure>
+  getMailboxLock(
+    path: string,
+  ): Effect.Effect<ImapMailboxLock, ImapMailboxLockFailure | MissingMailbox>
+  search(
+    query: SearchObject,
+  ): Effect.Effect<number[] | false, ImapOperationFailure | MissingServerExtension>
+  fetchOne(uid: number): Effect.Effect<ImapMessage | null, ImapOperationFailure>
+  logout(): Effect.Effect<void, ImapOperationFailure>
 }
 
 export class MissingServerExtension extends Schema.TaggedError<MissingServerExtension>()(
@@ -38,6 +42,30 @@ export class MissingMailbox extends Schema.TaggedError<MissingMailbox>()("Missin
   cause: Schema.Defect(),
 }) {}
 
+export class ImapOperationFailure extends Schema.TaggedError<ImapOperationFailure>()(
+  "ImapOperationFailure",
+  {
+    stage: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `${this.stage}: ${getErrorMessage(this.cause)}`
+  }
+}
+
+export class ImapMailboxLockFailure extends Schema.TaggedError<ImapMailboxLockFailure>()(
+  "ImapMailboxLockFailure",
+  {
+    path: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to lock Gmail IMAP mailbox ${this.path}: ${getErrorMessage(this.cause)}`
+  }
+}
+
 export class ImapFlowClient implements ImapClient {
   private readonly raw: ImapFlow
 
@@ -51,10 +79,11 @@ export class ImapFlowClient implements ImapClient {
 
   readonly connect = Effect.fn("Email2FA.ImapFlowClient.connect")(
     { self: this },
-    function* (this: ImapFlowClient): Effect.fn.Return<void, Error> {
+    function* (this: ImapFlowClient): Effect.fn.Return<void, ImapOperationFailure> {
       yield* Effect.tryPromise({
         try: () => this.raw.connect(),
-        catch: (error) => toError(error, "Failed to connect to Gmail IMAP"),
+        catch: (cause) =>
+          new ImapOperationFailure({ stage: "Failed to connect to Gmail IMAP", cause }),
       })
     },
   )
@@ -64,15 +93,13 @@ export class ImapFlowClient implements ImapClient {
     function* (
       this: ImapFlowClient,
       path: string,
-    ): Effect.fn.Return<ImapMailboxLock, Error | MissingMailbox> {
+    ): Effect.fn.Return<ImapMailboxLock, ImapMailboxLockFailure | MissingMailbox> {
       return yield* Effect.tryPromise({
         try: () => this.raw.getMailboxLock(path),
         catch: (cause) =>
           Predicate.isObject(cause) && cause.mailboxMissing === true
             ? new MissingMailbox({ path, cause })
-            : new Error(`Failed to lock Gmail IMAP mailbox ${path}: ${getErrorMessage(cause)}`, {
-                cause,
-              }),
+            : new ImapMailboxLockFailure({ path, cause }),
       })
     },
   )
@@ -82,7 +109,7 @@ export class ImapFlowClient implements ImapClient {
     function* (
       this: ImapFlowClient,
       query: SearchObject,
-    ): Effect.fn.Return<number[] | false, Error | MissingServerExtension> {
+    ): Effect.fn.Return<number[] | false, ImapOperationFailure | MissingServerExtension> {
       return yield* Effect.tryPromise({
         try: () => this.raw.search(query, { uid: true }),
         catch: (cause) => {
@@ -91,7 +118,8 @@ export class ImapFlowClient implements ImapClient {
           if (originalError?.code === "MissingServerExtension") {
             return new MissingServerExtension({ cause })
           }
-          return new Error(`Failed to search Gmail IMAP mailbox: ${getErrorMessage(cause)}`, {
+          return new ImapOperationFailure({
+            stage: "Failed to search Gmail IMAP mailbox",
             cause,
           })
         },
@@ -101,7 +129,10 @@ export class ImapFlowClient implements ImapClient {
 
   readonly fetchOne = Effect.fn("Email2FA.ImapFlowClient.fetchOne")(
     { self: this },
-    function* (this: ImapFlowClient, uid: number): Effect.fn.Return<ImapMessage | null, Error> {
+    function* (
+      this: ImapFlowClient,
+      uid: number,
+    ): Effect.fn.Return<ImapMessage | null, ImapOperationFailure> {
       return yield* Effect.map(
         Effect.tryPromise({
           try: () =>
@@ -110,7 +141,11 @@ export class ImapFlowClient implements ImapClient {
               { source: true, envelope: true, internalDate: true },
               { uid: true },
             ),
-          catch: (error) => toError(error, "Failed to fetch Gmail IMAP message"),
+          catch: (cause) =>
+            new ImapOperationFailure({
+              stage: "Failed to fetch Gmail IMAP message",
+              cause,
+            }),
         }),
         (message) =>
           message
@@ -126,10 +161,14 @@ export class ImapFlowClient implements ImapClient {
 
   readonly logout = Effect.fn("Email2FA.ImapFlowClient.logout")(
     { self: this },
-    function* (this: ImapFlowClient): Effect.fn.Return<void, Error> {
+    function* (this: ImapFlowClient): Effect.fn.Return<void, ImapOperationFailure> {
       yield* Effect.tryPromise({
         try: () => this.raw.logout(),
-        catch: (error) => toError(error, "Failed to close IMAP connection cleanly"),
+        catch: (cause) =>
+          new ImapOperationFailure({
+            stage: "Failed to close IMAP connection cleanly",
+            cause,
+          }),
       })
     },
   )

--- a/src/fintual/email-2fa/email-2fa-policy.ts
+++ b/src/fintual/email-2fa/email-2fa-policy.ts
@@ -1,7 +1,7 @@
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import type { SearchObject } from "imapflow"
 import { simpleParser } from "mailparser"
-import { toError } from "../../log.ts"
+import { getErrorMessage } from "../../log.ts"
 
 export interface Email2FASearchPolicy {
   host: string
@@ -12,6 +12,17 @@ export interface Email2FACandidate {
   source: Buffer | Uint8Array
   envelopeSubject?: string
   receivedAt?: Date
+}
+
+export class EmailMessageParseFailure extends Schema.TaggedError<EmailMessageParseFailure>()(
+  "EmailMessageParseFailure",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to parse Gmail IMAP message: ${getErrorMessage(this.cause)}`
+  }
 }
 
 export function buildEmail2FASearchQueries(
@@ -36,7 +47,7 @@ export function buildEmail2FASearchQueries(
 export const selectEmail2FACode = Effect.fn("Email2FA.selectEmail2FACode")(function* (
   candidates: Iterable<Email2FACandidate>,
   afterTimestamp: Date,
-): Effect.fn.Return<string | null, Error> {
+): Effect.fn.Return<string | null, EmailMessageParseFailure> {
   for (const candidate of candidates) {
     if (candidate.receivedAt && candidate.receivedAt < afterTimestamp) {
       continue
@@ -69,7 +80,7 @@ function formatGmailAfterDate(date: Date): string {
 
 const collectMessageSources = Effect.fn("Email2FA.collectMessageSources")(function* (
   candidate: Email2FACandidate,
-): Effect.fn.Return<string[], Error> {
+): Effect.fn.Return<string[], EmailMessageParseFailure> {
   const sources: string[] = []
   if (candidate.envelopeSubject) {
     sources.push(candidate.envelopeSubject)
@@ -77,7 +88,7 @@ const collectMessageSources = Effect.fn("Email2FA.collectMessageSources")(functi
 
   const parsedMessage = yield* Effect.tryPromise({
     try: () => simpleParser(Buffer.from(candidate.source)),
-    catch: (error) => toError(error, "Failed to parse Gmail IMAP message"),
+    catch: (cause) => new EmailMessageParseFailure({ cause }),
   })
   if (parsedMessage.subject) {
     sources.push(parsedMessage.subject)

--- a/src/fintual/email-2fa/retrieve.test.ts
+++ b/src/fintual/email-2fa/retrieve.test.ts
@@ -5,6 +5,8 @@ import { describe, expect } from "vitest"
 import type { SearchObject } from "imapflow"
 import type { Email2FAConfig } from "../../env.ts"
 import {
+  ImapMailboxLockFailure,
+  ImapOperationFailure,
   MissingMailbox,
   MissingServerExtension,
   type ImapClient,
@@ -34,11 +36,14 @@ const NON_GMAIL_CONFIG: Email2FAConfig = {
 const GMAIL_CONFIG: Email2FAConfig = { ...NON_GMAIL_CONFIG, host: "imap.gmail.com" }
 
 interface FakeClientOptions {
-  connectError?: Error
+  connectError?: ImapOperationFailure
   lockFailures?: ReadonlySet<string>
-  lockError?: Error
-  search?: (query: SearchObject, searchCount: number) => number[] | false | Error
-  fetchOne?: (uid: number) => ImapMessage | null | Error
+  lockError?: ImapMailboxLockFailure
+  search?: (
+    query: SearchObject,
+    searchCount: number,
+  ) => number[] | false | ImapOperationFailure | MissingServerExtension
+  fetchOne?: (uid: number) => ImapMessage | null | ImapOperationFailure
 }
 
 interface FakeClient {
@@ -65,7 +70,9 @@ function createFakeClient(options: FakeClientOptions = {}): FakeClient {
         usable = true
       })
     },
-    getMailboxLock: (path: string): Effect.Effect<ImapMailboxLock, Error> => {
+    getMailboxLock: (
+      path: string,
+    ): Effect.Effect<ImapMailboxLock, ImapMailboxLockFailure | MissingMailbox> => {
       ops.push(`lock:${path}`)
       if (options.lockError) {
         return Effect.fail(options.lockError)
@@ -206,7 +213,10 @@ describe("retrieveEmail2FACode", () => {
   it.effect("surfaces a connect failure as Operational without logging out", () =>
     Effect.gen(function* () {
       const fake = createFakeClient({
-        connectError: new Error("connection refused"),
+        connectError: new ImapOperationFailure({
+          stage: "Failed to connect to Gmail IMAP",
+          cause: new Error("connection refused"),
+        }),
         search: () => false,
       })
 
@@ -269,7 +279,12 @@ describe("retrieveEmail2FACode recoverability", () => {
 
   it.effect("surfaces a non-missing mailbox lock failure as Operational", () =>
     Effect.gen(function* () {
-      const fake = createFakeClient({ lockError: new Error("connection dropped") })
+      const fake = createFakeClient({
+        lockError: new ImapMailboxLockFailure({
+          path: "INBOX",
+          cause: new Error("connection dropped"),
+        }),
+      })
 
       const exit = yield* runRetrieval(
         GMAIL_CONFIG,
@@ -292,7 +307,10 @@ describe("retrieveEmail2FACode recoverability", () => {
           search: () => [111, 222],
           fetchOne: (uid) => {
             if (uid === 111) {
-              return new Error("message stream broken")
+              return new ImapOperationFailure({
+                stage: "Failed to fetch Gmail IMAP message",
+                cause: new Error("message stream broken"),
+              })
             }
             return messageWithCode("222222")
           },
@@ -322,7 +340,12 @@ describe("retrieveEmail2FACode recoverability", () => {
         search: () => [111],
         fetchOne: () => {
           fetches += 1
-          return fetches === 1 ? new Error("message stream broken") : messageWithCode("111111")
+          return fetches === 1
+            ? new ImapOperationFailure({
+                stage: "Failed to fetch Gmail IMAP message",
+                cause: new Error("message stream broken"),
+              })
+            : messageWithCode("111111")
         },
       })
 
@@ -344,7 +367,13 @@ describe("retrieveEmail2FACode recoverability", () => {
 
   it.effect("surfaces a search failure as Operational", () =>
     Effect.gen(function* () {
-      const fake = createFakeClient({ search: () => new Error("IMAP search failed") })
+      const fake = createFakeClient({
+        search: () =>
+          new ImapOperationFailure({
+            stage: "Failed to search Gmail IMAP mailbox",
+            cause: new Error("IMAP search failed"),
+          }),
+      })
 
       const exit = yield* runRetrieval(
         NON_GMAIL_CONFIG,

--- a/src/fintual/email-2fa/retrieve.ts
+++ b/src/fintual/email-2fa/retrieve.ts
@@ -1,9 +1,16 @@
 import { Clock, Context, Effect, Layer, Option, Schedule, Schema } from "effect"
 import type { Email2FAConfig } from "../../env.ts"
 import { getErrorMessage } from "../../log.ts"
-import { createImapClient, MissingServerExtension, type ImapClient } from "../email-2fa-client.ts"
+import {
+  createImapClient,
+  ImapMailboxLockFailure,
+  ImapOperationFailure,
+  MissingServerExtension,
+  type ImapClient,
+} from "../email-2fa-client.ts"
 import {
   buildEmail2FASearchQueries,
+  EmailMessageParseFailure,
   isGmailImapHost,
   selectEmail2FACode,
   type Email2FACandidate,
@@ -113,7 +120,7 @@ export const retrieveEmail2FACode = Effect.fn("Email2FA.retrieveEmail2FACode")(f
 const connectImapClient = Effect.fn("Email2FA.connectImapClient")(function* (
   clientFactory: ImapClientFactory["Service"],
   config: Email2FAConfig,
-): Effect.fn.Return<ImapClient, Error> {
+): Effect.fn.Return<ImapClient, ImapOperationFailure> {
   const imapClient = clientFactory.create(config)
   yield* imapClient.connect()
   return imapClient
@@ -144,7 +151,10 @@ const pollForCode = Effect.fn("Email2FA.pollForCode")(function* (
   imapClient: ImapClient,
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
-): Effect.fn.Return<Option.Option<Email2FACode>, Error> {
+): Effect.fn.Return<
+  Option.Option<Email2FACode>,
+  ImapOperationFailure | ImapMailboxLockFailure | EmailMessageParseFailure
+> {
   for (const mailboxPath of imapSearchMailboxes(config)) {
     const code = yield* searchMailbox(
       config,
@@ -174,7 +184,10 @@ const searchMailbox = Effect.fn("Email2FA.searchMailbox")(function* (
   mailboxPath: string,
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
-): Effect.fn.Return<Option.Option<Email2FACode>, Error> {
+): Effect.fn.Return<
+  Option.Option<Email2FACode>,
+  ImapOperationFailure | ImapMailboxLockFailure | EmailMessageParseFailure
+> {
   const lock = yield* Effect.catchTag(
     imapClient.getMailboxLock(mailboxPath),
     "MissingMailbox",
@@ -199,7 +212,7 @@ const searchLockedMailbox = Effect.fn("Email2FA.searchLockedMailbox")(function* 
   mailboxPath: string,
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
-): Effect.fn.Return<Option.Option<Email2FACode>, Error> {
+): Effect.fn.Return<Option.Option<Email2FACode>, ImapOperationFailure | EmailMessageParseFailure> {
   const messageUids = yield* runMailboxSearch(config, imapClient, afterTimestamp)
   if (config.debug) {
     yield* Effect.log(
@@ -223,7 +236,7 @@ const runMailboxSearch = Effect.fn("Email2FA.runMailboxSearch")(function* (
   config: Email2FAConfig,
   imapClient: ImapClient,
   afterTimestamp: Date,
-): Effect.fn.Return<number[] | false, Error> {
+): Effect.fn.Return<number[] | false, ImapOperationFailure> {
   const queries = buildEmail2FASearchQueries(config, afterTimestamp)
 
   for (const query of queries) {
@@ -246,7 +259,7 @@ const extractCodeFromMailboxUids = Effect.fn("Email2FA.extractCodeFromMailboxUid
   messageUids: number[],
   afterTimestamp: Date,
   seenMessageKeys: Set<string>,
-): Effect.fn.Return<Option.Option<Email2FACode>, Error> {
+): Effect.fn.Return<Option.Option<Email2FACode>, EmailMessageParseFailure> {
   const recentUids = messageUids.slice(-MAX_RESULTS).reverse()
 
   const candidates: Email2FACandidate[] = []

--- a/src/fintual/fintual-error.ts
+++ b/src/fintual/fintual-error.ts
@@ -49,6 +49,7 @@ export class MalformedPerformanceSnapshot extends Schema.TaggedError<MalformedPe
   "MalformedPerformanceSnapshot",
   {
     issues: Schema.String,
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {

--- a/src/fintual/new-performance.ts
+++ b/src/fintual/new-performance.ts
@@ -63,30 +63,49 @@ const goalPerformanceDataResponseSchema = Schema.Struct({
 
 export type GoalPerformanceData = (typeof goalPerformanceDataResponseSchema.Type)["data"]
 
+class InvalidGoalPerformanceResponse extends Schema.TaggedError<InvalidGoalPerformanceResponse>()(
+  "InvalidGoalPerformanceResponse",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return getErrorMessage(this.cause)
+  }
+}
+
 export const parseGoalPerformanceResponseBody = Effect.fn(
   "FintualPerformance.parseGoalPerformanceResponseBody",
-)(function* (body: string): Effect.fn.Return<GoalPerformanceData, Error> {
+)(function* (body: string): Effect.fn.Return<GoalPerformanceData, InvalidGoalPerformanceResponse> {
   const parsedJson = yield* Effect.try({
     // oxlint-disable-next-line typescript/consistent-type-assertions
     try: () => JSON.parse(body) as unknown,
     catch: (cause) =>
-      new Error(`Failed to parse goal performance response body: ${getErrorMessage(cause)}`, {
-        cause,
+      new InvalidGoalPerformanceResponse({
+        cause: new Error(
+          `Failed to parse goal performance response body: ${getErrorMessage(cause)}`,
+          { cause },
+        ),
       }),
   })
 
   if (Predicate.isObject(parsedJson) && "errors" in parsedJson) {
-    return yield* Effect.fail(
-      new Error("Failed to validate goal performance data: GraphQL response contains errors"),
-    )
+    return yield* new InvalidGoalPerformanceResponse({
+      cause: new Error(
+        "Failed to validate goal performance data: GraphQL response contains errors",
+      ),
+    })
   }
 
   return yield* Schema.decodeUnknownEffect(goalPerformanceDataResponseSchema)(parsedJson).pipe(
     Effect.map((response) => response.data),
     Effect.mapError(
       (cause) =>
-        new Error(`Failed to validate goal performance data: ${getValidationFailure(parsedJson)}`, {
-          cause,
+        new InvalidGoalPerformanceResponse({
+          cause: new Error(
+            `Failed to validate goal performance data: ${getValidationFailure(parsedJson)}`,
+            { cause },
+          ),
         }),
     ),
   )

--- a/src/fintual/performance.ts
+++ b/src/fintual/performance.ts
@@ -60,20 +60,18 @@ export class FintualPerformance extends Context.Service<
             "recent",
           )
 
-          const snapshot = yield* Effect.mapError(
-            Effect.try({
-              try: () => foldGoalPerformanceData(reference, recent),
-              catch: (cause) =>
-                new Error(`Failed to fold Fintual performance data: ${getErrorMessage(cause)}`, {
-                  cause,
-                }),
-            }),
-            (cause) => new MalformedPerformanceSnapshot({ issues: getErrorMessage(cause) }),
-          )
+          const snapshot = yield* Effect.try({
+            try: () => foldGoalPerformanceData(reference, recent),
+            catch: (cause) =>
+              new MalformedPerformanceSnapshot({
+                issues: `Failed to fold Fintual performance data: ${getErrorMessage(cause)}`,
+                cause,
+              }),
+          })
 
           const validatedSnapshot = yield* Effect.mapError(
             validatePerformanceSnapshot(snapshot),
-            (cause) => new MalformedPerformanceSnapshot({ issues: cause.issues }),
+            (cause) => new MalformedPerformanceSnapshot({ issues: cause.issues, cause }),
           )
           yield* snapshotWriter.write(validatedSnapshot)
 
@@ -228,14 +226,16 @@ const readResponseBody = Effect.fn("FintualPerformance.readResponseBody")(functi
   response: Response,
   stage: string,
 ): Effect.fn.Return<string, FintualError> {
-  return yield* Effect.mapError(
-    Effect.tryPromise({
-      try: () => response.text(),
-      catch: (cause) =>
-        new Error(`${stage}: failed to read response body: ${getErrorMessage(cause)}`, { cause }),
-    }),
-    (cause) => new HttpTransportFailure({ stage, cause }),
-  )
+  return yield* Effect.tryPromise({
+    try: () => response.text(),
+    catch: (cause) =>
+      new HttpTransportFailure({
+        stage,
+        cause: new Error(`${stage}: failed to read response body: ${getErrorMessage(cause)}`, {
+          cause,
+        }),
+      }),
+  })
 })
 
 function failUnexpectedStatus(stage: string, status: number): Effect.Effect<never, FintualError> {

--- a/src/log.ts
+++ b/src/log.ts
@@ -46,14 +46,6 @@ export function getErrorMessage(error: unknown): string {
   return "Unknown error"
 }
 
-export function toError(error: unknown, message: string | ((error: unknown) => string)): Error {
-  if (typeof message === "function") {
-    return new Error(message(error), { cause: error })
-  }
-
-  return new Error(`${message}: ${getErrorMessage(error)}`, { cause: error })
-}
-
 export function redactSensitiveText(value: string): string {
   let redactedValue = value
 

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -37,6 +37,7 @@ class UnexpectedFailure extends Schema.TaggedError<UnexpectedFailure>()("Unexpec
   }
 
   override get name(): string {
+    // Keep Cause.pretty's prefix as `Error:` so the render assertion stays faithful.
     return "Error"
   }
 }

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -1,8 +1,13 @@
 import { it as effectIt } from "@effect/vitest"
-import { Cause, Console, Effect, Logger, Redacted } from "effect"
+import { Cause, Console, Effect, Logger, Redacted, Schema } from "effect"
 import { describe, expect, it } from "vitest"
 import type { RuntimeConfig } from "./env.ts"
-import { configureSensitiveValues, redactSensitiveText, revealSecret } from "./log.ts"
+import {
+  configureSensitiveValues,
+  getErrorMessage,
+  redactSensitiveText,
+  revealSecret,
+} from "./log.ts"
 import { redactingLogger, reportUnhandledFailure } from "./once.ts"
 
 const secret = "hunter2-super-secret"
@@ -22,6 +27,18 @@ const runtimeConfig: RuntimeConfig = {
     goalId: "goal-42",
     email2FA: null,
   },
+}
+
+class UnexpectedFailure extends Schema.TaggedError<UnexpectedFailure>()("UnexpectedFailure", {
+  cause: Schema.Defect(),
+}) {
+  override get message(): string {
+    return getErrorMessage(this.cause)
+  }
+
+  override get name(): string {
+    return "Error"
+  }
 }
 
 function configureLoggingSecrets(): void {
@@ -134,7 +151,9 @@ describe("reportUnhandledFailure", () => {
     Effect.gen(function* () {
       configureLoggingSecrets()
       const lines: Array<string> = []
-      const program = Effect.fail(new Error(`unexpected ${secret}`)).pipe(
+      const program = Effect.fail(
+        new UnexpectedFailure({ cause: new Error(`unexpected ${secret}`) }),
+      ).pipe(
         Effect.tapCause(reportUnhandledFailure),
         Effect.catchCause(() => Effect.void),
       )

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path"
 import { it } from "@effect/vitest"
 import { Effect } from "effect"
 import { expect } from "vitest"
+import { getErrorMessage } from "./log.ts"
 import {
   PERFORMANCE_SNAPSHOT_PATH,
   validatePerformanceSnapshot,
@@ -114,7 +115,8 @@ it.effect("fails when the Performance Snapshot cannot be written", () =>
       fs.mkdirSync(snapshotPath, { recursive: true })
       const error = yield* Effect.flip(writePerformanceSnapshot(performanceSnapshot()))
 
-      expect(error.message).toContain("Failed to write performance snapshot artifact")
+      expect(error).toMatchObject({ _tag: "SnapshotWriteFailure" })
+      expect(getErrorMessage(error)).toContain("Failed to write performance snapshot artifact")
     } finally {
       fs.rmSync(snapshotPath, { force: true, recursive: true })
       restoreFile(snapshotPath, originalContents)

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -15,10 +15,7 @@ export class SnapshotWriter extends Context.Service<
   static readonly layer = Layer.sync(SnapshotWriter, () =>
     SnapshotWriter.of({
       write: Effect.fn("SnapshotWriter.write")(function* (snapshot) {
-        return yield* Effect.mapError(
-          writePerformanceSnapshot(snapshot),
-          (cause) => new SnapshotWriteFailure({ cause }),
-        )
+        return yield* writePerformanceSnapshot(snapshot)
       }),
     }),
   )
@@ -67,7 +64,7 @@ export const validatePerformanceSnapshot = Effect.fn("PerformanceSnapshot.valida
 
 export const writePerformanceSnapshot = Effect.fn("PerformanceSnapshot.write")(function* (
   snapshot: PerformanceSnapshot,
-): Effect.fn.Return<void, Error> {
+): Effect.fn.Return<void, SnapshotWriteFailure> {
   return yield* Effect.andThen(
     Effect.try({
       try: () => {
@@ -75,8 +72,11 @@ export const writePerformanceSnapshot = Effect.fn("PerformanceSnapshot.write")(f
         fs.writeFileSync(PERFORMANCE_SNAPSHOT_PATH, JSON.stringify(snapshot, null, 2), "utf-8")
       },
       catch: (cause) =>
-        new Error(`Failed to write performance snapshot artifact: ${getErrorMessage(cause)}`, {
-          cause,
+        new SnapshotWriteFailure({
+          cause: new Error(
+            `Failed to write performance snapshot artifact: ${getErrorMessage(cause)}`,
+            { cause },
+          ),
         }),
     }),
     () => Effect.logInfo(`Performance snapshot saved to ${PERFORMANCE_SNAPSHOT_PATH}`),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,7 @@
 		],
 		"plugins": [
 			{
-				"name": "@effect/language-service",
-				"ignoreEffectWarningsInTscExitCode": true
+				"name": "@effect/language-service"
 			}
 		]
 	},


### PR DESCRIPTION
Closes #343

## Summary

Removes `ignoreEffectWarningsInTscExitCode: true` from the `@effect/language-service` plugin block after converting all 23 gated Effect warnings (12x `globalErrorInEffectCatch`, 11x `globalErrorInEffectFailure`) to `Schema.TaggedError` failures at the flagged seams.

## Atomic commits

- `test: use a tagged failure in the redacted logger test`
- `refactor: model IMAP 2FA failures as tagged errors`
- `refactor: fail goal performance parsing with a tagged error`
- `refactor: type Fintual HTTP transport failures at the seam`
- `refactor: type performance snapshot write failures`
- `refactor: remove unused toError helper`
- `chore: stop ignoring Effect warnings in typecheck`

Each commit passes `pnpm typecheck` and the full test suite independently; the flag is removed only in the final commit.

## Notes

- Message wording and original failures in `cause` are preserved per `docs/adr/0003-typed-failures-at-domain-seams.md`.
- Fallow dead-code baseline regenerated for the tsconfig change; `@effect/tsgo` added to Fallow `ignoreDependencies` because it is referenced by `prepare` and the tsconfig schema, not source imports.
- Remaining Effect diagnostics are suggestions and are not gated by the exit code.

## Verification

`pnpm typecheck` exits 0 with the gate active, 94/94 tests pass, and `pnpm lint`, `pnpm format:check`, and `pnpm fallow:audit` are clean.