### PR TITLE
chore: streamline agent delivery and Fallow diagnostics

### DIFF
--- a/.agents/friction-log/20260811174034-fallow-evidence-limit/friction.md
+++ b/.agents/friction-log/20260811174034-fallow-evidence-limit/friction.md
@@ -1,0 +1,35 @@
+---
+title: 'Fallow evidence limit makes valid member references fail complete analysis'
+severity: 'minor'
+target: 'fallow-rs/fallow'
+---
+
+## Expected Behavior
+
+Type-aware Fallow analysis should remain complete when a class member has more
+than one legitimate static reference, or expose a repository-configurable
+evidence bound.
+
+## Current Behavior
+
+Fallow 3.14.0 can mark the whole analysis partial with gap reason
+`evidence-limit` when a tagged error's `.message` member gains a second test
+reference. Because this repository requires complete type-aware analysis, the
+audit fails even though both references are valid.
+
+## Possible Solution
+
+Do not downgrade completeness merely because reference payloads are bounded, or
+provide a configuration option that raises the evidence limit independently
+from retained-reference proof.
+
+## Minimal Reproducible Example
+
+Add a second direct `.message` assertion for the same
+`Schema.TaggedErrorClass` member and run `pnpm fallow:audit` with
+`typeAware.require` set to `complete`.
+
+## Context
+
+Observed while implementing issue #343 with Fallow 3.14.0. The installed schema
+exposes the completeness policy but no evidence-limit setting.

--- a/.agents/friction-log/20260811175106-effect-solutions-error/friction.md
+++ b/.agents/friction-log/20260811175106-effect-solutions-error/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'effect-solutions error guide uses an API absent from pinned Effect'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The effect-solutions error-handling guide should use APIs provided by the Effect version pinned in this repository.
+
+## Current Behavior
+
+The guide recommends Schema.TaggedErrorClass throughout, but effect 4.0.0-beta.106 exports Schema.TaggedError instead. Following the guide produces a TypeScript error and contradicts node_modules/effect/AGENTS.md and the installed source.
+
+## Possible Solution
+
+Generate or version the guide against the pinned Effect API, and replace Schema.TaggedErrorClass examples with Schema.TaggedError for this Effect release.
+
+## Minimal Reproducible Example
+
+Run effect-solutions show error-handling, copy its ValidationError example into this repository, and run pnpm typecheck.
+
+## Context
+
+Found while addressing the review of PR #345. The repository-local Effect skill contained the same stale identifier.

--- a/.agents/skills/effect/SKILL.md
+++ b/.agents/skills/effect/SKILL.md
@@ -86,6 +86,21 @@ If a task spans several branches, read all matching files before editing.
 - Retry only when the operation has proven idempotency.
 - Let exhausted failures remain visible unless the boundary has a real fallback.
 
+## Typed Failure Checklist
+
+When introducing or changing an expected failure at a domain seam, verify all of
+these before moving to the next seam:
+
+- Use `Schema.TaggedErrorClass` rather than global `Error` in the typed failure
+  channel.
+- Preserve the established human-readable message.
+- Store the original failure in a `cause: Schema.Defect` field.
+- Keep the error class module-local unless consumers intentionally need it in the
+  public failure union.
+- Recover or classify with tags and stable fields, never message text.
+- Exercise message and cause behavior with a focused test when the seam already
+  has a compatibility contract.
+
 ## Do Nots
 
 - Do not use `as any`, non-null assertions, or unchecked casts to silence Effect typing problems.

--- a/.agents/skills/effect/SKILL.md
+++ b/.agents/skills/effect/SKILL.md
@@ -41,7 +41,7 @@ If a task spans several branches, read all matching files before editing.
 - Prefer `Context.Service` for application services when the codebase has not standardized on another current service-tag style.
 - Build real service implementations with `Layer.effect(Service, Effect.gen(...))` and return `Service.of({ ... })`.
 - Model records with `Schema.Struct(...)` plus a same-name `interface`.
-- Model typed Effect errors with `Schema.TaggedErrorClass`.
+- Model typed Effect errors with `Schema.TaggedError`.
 - Read runtime config through `Config`, not direct `process.env` access in application logic.
 - Use `Schedule` for retry, repeat, polling, pacing, and backoff policies.
 - Use `Stream` for effectful sources that emit many values over time and need pull, backpressure, interruption, or transformation.
@@ -57,7 +57,7 @@ If a task spans several branches, read all matching files before editing.
 - Reusable boundary-crossing tagged variant: `Schema.TaggedStruct(...)` plus same-name `interface`.
 - Boundary-crossing tagged union: `Schema.TaggedUnion(...)` with `.cases`, `.guards`, and `.match`.
 - External/custom discriminator such as `type`: `Schema.Struct({ type: Schema.tag("variant"), ... })` plus `Schema.toTaggedUnion("type")` when union helpers are needed.
-- Expected typed failure: `Schema.TaggedErrorClass`.
+- Expected typed failure: `Schema.TaggedError`.
 - Unknown boundary payload: `Schema.decodeUnknownEffect(...)`.
 - Service boundary: `Context.Service<Service, Interface>()(...)` plus `Layer.effect(...)` plus `Service.of(...)`.
 - Public or non-trivial internal service method: `Effect.fn("Domain.operation")`.
@@ -91,10 +91,10 @@ If a task spans several branches, read all matching files before editing.
 When introducing or changing an expected failure at a domain seam, verify all of
 these before moving to the next seam:
 
-- Use `Schema.TaggedErrorClass` rather than global `Error` in the typed failure
+- Use `Schema.TaggedError` rather than global `Error` in the typed failure
   channel.
 - Preserve the established human-readable message.
-- Store the original failure in a `cause: Schema.Defect` field.
+- Store the original failure in a `cause: Schema.Defect()` field.
 - Keep the error class module-local unless consumers intentionally need it in the
   public failure union.
 - Recover or classify with tags and stable fields, never message text.
@@ -105,7 +105,7 @@ these before moving to the next seam:
 
 - Do not use `as any`, non-null assertions, or unchecked casts to silence Effect typing problems.
 - Do not introduce `Schema.Class` or `Schema.TaggedClass` as default app data-modeling patterns.
-- Do not hand-roll `_tag` error classes when `Schema.TaggedErrorClass` fits.
+- Do not hand-roll `_tag` error classes when `Schema.TaggedError` fits.
 - Do not use cause-level recovery when typed-error recovery is enough.
 - Do not use `Layer.mergeAll(...)` or `provideMerge(...)` as blind make-it-compile tools.
 - Do not hide required application authority, credentials, persistence, transports, or external services behind `Context.Reference` defaults.

--- a/.agents/skills/effect/references/SCHEMA.md
+++ b/.agents/skills/effect/references/SCHEMA.md
@@ -109,10 +109,10 @@ Guidance:
 
 ## Errors
 
-`Schema.TaggedErrorClass` is the explicit class exception for typed Effect errors.
+`Schema.TaggedError` is the explicit class exception for typed Effect errors.
 
 ```ts
-export class PersistenceError extends Schema.TaggedErrorClass<PersistenceError>()(
+export class PersistenceError extends Schema.TaggedError<PersistenceError>()(
   "UserRepo.PersistenceError",
   {
     operation: Schema.String,

--- a/.agents/skills/effect/references/SERVICES_LAYERS.md
+++ b/.agents/skills/effect/references/SERVICES_LAYERS.md
@@ -28,7 +28,7 @@ export const layer = Layer.effect(
   }),
 )
 
-export class NotFound extends Schema.TaggedErrorClass<NotFound>()(
+export class NotFound extends Schema.TaggedError<NotFound>()(
   "UserRepo.NotFound",
   { id: UserId },
 ) {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,11 @@ Domain documentation uses a single-context layout. See `docs/agents/domain.md`.
 
 Tests favor readable, behavior-focused workflows with explicit setup. See `docs/agents/testing-principles.md`.
 
+### Delivery workflow
+
+Plan commits, run diagnostic probes, verify changes, and publish issues and PRs
+according to `docs/agents/delivery-workflow.md`.
+
 ### Verification
 
 Do not routinely run typechecks, Fallow, formatting, linting, or the full test

--- a/bin/diagnose-fallow.mjs
+++ b/bin/diagnose-fallow.mjs
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process"
+
+const run = spawnSync(
+  "pnpm",
+  ["exec", "fallow", "dead-code", "--format", "json", "--quiet"],
+  { encoding: "utf8" },
+)
+
+if (run.stderr.length > 0) {
+  process.stderr.write(run.stderr)
+}
+
+let report
+try {
+  report = JSON.parse(run.stdout)
+} catch {
+  process.stderr.write("Fallow did not return a JSON report.\n")
+  if (run.stdout.length > 0) process.stderr.write(run.stdout)
+  process.exit(run.status ?? 1)
+}
+
+const typeAware = report._meta?.type_aware
+if (typeAware === undefined) {
+  console.error("Fallow did not include type-aware analysis metadata.")
+  process.exit(run.status ?? 1)
+}
+
+const { identity, queries = [], candidate_decisions: decisions = [] } = typeAware
+const decisionsByQuery = new Map(decisions.map((decision) => [decision.query_id, decision]))
+const incomplete = queries.filter((query) => query.status !== "complete")
+
+console.log(`Type-aware analysis: ${identity.completeness}`)
+console.log(`Backend: ${identity.backend_family}`)
+console.log(`Project hash: ${identity.project_config_hash}`)
+console.log(`Queries: ${queries.length - incomplete.length} complete, ${incomplete.length} incomplete`)
+
+for (const query of incomplete) {
+  const decision = decisionsByQuery.get(query.query_id)
+  const subject = decision?.subject
+  const location = subject === undefined
+    ? "unknown subject"
+    : `${subject.path}:${subject.line}:${subject.col} ${subject.owner === undefined ? "" : `${subject.owner}.`}${subject.local_name}`
+
+  console.log("")
+  console.log(`#${query.query_id} ${query.capability}/${query.assertion}: ${query.status}`)
+  console.log(`  subject: ${location}`)
+  console.log(`  gap: ${query.reason_code ?? decision?.reason_code ?? "unspecified"}`)
+  console.log(`  evidence: ${query.total_evidence_count}${query.truncated ? " (truncated)" : ""}`)
+  for (const omission of query.omissions ?? decision?.omissions ?? []) {
+    console.log(`  omitted: ${omission.reason_code} (${omission.count})`)
+  }
+  if (decision?.explanation !== undefined) console.log(`  explanation: ${decision.explanation}`)
+}
+
+if (identity.completeness !== "complete" || incomplete.length > 0) {
+  process.exitCode = 2
+} else if (run.status !== 0 && run.status !== 1) {
+  process.exitCode = run.status ?? 1
+}

--- a/docs/agents/delivery-workflow.md
+++ b/docs/agents/delivery-workflow.md
@@ -1,0 +1,62 @@
+# Agent delivery workflow
+
+Use this workflow for repository changes that will be committed or published.
+
+## Establish the live scope
+
+- Read the requested issue and its comments.
+- Resolve every referenced issue or PR that could affect scope, sequencing, or
+  ownership. Check its current state and purpose before presenting it as an open
+  decision. Closed exploration notes are context, not implementation tickets,
+  unless the user explicitly asks to reopen or supersede them.
+- Check the current branch, remote default branch, working tree, and related PRs
+  before editing. Start from current remote history rather than a stale detached
+  commit.
+
+## Plan reviewable commits before editing
+
+For a multi-part change, write down the intended commit boundaries before the
+first commit. Prefer coherent commits that each leave the repository usable.
+"Land together" or "change atomically" does not imply one large commit.
+
+Do not create a combined commit with the intention of splitting it later. If the
+user changes the requested history after an unpublished commit exists, rewriting
+that local history is acceptable, but it should be the exception.
+
+## Keep diagnostic probes disposable
+
+- Prefer read-only diagnostics.
+- If a temporary code or configuration change is necessary, isolate it in a
+  throwaway worktree or record the reverse patch before applying it.
+- Restore the probe immediately after recording the result, then run the focused
+  test or check affected by the probe.
+- Inspect `git diff` before moving from diagnosis back to implementation.
+
+Never preserve an awkward production or test-code shape solely to satisfy a
+tool's evidence bound. Record the tool limitation and prefer a narrow tool
+configuration or upstream fix.
+
+## Use the hook verification boundary
+
+- During development, run focused tests that directly support the change.
+- Let pre-commit format and lint staged TypeScript.
+- Let pre-push run the full format, lint, TypeScript, test, and Fallow gates once
+  for the final branch.
+- Run an individual full-project check outside the hooks only to diagnose a
+  reported failure or when the user explicitly requests it.
+- Do not rerun the full suite for every commit unless independently verified
+  commits are an explicit requirement.
+
+Use the repository's scoped formatting scripts. For files outside their scope,
+make a minimal edit and preserve the existing layout; do not run a broad
+formatter over unrelated configuration.
+
+## Publish before resolving
+
+An implementation issue is not complete when its change exists only in a local
+commit. Push the branch and open the PR first. Prefer a closing keyword such as
+`Fixes #123` in the PR body so merge closes the issue. Close an implementation
+issue manually before merge only when the repository or user explicitly asks
+for that workflow.
+
+Before publishing, inspect the complete diff and stage only files in scope.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -11,6 +11,15 @@ Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all o
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --comment "..."`
 
+Before treating a referenced issue as a blocker, ownership choice, or open
+decision, fetch its current state and read enough context to distinguish an
+implementation ticket from an exploration note. A closed exploration issue is
+context unless the user explicitly asks to reopen or supersede it.
+
+For implementation work delivered through a pull request, prefer a closing
+keyword such as `Fixes #<number>` in the PR body and let merge close the issue.
+Do not close the issue while the implementation exists only in a local commit.
+
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
 ## Pull requests as a triage surface

--- a/docs/fallow.md
+++ b/docs/fallow.md
@@ -19,6 +19,7 @@ Baselines live in `fallow-baselines/` and capture the current finding set, so pr
 ```bash
 pnpm fallow:audit      # PR gate: fails only on findings introduced by the change
 pnpm fallow:baseline   # Regenerate all baselines after genuine fixes
+pnpm fallow:diagnose   # Explain type-aware completeness without changing files
 pnpm fallow:fix:preview  # Dry-run auto-fixes
 pnpm fallow:fix        # Apply safe fixes (not run in CI)
 ```
@@ -50,7 +51,40 @@ git add fallow-baselines/
 
 The dead-code baseline is saved through the combined `fallow` run so its analysis identity (including `type-coupling`) matches what the audit gate produces.
 
+Always use `pnpm fallow:baseline`; do not assemble individual
+`--save-baseline` commands. The repository script preserves the analysis modes
+and baseline identities expected by the audit gate.
+
 Regenerating a worse baseline to silence CI is not acceptable — fix the code or justify narrow config changes.
+
+## Diagnosing partial type-aware analysis
+
+With `typeAware.require: complete`, a bounded or unsupported semantic query is a
+gate failure even when the underlying code is valid. Start with:
+
+```bash
+pnpm fallow:diagnose
+```
+
+The command prints the project identity and every incomplete query with its gap
+reason and subject. It does not update baselines. Investigate in this order:
+
+1. Trace newly exported symbols. An implementation-only class or helper should
+   normally remain module-local.
+2. Inspect queries whose gap reason is `evidence-limit`. This is a bounded-tool
+   result, not proof that the referenced member is dead. Do not reshape tests or
+   production code merely to reduce legitimate references.
+3. Compare the project configuration hash with the committed dead-code baseline.
+   A deliberate tsconfig change requires a baseline refresh only after the
+   analysis is complete.
+4. Treat config-only dependencies as narrow `ignoreDependencies` entries when
+   they are genuinely used by lifecycle scripts or compiler configuration but
+   have no import edge.
+5. Use `fallow dead-code --trace <file>:<export>` for a specific symbol before
+   changing code or baselines.
+
+If the result stays partial because of an analyzer bound or unsupported relation,
+run `pnpx frog list` and record new repository friction with `pnpx frog log`.
 
 ## CI behavior
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"fallow": "fallow",
 		"fallow:audit": "FALLOW_AUDIT_BASE=origin/main fallow audit",
 		"fallow:baseline": "fallow --save-baseline fallow-baselines/dead-code.json || { s=$?; [ $s -eq 1 ] || exit $s; }; fallow health --save-baseline fallow-baselines/health.json --baseline-mode identity || { s=$?; [ $s -eq 1 ] || exit $s; }; fallow dupes --save-baseline fallow-baselines/dupes.json || { s=$?; [ $s -eq 1 ] || exit $s; }",
+		"fallow:diagnose": "node bin/diagnose-fallow.mjs",
 		"fallow:fix:preview": "fallow fix --dry-run",
 		"fallow:fix": "fallow fix --yes",
 		"dev": "node src/once.ts",


### PR DESCRIPTION
## Summary

- add a repository delivery workflow covering live issue-state checks, up-front atomic commit planning, disposable diagnostic probes, hook-based verification, scoped formatting, and merge-time issue closure
- add a typed Effect failure checklist that preserves messages and original causes and keeps implementation-only errors private
- add `pnpm fallow:diagnose` to report semantic completeness, incomplete queries, gap reasons, omissions, and affected symbols without changing baselines
- document the safe Fallow baseline and partial-analysis workflow
- record Fallow's non-configurable evidence-limit behavior as upstream friction

## Why

A review of Codex task `019ff29f-acec-73e1-982e-6160657b3962` found repeated avoidable work: stale linked-issue assumptions, a combined commit that later needed splitting, redundant full-suite runs, leaked diagnostic edits, late discovery of a dropped Effect cause, premature issue closure, broad formatting churn, and a long investigation into opaque Fallow completeness failures.

This PR turns those lessons into repository guidance and an executable diagnostic command.

## Impact

Agents get one discoverable delivery workflow and a focused Fallow troubleshooting path. The new diagnostic command is read-only. Runtime application behavior is unchanged.

Fallow's evidence bound is not exposed by the installed configuration schema, so this PR records that limitation for upstream follow-up instead of contorting application or test code around it.

## Verification

The pre-push hook passed:

- 94 tests
- TypeScript
- Fallow audit
- repository formatting and lint checks

`pnpm fallow:diagnose` also reports complete type-aware analysis on the current tree.
