### PR TITLE
Make ADRs Effect-first

### DIFF
--- a/docs/adr/0000-effect-first-application-architecture.md
+++ b/docs/adr/0000-effect-first-application-architecture.md
@@ -21,7 +21,7 @@ The following rules govern every other ADR:
 - Public and non-trivial internal operations use named `Effect.fn` functions. Multi-step workflows use `Effect.gen`.
 - Runtime configuration is decoded with `Config` in layers. Secrets use `Redacted`; application logic does not read `process.env` or mutate global configuration.
 - Records and boundary contracts use `Schema.Struct` with same-name interfaces. Scalar identifiers use constrained branded schemas. Unknown HTTP, file, and SDK data is decoded with `Schema.decodeUnknownEffect` at the owning boundary.
-- Expected failures use domain-owned `Schema.TaggedErrorClass` values. Defects, interruption, and expected failures remain distinct. Public services do not expose plain `Error`, third-party error types, or message-text classification.
+- Expected failures use domain-owned `Schema.TaggedError` values. Defects, interruption, and expected failures remain distinct. Public services do not expose plain `Error`, third-party error types, or message-text classification.
 - External HTTP uses Effect `HttpClient`. Each adapter owns request construction, authentication, status classification, response decoding, cancellation, and domain-error mapping.
 - Resources use `Scope`, `Effect.acquireRelease`, or the corresponding scoped layer constructor. Background work is forked into its owning scope and never outlives that scope.
 - Retry, repetition, polling, timeout, and pacing use `Schedule`, `Clock`, and the relevant Effect combinators. Retry is bounded and limited to operations proven safe to repeat.
@@ -30,6 +30,10 @@ The following rules govern every other ADR:
 - Tests use `@effect/vitest`, explicit test layers, `ConfigProvider`, `TestClock`, and deterministic synchronization. Tests do not mutate process globals or wait with real sleeps.
 
 Modules expose the smallest domain capability that callers need. Leaf adapters remain replaceable services, while orchestration and policy remain free of platform and vendor APIs. Compatibility shims and duplicate legacy entry points are removed rather than retained.
+
+## Delivery status
+
+This ADR set records the normative target architecture. The implementation may temporarily differ while its reviewable PR stack lands; those intermediate states do not amend these decisions. Delivery progress belongs in the issue tracker and PR stack rather than in the durable ADR text. Once the stack is complete, shipped code must conform to these decisions or a new ADR must explicitly supersede them.
 
 ## Considered options
 

--- a/docs/adr/0000-effect-first-application-architecture.md
+++ b/docs/adr/0000-effect-first-application-architecture.md
@@ -1,0 +1,46 @@
+# Effect-first application architecture
+
+## Status
+
+Accepted
+
+## Context
+
+This is a greenfield application. Compatibility with earlier internal APIs is not a design goal, so transitional wrappers, mixed Promise/Effect application code, and legacy dependency-passing styles would add complexity without protecting a supported consumer.
+
+Effect is therefore the application architecture, not a utility used around selected operations. The design should preserve Effect's typed error, dependency, resource, concurrency, configuration, observability, and testing models from the process entry point down to external adapters.
+
+## Decision
+
+All application workflows are Effect programs. Domain capabilities and external adapters are `Context.Service` contracts implemented by `Layer`s. A single application layer graph is assembled at the composition root and provided once before `NodeRuntime.runMain`.
+
+The following rules govern every other ADR:
+
+- Public service methods have an `R` type of `never`; implementation dependencies are acquired while constructing the service layer.
+- Real implementations default to `Layer.effect(Service, Effect.gen(...))` and return `Service.of({ ... })`. Constructors such as `Layer.succeed`, `Layer.sync`, and `Layer.scoped` are used when their semantics are more accurate.
+- Public and non-trivial internal operations use named `Effect.fn` functions. Multi-step workflows use `Effect.gen`.
+- Runtime configuration is decoded with `Config` in layers. Secrets use `Redacted`; application logic does not read `process.env` or mutate global configuration.
+- Records and boundary contracts use `Schema.Struct` with same-name interfaces. Scalar identifiers use constrained branded schemas. Unknown HTTP, file, and SDK data is decoded with `Schema.decodeUnknownEffect` at the owning boundary.
+- Expected failures use domain-owned `Schema.TaggedErrorClass` values. Defects, interruption, and expected failures remain distinct. Public services do not expose plain `Error`, third-party error types, or message-text classification.
+- External HTTP uses Effect `HttpClient`. Each adapter owns request construction, authentication, status classification, response decoding, cancellation, and domain-error mapping.
+- Resources use `Scope`, `Effect.acquireRelease`, or the corresponding scoped layer constructor. Background work is forked into its owning scope and never outlives that scope.
+- Retry, repetition, polling, timeout, and pacing use `Schedule`, `Clock`, and the relevant Effect combinators. Retry is bounded and limited to operations proven safe to repeat.
+- Collections over time use `Stream` when pull, backpressure, interruption, or incremental consumption matters. `Queue`, `PubSub`, `Deferred`, `Latch`, and `Ref` are preferred over ad-hoc concurrency state.
+- Application logging uses Effect logging and a logger layer. Direct console output is limited to tooling that is outside the application runtime.
+- Tests use `@effect/vitest`, explicit test layers, `ConfigProvider`, `TestClock`, and deterministic synchronization. Tests do not mutate process globals or wait with real sleeps.
+
+Modules expose the smallest domain capability that callers need. Leaf adapters remain replaceable services, while orchestration and policy remain free of platform and vendor APIs. Compatibility shims and duplicate legacy entry points are removed rather than retained.
+
+## Considered options
+
+- **Use Effect only for error handling and retries** — rejected because it creates two execution and dependency models and loses typed requirements at their boundary.
+- **Keep Promise-based domain APIs and run Effect internally** — rejected because cancellation, scope, typed errors, and service requirements disappear from the public contract.
+- **Preserve legacy factories and aliases during migration** — rejected because this project has no compatibility requirement and the extra surface would become accidental architecture.
+
+## Consequences
+
+- The type of each program describes its success, expected failure, and remaining service requirements.
+- Resource lifetime, cancellation, configuration, logging, and tests share one runtime model.
+- Replacing an adapter means replacing a layer, not changing domain workflows.
+- Effect-unsafe convenience code is treated as architectural drift even when it appears locally simpler.
+- Unstable Effect modules may be used deliberately in this greenfield codebase; upgrades update the adapter rather than preserving a parallel legacy abstraction.

--- a/docs/adr/0001-fintual-performance-service.md
+++ b/docs/adr/0001-fintual-performance-service.md
@@ -1,33 +1,44 @@
-# Fintual ingestion is one Effect Service around the Performance Snapshot
-
-The Fintual sync seam currently exposes intermediate Reference and Recent Goal Performance Data through `createAuthenticatedFintualIngestion`, with login, folding, Valibot validation, and inspection-artifact writing composed in a shallow `http-sync.ts` that fails the deletion test; snapshot writes warn instead of failing, and the fold carries dead `null` paths. The design collapses all of it into one deep module, `src/fintual/performance.ts`, exposing a single Effect Service — `FintualPerformance.fetchPerformanceSnapshot(): Effect<PerformanceSnapshot, FintualError>` — with `FintualConfig` provided as a service value and fetch, email 2FA, and snapshot writing as internal services.
-
-`FintualError` is a tagged union that enumerates every failure the public seam can produce, one variant per failure source:
-
-- `UnexpectedHttpStatus { stage, status }` — login/GraphQL responses outside the expected statuses
-- `HttpTransportFailure { stage, cause }` — fetch or response-body reads that throw
-- `LoginFailed { status }` — 401 on `initiate_login` (wrong credentials)
-- `MalformedGoalPerformanceData { purpose, cause }` — malformed JSON, schema mismatch, or GraphQL errors in the reference/recent response
-- `MalformedPerformanceSnapshot { issues }` — fold output failing snapshot validation
-- `Email2FAFailure { cause }` — no code before timeout, or IMAP retrieval failures
-- `SnapshotWriteFailure { cause }` — the inspection artifact could not be written
-
-Folding becomes total (no `null` inputs or outputs; empty arrays surface as `MalformedPerformanceSnapshot`), and write failures fail the sync instead of warning.
+# Fintual performance ingestion is one Effect service
 
 ## Status
 
-accepted
+Accepted
 
-## Considered Options
+## Context
 
-- **Plain factory composition (current design)** — `createAuthenticatedFintualIngestion` plus a thin wrapper in `http-sync.ts`; intermediate Reference/Recent Goal Performance Data cross module boundaries and the composition module fails the deletion test. Rejected: the external seam should be the business outcome, a validated Performance Snapshot.
-- **Config as a plain argument** — `fetchPerformanceSnapshot(config)` with stateless dependency services. Rejected in favor of config as a service value: the layer requires `FintualConfig` and the email-2FA live impl reads `config.email2FA` from context, so provision-time wiring stays explicit and env.ts remains the only env reader.
-- **Untyped `Error` failures** — rejected: a typed `FintualError` union makes every failure mode of the public seam discoverable and testable without reading the module.
-- **Warn-and-succeed on write failure (previous behavior)** — rejected: the sync should report when it cannot produce its inspection artifact.
-- **Defensive `null` folding** — rejected as dead code; the ingestion never produces null data.
+Callers need a validated `PerformanceSnapshot`, not login steps, GraphQL payloads, cookie handling, fold inputs, or inspection-file mechanics. Exposing those intermediate concepts would leak provider protocol into the application workflow and force callers to coordinate resource lifetime and failure mapping.
+
+## Decision
+
+`FintualPerformance` is a `Context.Service` exposing one named operation:
+
+```text
+fetchPerformanceSnapshot(): Effect<PerformanceSnapshot, FintualError>
+```
+
+Its live layer acquires validated Fintual configuration, an Effect `HttpClient`-backed session adapter, `Email2FA`, and `SnapshotWriter`. The method itself has no remaining environment requirements.
+
+The module owns the complete workflow: establish a scoped authenticated session, perform login and optional email 2FA, fetch reference and recent performance data, decode both responses with Schema, fold them into the domain model, validate the final snapshot, and persist the inspection artifact.
+
+The HTTP adapter owns cookies, authentication headers, cancellation, status classification, body decoding, and transport-error mapping. Provider calls never use raw `fetch` in the domain service. Intermediate provider DTOs remain private to the adapter/module.
+
+`FintualError` is a Schema union of domain-owned `Schema.TaggedErrorClass` variants covering authentication rejection, transport failure, unexpected provider response, malformed provider data, invalid folded snapshot, email 2FA failure, and snapshot persistence failure. Each variant carries structured diagnostic fields and a `Schema.Defect()` cause when appropriate. Message strings are not control-flow APIs.
+
+Empty or malformed provider datasets fail explicitly. Folding is total over validated inputs and does not accept defensive `null` states that the boundary cannot produce. Failure to write the required inspection artifact fails the operation.
+
+All public and non-trivial internal operations use stable `Effect.fn` names. Runtime configuration is obtained by the live layer from Effect `Config`; credentials remain `Redacted` until the HTTP adapter uses them.
+
+## Considered options
+
+- **Expose login and GraphQL operations to callers** — rejected because it leaks protocol sequencing and weakens the domain seam.
+- **Keep a plain factory around raw `fetch`** — rejected because Effect `HttpClient` provides the native cancellation, layers, transforms, status handling, and schema decoding this application requires.
+- **Pass configuration into every call** — rejected because configuration is an implementation dependency of the live layer, not domain input.
+- **Return third-party or generic errors** — rejected because callers need a closed, discoverable failure surface.
+- **Warn when the artifact write fails** — rejected because the operation promises both the validated snapshot and its required inspection artifact.
 
 ## Consequences
 
-- Callers learn one domain outcome; interval and sequencing knowledge gains locality; the shallow `http-sync.ts` composition module disappears.
-- This is the repo's first Effect Service, deliberately module-scoped: Actual sync, email 2FA, and env config keep their plain styles until the repo-wide Effect-native push (#284, #285, #286) decides their shape — this module is the pattern-setting precedent for those.
-- The design was settled by `/grill-with-docs` (issue #283); implementation tickets are the follow-up.
+- Callers depend on one business outcome and one typed failure union.
+- Provider protocol and raw payloads cannot spread into orchestration code.
+- Tests replace the leaf layers and exercise the complete service workflow without network, filesystem, environment, or real-time dependencies.
+- Provider contract changes are localized to schemas and the HTTP adapter.

--- a/docs/adr/0001-fintual-performance-service.md
+++ b/docs/adr/0001-fintual-performance-service.md
@@ -22,7 +22,7 @@ The module owns the complete workflow: establish a scoped authenticated session,
 
 The HTTP adapter owns cookies, authentication headers, cancellation, status classification, body decoding, and transport-error mapping. Provider calls never use raw `fetch` in the domain service. Intermediate provider DTOs remain private to the adapter/module.
 
-`FintualError` is a Schema union of domain-owned `Schema.TaggedErrorClass` variants covering authentication rejection, transport failure, unexpected provider response, malformed provider data, invalid folded snapshot, email 2FA failure, and snapshot persistence failure. Each variant carries structured diagnostic fields and a `Schema.Defect()` cause when appropriate. Message strings are not control-flow APIs.
+`FintualError` is a Schema union of domain-owned `Schema.TaggedError` variants covering authentication rejection, transport failure, unexpected provider response, malformed provider data, invalid folded snapshot, email 2FA failure, and snapshot persistence failure. Each variant carries structured diagnostic fields and a `Schema.Defect()` cause when appropriate. Message strings are not control-flow APIs.
 
 Empty or malformed provider datasets fail explicitly. Folding is total over validated inputs and does not accept defensive `null` states that the boundary cannot produce. Failure to write the required inspection artifact fails the operation.
 

--- a/docs/adr/0002-email-2fa-deep-module.md
+++ b/docs/adr/0002-email-2fa-deep-module.md
@@ -1,21 +1,41 @@
-# Email 2FA retrieval is a deep module with typed outcomes
-
-Email 2FA retrieval lives in `src/fintual/email-2fa/` behind a single public entry point: it takes a real `Email2FAConfig` and returns a branded `Email2FACode` or a tagged failure (`TimedOut | Operational`). Disabled 2FA is caller-side configuration, not a module outcome — `http-sync.ts` fails fast when the login requires a code but Gmail credentials are not configured. The module owns the IMAP lifecycle through Effect Scope, the 120-second polling window, mailbox traversal (Gmail mailbox fallback list), search-query fallback, deduplication, parsing policy, and cleanup; a thin operation-level client seam separates the ImapFlow adapter from the module so tests run against a fake client with deterministic polling via Clock/Schedule.
+# Email 2FA retrieval is a scoped Effect service
 
 ## Status
 
-accepted
+Accepted
 
-## Considered Options
+## Context
 
-- **`string | null` return (previous design)** — collapsed disabled, timeout, and every operational failure into one value; the consumer reported all three as "no code received before timeout". Rejected: operational failures must remain truthful.
-- **Explicit result variant (`code | TimedOut` as a success value)** — rejected because the consumer treats every non-code outcome as a login failure; failure-side typing composes with `catch`/`retry`, and the tagged union lets future callers retry timeouts without folding on a success variant.
-- **Disabled handled inside the module** — rejected: configuration assembly is the caller's concern; the module never needs a "disabled" branch.
-- **Flat sibling files** — rejected: one entry point per module is the point of the deepening.
+Email 2FA is a time-bound resource workflow: connect to IMAP, search one or more mailboxes repeatedly, deduplicate messages, extract a valid code, and close the connection on success, failure, timeout, or interruption. A nullable string or a Promise helper cannot describe those semantics truthfully.
+
+## Decision
+
+`Email2FA` is a `Context.Service`. Its public operation accepts only request-specific input, such as the login start time, and returns:
+
+```text
+getCode(request): Effect<Email2FACode, Email2FATimedOut | Email2FAOperationalError>
+```
+
+The live layer acquires validated email configuration and an `ImapClientFactory`; callers never pass credentials or construct clients. Disabled email 2FA is represented while decoding application configuration and is handled before requiring this service. It is not a retrieval result.
+
+`Email2FACode` is a constrained branded Schema. Public failures are `Schema.TaggedErrorClass` values. Vendor errors are mapped at the IMAP adapter boundary and never escape the service.
+
+The service owns the IMAP client with `Effect.acquireRelease` in a `Scope`. Logout runs exactly once and is uninterruptible. Polling and the overall deadline use `Schedule` and `Clock`; mailbox and query fallback policy remains pure domain logic. The implementation preserves interruption rather than translating it into an operational failure.
+
+The module exports the service contract, request and result schemas, failure union, live layer, and a first-class test layer. IMAP commands, mailbox traversal, MIME parsing, deduplication, and polling mechanics are private.
+
+Tests use `@effect/vitest`, `TestClock`, and a stateful fake service backed by Effect synchronization primitives. They assert timeout, cleanup, interruption, fallback ordering, deduplication, and operational-failure behavior without real sleeps.
+
+## Considered options
+
+- **Return `string | null`** — rejected because it conflates disabled configuration, timeout, malformed mail, and infrastructure failure.
+- **Return timeout as a success variant** — rejected because failing to obtain the required code is an expected failure of this operation and composes naturally in the Effect error channel.
+- **Pass configuration into `getCode`** — rejected because credentials and provider settings belong to layer construction.
+- **Expose a low-level IMAP client to the caller** — rejected because it transfers protocol sequencing and cleanup responsibility out of the module.
 
 ## Consequences
 
-- Consumer error messages are now truthful: timeout stays "no code received before timeout"; operational failures carry the IMAP cause.
-- Cleanup (logout exactly once, even on interruption) becomes a testable invariant via Scope finalizers observed by the fake client.
-- Deterministic timeout and polling tests are possible with the test clock.
-- `debug` in `Email2FAConfig` only controls logging; it no longer participates in recoverability decisions.
+- The public method expresses only the domain request and outcomes.
+- Connection lifetime and cancellation are correct by construction.
+- Timeout and polling behavior are deterministic in tests.
+- Changing IMAP libraries affects only the adapter layer.

--- a/docs/adr/0002-email-2fa-effect-service.md
+++ b/docs/adr/0002-email-2fa-effect-service.md
@@ -18,7 +18,7 @@ getCode(request): Effect<Email2FACode, Email2FATimedOut | Email2FAOperationalErr
 
 The live layer acquires validated email configuration and an `ImapClientFactory`; callers never pass credentials or construct clients. Disabled email 2FA is represented while decoding application configuration and is handled before requiring this service. It is not a retrieval result.
 
-`Email2FACode` is a constrained branded Schema. Public failures are `Schema.TaggedErrorClass` values. Vendor errors are mapped at the IMAP adapter boundary and never escape the service.
+`Email2FACode` is a constrained branded Schema. Public failures are `Schema.TaggedError` values. Vendor errors are mapped at the IMAP adapter boundary and never escape the service.
 
 The service owns the IMAP client with `Effect.acquireRelease` in a `Scope`. Logout runs exactly once and is uninterruptible. Polling and the overall deadline use `Schedule` and `Clock`; mailbox and query fallback policy remains pure domain logic. The implementation preserves interruption rather than translating it into an operational failure.
 

--- a/docs/adr/0003-typed-failures-at-domain-seams.md
+++ b/docs/adr/0003-typed-failures-at-domain-seams.md
@@ -1,20 +1,41 @@
-# Typed failures at domain seams
-
-The old `src/effect.ts` aliases wrap third-party rejections in a plain `Error`, erasing domain distinctions and forcing consumers such as the Actual retry classifier to inspect message text. Delete the generic aliases and model expected failures at each domain seam as `Schema.TaggedErrorClass` values. Preserve the existing message wording, keep the original failure in `cause`, and compute retryability or other control-flow classification where the third-party failure is first visible. Consumers use `catchTag` or `catchIf`; they do not classify failures by message text.
-
-Per-seam implementations are owned by the domain issues: Actual by #286, Fintual HTTP and the snapshot artifact by #283, and IMAP by #284. This ADR records the shared convention used by those implementations and by #285 when it removes the aliases.
+# Expected failures are Schema-tagged domain values
 
 ## Status
 
-accepted
+Accepted
 
-## Considered Options
+## Context
 
-- **One shared tagged error with a source field** — rejected because it centralizes unrelated failures and weakens domain-specific recovery.
-- **Plain `Error` values with message classification** — rejected because message wording becomes a hidden control-flow API; it also leaves the record-shaped `PostError` retry branch unreachable after the aliases wrap the original failure.
+Generic `Error` values and third-party rejection types erase the operation that failed, encourage message parsing, and make retry and recovery policies implicit. They also blur the distinction between an expected failure, a defect, and fiber interruption.
+
+## Decision
+
+Every domain or adapter seam maps expected failures into domain-owned `Schema.TaggedErrorClass` values. Public failure surfaces are explicit unions and, when they cross a serialization or API boundary, Schema unions.
+
+Failure types follow these rules:
+
+- Tags are stable and domain-qualified where ambiguity is possible.
+- Fields carry structured recovery and diagnostic data: operation, stable provider code, status, retryability, identifiers, and `Schema.Defect()` causes as appropriate.
+- Adapters classify third-party failures at the first boundary where stable codes or statuses are visible.
+- Higher-level services translate lower-level failures only when they can add a truthful domain meaning; otherwise they preserve the typed value.
+- Consumers recover with tag-, reason-, or field-based combinators such as `catchTag`, `catchTags`, and `catchIf`. They never inspect rendered messages.
+- Retryability is data derived at the adapter boundary, not inferred later from prose.
+- Broad cause handling preserves interruption. Expected failures stay in the typed error channel; programmer bugs and violated invariants become defects.
+- Expected absence uses `Option` when absence is a valid result, not an exception.
+- Public services do not expose plain `Error`, `unknown`, parsing-library failures, SDK errors, or transport-library errors.
+
+There is no shared catch-all application error. Each domain owns the smallest useful taxonomy for its callers. Error rendering and redaction are observability concerns and do not alter error identity.
+
+## Considered options
+
+- **One global error type with a source string** — rejected because it centralizes unrelated domains and weakens exhaustive recovery.
+- **Plain errors plus message conventions** — rejected because wording becomes an unstable, hidden control-flow protocol.
+- **Wrap every lower-level error at every layer** — rejected because redundant wrapping obscures the original typed failure without adding domain meaning.
+- **Catch all causes into expected errors** — rejected because it swallows defects and interruption.
 
 ## Consequences
 
-- Public domain seams expose discoverable failure unions instead of generic errors.
-- Existing human-readable error messages remain stable while control flow depends on tags and fields.
-- Each domain issue owns its error taxonomy and third-party failure mapping; this convention does not add configuration work outside those issue scopes.
+- Service signatures are executable documentation of recoverable failure.
+- Recovery, retry, HTTP mapping, and tests use stable structure rather than text.
+- Infrastructure libraries can be replaced without changing domain error contracts.
+- Adding a new expected failure requires an intentional public type change and exhaustive handling where appropriate.

--- a/docs/adr/0003-typed-failures-at-domain-seams.md
+++ b/docs/adr/0003-typed-failures-at-domain-seams.md
@@ -10,7 +10,7 @@ Generic `Error` values and third-party rejection types erase the operation that 
 
 ## Decision
 
-Every domain or adapter seam maps expected failures into domain-owned `Schema.TaggedErrorClass` values. Public failure surfaces are explicit unions and, when they cross a serialization or API boundary, Schema unions.
+Every domain or adapter seam maps expected failures into domain-owned `Schema.TaggedError` values. Public failure surfaces are explicit unions and, when they cross a serialization or API boundary, Schema unions.
 
 Failure types follow these rules:
 

--- a/docs/adr/0004-redaction-at-the-logging-render-edge.md
+++ b/docs/adr/0004-redaction-at-the-logging-render-edge.md
@@ -1,25 +1,35 @@
-# Redaction at the logging render edge
-
-Credentials and email addresses must never appear in job output. Redaction currently runs while error messages are created, coupling message construction to the policy and leaving any logging path that bypasses the aliases unprotected. Keep `src/log.ts` as the redaction policy module, and install a custom `Logger` at the `once.ts` process edge through `NodeRuntime.runMain` from `@effect/platform-node`. The logger redacts message, cause, and annotation values when it renders every log event. Retain creation-time redaction through `getErrorMessage` during the domain migration as an additional safeguard.
-
-The rendered output is timestamped, level-prefixed plain text because the cron output is read by humans.
+# Redaction is enforced by an Effect logger layer
 
 ## Status
 
-accepted
+Accepted
 
-## Considered Options
+## Context
 
-- **Creation-time-only redaction** — rejected because every call site becomes a possible leak boundary.
-- **No logger integration** — rejected because causes and annotations can contain secrets even when the main message has already been sanitized.
-- **Structured JSON output** — rejected for now because the job output is consumed directly by humans rather than a log ingestion system.
+Credentials, tokens, account identifiers, and email addresses can appear in messages, causes, annotations, or third-party failures. Call-site sanitization alone is incomplete because every new logging path becomes another security boundary.
+
+## Decision
+
+All application logs use Effect logging. The application composition root installs one custom `Logger` layer before running the program with `NodeRuntime.runMain`. The logger applies redaction to the fully rendered event, including message values, cause output, spans, and annotations.
+
+The redaction policy is an explicit service/layer built from validated runtime configuration. It is immutable for the lifetime of the application runtime; the design does not use a mutable module-global registry. Secrets remain `Redacted` in application configuration. Plaintext access is confined to the external adapter that must send a secret and to the redaction layer that must recognize it; domain and orchestration code never reveal it. The logger's policy is initialized with all values that must be suppressed before application work starts.
+
+Domain errors retain structured evidence and original causes. Redaction changes only rendering, never error construction, tags, retry classification, or program control flow. Adapters must still avoid logging entire request headers, cookies, credentials, or private response bodies.
+
+The process entry point is intentionally thin: load the `ConfigProvider`, construct the application and logger layers, provide them once, and invoke `NodeRuntime.runMain`. Runtime-reported terminal failures pass through the same logger. Application modules do not call `console`, format terminal failures independently, or maintain a second redaction mechanism.
+
+Human-readable output may remain a configured logger format for the cron environment; the event data and redaction policy stay independent of that renderer so a structured sink can replace it without changing domain code.
+
+## Considered options
+
+- **Sanitize only while constructing errors** — rejected because causes, annotations, and future logging sites can bypass it.
+- **Maintain a mutable global set of discovered secrets** — rejected because it introduces hidden process state, ordering dependence, and test isolation problems.
+- **Discard causes before logging** — rejected because it removes essential diagnostics instead of securing their rendering.
+- **Let `NodeRuntime` print failures separately** — rejected because it creates an unredacted output path.
 
 ## Consequences
 
-- All Effect logs cross one redacting render edge before reaching process output.
-- `src/log.ts` remains the policy module and keeps its current configuration API; #285 does not introduce a new configuration service.
-- `once.ts` uses `NodeRuntime.runMain`, preserving the runtime's standard exit behavior while reporting unhandled failures through the logger.
-
-## Amendment (2026-08-11)
-
-Issue #315 changes what the existing logging policy receives from runtime configuration. Credentials are decoded as `Redacted` values and are no longer copied into the redaction registry during startup. The owning adapter calls `revealSecret` at the external boundary; that helper reveals the value for the request and registers the plaintext with `src/log.ts` so the render edge continues to redact it. `configureSensitiveValues` remains the configuration entry point for non-secret identifiers and addresses.
+- Every Effect log event and terminal failure crosses one redaction boundary.
+- Tests provide an isolated policy/logger layer and cannot leak redaction state across cases.
+- Error models remain useful for diagnosis without coupling domain construction to presentation policy.
+- Adding a new sensitive configuration value requires updating the redaction-policy layer before that value can be logged safely.

--- a/docs/adr/0005-actual-synchronization-effect-module.md
+++ b/docs/adr/0005-actual-synchronization-effect-module.md
@@ -29,7 +29,7 @@ The client is acquired with `Effect.acquireRelease` inside an attempt-local `Sco
 
 Reconciliation is pure domain policy over Schema-validated values. Its action algebra uses exhaustive tagged variants. Imported identifiers make recovery after an ambiguous mutation response idempotent on the next full attempt.
 
-Adapters map SDK, filesystem, and HTTP failures to operation-specific `Schema.TaggedErrorClass` values and attach structured retryability derived from stable codes and status classes. The orchestration layer never parses messages. The health adapter uses Effect `HttpClient`, including cancellation and timeout.
+Adapters map SDK, filesystem, and HTTP failures to operation-specific `Schema.TaggedError` values and attach structured retryability derived from stable codes and status classes. The orchestration layer never parses messages. The health adapter uses Effect `HttpClient`, including cancellation and timeout.
 
 Retry wraps the entire scoped attempt. A bounded `Schedule` supplies capped exponential backoff, jitter, retry logging, and the attempt limit. Only failures classified as retryable enter the schedule, and only because the complete attempt is safe to repeat. Dates, timeout, backoff, and jitter use Effect `DateTime`, `Clock`, and `Random` services.
 

--- a/docs/adr/0005-actual-synchronization-effect-module.md
+++ b/docs/adr/0005-actual-synchronization-effect-module.md
@@ -1,55 +1,50 @@
-# Actual synchronization is a scoped Effect workflow
-
-Actual synchronization exposes one application-facing operation:
-`ActualSynchronization.synchronize(snapshot)`. The process entrypoint keeps its
-existing `main(config, snapshot)` shape and only provides the configuration and
-live layers needed by that service.
-
-The Actual SDK singleton is an adapter behind `ActualClientFactory`. Each
-Synchronization Attempt acquires the client in an Effect `Scope` and releases
-it exactly once through `shutdown`, including failure and interruption paths.
-Filesystem reset and the `/health` request are separate adapters so tests can
-replace production filesystem and network behavior without touching the
-workflow.
-
-The retryable unit is the complete Synchronization Attempt:
-
-```text
-reset → health check → initialize → download budget → read state → plan
-      → apply mutations → sync → shutdown
-```
-
-Every retry acquires a fresh client and re-derives the Reconciliation Plan from
-freshly downloaded state. Imported ids make a mutation whose response was lost
-safe to reconcile on the next attempt.
-
-Expected Actual failures are tagged errors. The adapters preserve the original
-cause and compute a `retryable` field from stable Actual error codes or HTTP
-status classes. The orchestration layer never classifies failures by message.
-Effect `Schedule` supplies the five-attempt cap, capped exponential backoff,
-jitter, Clock/Random integration, and retry logging. Current-date lookup uses
-Effect `DateTime` so workflow tests can control it with `TestClock`.
+# Actual synchronization is a scoped Effect service
 
 ## Status
 
-accepted
+Accepted
 
-## Considered Options
+## Context
 
-- **Manual recursive retry around the SDK singleton** — rejected: it kept
-  lifecycle, retry policy, and failure classification coupled and reused a
-  potentially dirty singleton across attempts.
-- **A single shared Actual error with an operation field** — rejected: the
-  domain convention calls for discoverable failure variants at meaningful
-  operation boundaries.
-- **Passing production dependencies as ordinary function arguments** —
-  rejected: Effect services and Layers keep the public synchronization seam
-  small while making deterministic workflow adapters explicit.
+Synchronizing a snapshot to Actual combines filesystem preparation, a health check, SDK resource management, remote reads, reconciliation policy, mutations, final sync, retry, and cleanup. Retrying only part of that sequence or reusing a failed SDK singleton can apply a plan derived from stale state.
+
+## Decision
+
+`ActualSynchronization` is a `Context.Service` exposing one named operation:
+
+```text
+synchronize(snapshot): Effect<void, ActualSynchronizationError>
+```
+
+Its live layer acquires validated Actual configuration and the `ActualClientFactory`, `ActualFileSystem`, `ActualHealthCheck`, and retry-policy services. The public method has no remaining environment requirements. The application entry point calls this service; no parallel plain-function API is retained.
+
+Each synchronization attempt executes this complete unit:
+
+```text
+reset -> health check -> acquire client -> download -> read -> plan
+      -> apply mutations -> sync -> release client
+```
+
+The client is acquired with `Effect.acquireRelease` inside an attempt-local `Scope`. A retry therefore gets a fresh client, downloads fresh state, and derives a fresh reconciliation plan. The release finalizer is uninterruptible and never leaks a resource. Cleanup failures are recorded through Effect observability without replacing an already meaningful domain failure; the finalizer itself has no typed failure channel.
+
+Reconciliation is pure domain policy over Schema-validated values. Its action algebra uses exhaustive tagged variants. Imported identifiers make recovery after an ambiguous mutation response idempotent on the next full attempt.
+
+Adapters map SDK, filesystem, and HTTP failures to operation-specific `Schema.TaggedErrorClass` values and attach structured retryability derived from stable codes and status classes. The orchestration layer never parses messages. The health adapter uses Effect `HttpClient`, including cancellation and timeout.
+
+Retry wraps the entire scoped attempt. A bounded `Schedule` supplies capped exponential backoff, jitter, retry logging, and the attempt limit. Only failures classified as retryable enter the schedule, and only because the complete attempt is safe to repeat. Dates, timeout, backoff, and jitter use Effect `DateTime`, `Clock`, and `Random` services.
+
+Tests use the service with explicit fake layers and deterministic `TestClock`/`TestRandom` control. They assert the attempt boundary, fresh acquisition, finalization, retry cap, backoff, idempotent reconciliation, and non-retryable short circuit.
+
+## Considered options
+
+- **Manual recursion around a shared SDK singleton** — rejected because it couples lifecycle and retry policy and can reuse contaminated state.
+- **Retry only the failed SDK call** — rejected because the reconciliation plan may already be stale or the remote mutation may have succeeded despite a lost response.
+- **Pass adapters and configuration as function arguments** — rejected because they are service implementation dependencies supplied by layers.
+- **Classify failures from messages in orchestration** — rejected because message text is neither stable nor domain-owned.
 
 ## Consequences
 
-- The Actual workflow can be tested end-to-end through one service method.
-- Shutdown, retry limits, backoff, and health-check timeout behavior are
-  observable without a live Actual server.
-- The SDK remains an external singleton, but its lifetime is bounded to one
-  attempt and never leaks into the reconciliation policy.
+- The retry boundary matches the consistency boundary.
+- Every attempt has isolated resource lifetime and freshly derived state.
+- The workflow is testable end to end without a live Actual server, filesystem, real clock, or process environment.
+- Vendor and platform details remain in replaceable leaf layers while reconciliation stays pure.


### PR DESCRIPTION
## What changed

- add a governing ADR that makes Effect the application architecture rather than an isolated utility
- revise the Fintual ingestion, email 2FA, typed-failure, logging/redaction, and Actual synchronization ADRs
- standardize on `Context.Service`, `Layer`, `Config`, `Schema`, Effect `HttpClient`, scoped resources, `Schedule`, and deterministic Effect tests
- remove transitional and backward-compatibility commitments for this greenfield project

## Why

The existing ADRs contained several transitional decisions and patterns that drifted from current Effect v4 guidance, including raw `fetch` boundaries, call-time configuration, generic errors, mutable global redaction state, and parallel non-Effect entry points. The revised ADRs establish a single Effect-first policy and make each domain decision inherit it.

## Impact

These ADRs become the architectural target for subsequent implementation work. Internal compatibility shims are explicitly out of scope; adapters, configuration, failures, resources, observability, and tests should use Effect-native abstractions end to end.

## Validation

The pre-push verification boundary passed:

- TypeScript typecheck
- 12 test files / 94 tests
- Fallow audit (no issues in the six changed files; one inherited finding excluded by the configured audit gate)