### PR TITLE
feat: migrate redaction policy to an Effect service/layer (#363)

### DIFF
--- a/src/actual/actual-client.ts
+++ b/src/actual/actual-client.ts
@@ -1,7 +1,6 @@
 import * as api from "@actual-app/api"
-import { Context, Effect, Layer, Predicate } from "effect"
+import { Context, Effect, Layer, Predicate, Redacted } from "effect"
 import type { ActualConfig } from "../env.ts"
-import { revealSecret } from "../log.ts"
 import type {
   ExistingVariationTransaction,
   VariationTransactionInput,
@@ -65,7 +64,7 @@ export class ActualClientFactory extends Context.Service<
             api.init({
               dataDir: ACTUAL_DATA_DIR,
               serverURL: config.serverUrl,
-              password: revealSecret(config.password),
+              password: Redacted.value(config.password),
               verbose: false,
             } satisfies ActualInitConfig),
           catch: (cause) =>

--- a/src/fintual/email-2fa-client.ts
+++ b/src/fintual/email-2fa-client.ts
@@ -1,7 +1,7 @@
-import { Context, Effect, Layer, Predicate, Schema } from "effect"
+import { Context, Effect, Layer, Predicate, Redacted, Schema } from "effect"
 import { ImapFlow, type SearchObject } from "imapflow"
 import type { Email2FAConfig } from "../env.ts"
-import { getErrorMessage, revealSecret } from "../log.ts"
+import { getErrorMessage } from "../log.ts"
 
 export interface ImapMailboxLock {
   release(): void
@@ -182,7 +182,7 @@ function createImapClient(config: Email2FAConfig): ImapClient {
       secure: true,
       auth: {
         user: config.userEmail,
-        pass: revealSecret(config.appPassword),
+        pass: Redacted.value(config.appPassword),
       },
       logger: false,
     }),

--- a/src/fintual/provider.ts
+++ b/src/fintual/provider.ts
@@ -1,6 +1,6 @@
-import { Context, DateTime, Effect, Layer, Predicate, Schema } from "effect"
+import { Context, DateTime, Effect, Layer, Predicate, Redacted, Schema } from "effect"
 import { FintualConfigService, type FintualConfig } from "../env.ts"
-import { getErrorMessage, revealSecret } from "../log.ts"
+import { getErrorMessage } from "../log.ts"
 import type { Email2FACode, Operational, TimedOut } from "./email-2fa.ts"
 import {
   Email2FAFailure,
@@ -217,7 +217,7 @@ const authenticate = Effect.fn("FintualProvider.authenticate")(function* (
         "Content-Type": "application/json",
         Referer: `${FINTUAL_ORIGIN}/f/sign-in/`,
       },
-      body: JSON.stringify({ email: config.email, password: revealSecret(config.password) }),
+      body: JSON.stringify({ email: config.email, password: Redacted.value(config.password) }),
     },
     "Fintual login",
   )
@@ -261,7 +261,7 @@ const authenticate = Effect.fn("FintualProvider.authenticate")(function* (
       },
       body: JSON.stringify({
         email: config.email,
-        password: revealSecret(config.password),
+        password: Redacted.value(config.password),
         code,
       }),
     },

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,64 +1,76 @@
 import { inspect } from "node:util"
-import { Predicate, Redacted } from "effect"
+import { Context, Layer, Predicate, Redacted } from "effect"
 import type { RuntimeConfig } from "./env.ts"
 
-let configuredRedactionSecrets = new Set<string>()
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi
 
-export function configureSensitiveValues(config: RuntimeConfig): void {
-  configuredRedactionSecrets = new Set(
+export class RedactionPolicy extends Context.Service<
+  RedactionPolicy,
+  {
+    readonly redact: (value: string) => string
+  }
+>()("fintual-api/RedactionPolicy") {
+  static readonly layer = (config: RuntimeConfig): Layer.Layer<RedactionPolicy, never, never> =>
+    Layer.succeed(RedactionPolicy, RedactionPolicy.fromConfig(config))
+
+  static readonly fromConfig = (config: RuntimeConfig): RedactionPolicy["Service"] =>
+    RedactionPolicy.of({
+      redact: (value) => redactSensitiveText(value, collectSensitiveValues(config)),
+    })
+
+  static readonly empty: RedactionPolicy["Service"] = RedactionPolicy.of({
+    redact: (value) => redactSensitiveText(value, new Set()),
+  })
+}
+
+function collectSensitiveValues(config: RuntimeConfig): ReadonlySet<string> {
+  const email2FA = config.fintual.email2FA
+  return new Set(
     [
       config.actual.serverUrl,
+      Redacted.value(config.actual.password),
       config.actual.syncId,
       config.actual.fintualAccount,
       config.fintual.email,
+      Redacted.value(config.fintual.password),
       config.fintual.goalId,
-      config.fintual.email2FA?.userEmail,
+      email2FA?.userEmail,
+      email2FA ? Redacted.value(email2FA.appPassword) : undefined,
     ].filter((value): value is string => Boolean(value)),
   )
 }
 
-export function revealSecret(secret: Redacted.Redacted<string>): string {
-  const value = Redacted.value(secret)
-  if (value) {
-    configuredRedactionSecrets.add(value)
-  }
-  return value
-}
-
+// Error rendering keeps the original cause evidence; redaction is applied once
+// by the logging render edge so no construction path becomes a second boundary.
 export function getErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message) {
-    return redactSensitiveText(error.message)
+    return error.message
   }
 
   if (Predicate.isObject(error)) {
     const structuredMessage = getStructuredErrorMessage(error)
     if (structuredMessage) {
-      return redactSensitiveText(structuredMessage)
+      return structuredMessage
     }
 
-    return redactSensitiveText(inspect(error, { depth: 3, breakLength: Number.POSITIVE_INFINITY }))
+    return inspect(error, { depth: 3, breakLength: Number.POSITIVE_INFINITY })
   }
 
   if (typeof error === "string" && error.trim()) {
-    return redactSensitiveText(error)
+    return error
   }
 
   return "Unknown error"
 }
 
-export function redactSensitiveText(value: string): string {
+function redactSensitiveText(value: string, sensitiveValues: ReadonlySet<string>): string {
   let redactedValue = value
 
-  for (const sensitiveValue of configuredRedactionSecrets) {
+  for (const sensitiveValue of sensitiveValues) {
     redactedValue = redactedValue.split(sensitiveValue).join("[redacted]")
   }
 
-  redactedValue = redactedValue.replaceAll(
-    /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
-    "[redacted email]",
-  )
-
-  return redactedValue
+  return redactedValue.replaceAll(EMAIL_PATTERN, "[redacted email]")
 }
 
 function getStructuredErrorMessage(error: Record<string, unknown>): string {

--- a/src/log.ts
+++ b/src/log.ts
@@ -13,14 +13,19 @@ export class RedactionPolicy extends Context.Service<
   static readonly layer = (config: RuntimeConfig): Layer.Layer<RedactionPolicy, never, never> =>
     Layer.succeed(RedactionPolicy, RedactionPolicy.fromConfig(config))
 
-  static readonly fromConfig = (config: RuntimeConfig): RedactionPolicy["Service"] =>
-    RedactionPolicy.of({
-      redact: (value) => redactSensitiveText(value, collectSensitiveValues(config)),
+  static readonly fromConfig = (config: RuntimeConfig): RedactionPolicy["Service"] => {
+    const sensitiveValues = collectSensitiveValues(config)
+    return RedactionPolicy.of({
+      redact: (value) => redactSensitiveText(value, sensitiveValues),
     })
+  }
 
-  static readonly empty: RedactionPolicy["Service"] = RedactionPolicy.of({
-    redact: (value) => redactSensitiveText(value, new Set()),
-  })
+  static readonly empty: RedactionPolicy["Service"] = (() => {
+    const sensitiveValues = new Set<string>()
+    return RedactionPolicy.of({
+      redact: (value) => redactSensitiveText(value, sensitiveValues),
+    })
+  })()
 }
 
 function collectSensitiveValues(config: RuntimeConfig): ReadonlySet<string> {

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -104,10 +104,29 @@ describe("RedactionPolicy", () => {
   })
 
   it("captures the sensitive snapshot once when the policy is built", () => {
-    const policy = RedactionPolicy.fromConfig(runtimeConfig)
-    const value = "value that must not be added later"
+    const config: RuntimeConfig = {
+      actual: {
+        serverUrl: "http://localhost:5006",
+        password: Redacted.make(secret),
+        syncId: "sync-before-build",
+        fintualAccount: "fintual-account",
+        startingDate: "2024-03-01",
+        payee: "Fintual",
+      },
+      fintual: {
+        email: "user@example.com",
+        password: Redacted.make("fintual-pass"),
+        goalId: "goal-42",
+        email2FA: null,
+      },
+    }
+    const policy = RedactionPolicy.fromConfig(config)
 
-    expect(policy.redact(value)).toBe(value)
+    config.actual.syncId = "sync-added-after-build"
+
+    expect(policy.redact("sync-before-build sync-added-after-build")).toBe(
+      "[redacted] sync-added-after-build",
+    )
   })
 
   effectIt.effect("provides an immutable policy layer from the validated runtime config", () =>

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -103,6 +103,13 @@ describe("RedactionPolicy", () => {
     expect(empty.redact(secret)).toBe(secret)
   })
 
+  it("captures the sensitive snapshot once when the policy is built", () => {
+    const policy = RedactionPolicy.fromConfig(runtimeConfig)
+    const value = "value that must not be added later"
+
+    expect(policy.redact(value)).toBe(value)
+  })
+
   effectIt.effect("provides an immutable policy layer from the validated runtime config", () =>
     Effect.gen(function* () {
       const policy = yield* RedactionPolicy
@@ -177,6 +184,27 @@ describe("redactingLogger", () => {
 })
 
 describe("reportUnhandledFailure", () => {
+  effectIt.effect("logs defects from a cause, not just typed failures", () =>
+    Effect.gen(function* () {
+      const lines: Array<string> = []
+      const program = Effect.die(new Error(`config exploded with ${secret}`)).pipe(
+        Effect.tapCause(reportUnhandledFailure),
+        Effect.catchCause(() => Effect.void),
+      )
+
+      yield* program.pipe(
+        Effect.provide(Logger.layer([redactingLoggerFor()])),
+        Effect.provideService(Console.Console, captureConsole(lines)),
+      )
+
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatch(
+        /^\[\d{2}:\d{2}:\d{2}\.\d{3}\] ERROR: Error: config exploded with \[redacted\]/,
+      )
+      expect(lines[0]).not.toContain(secret)
+    }),
+  )
+
   effectIt.effect("reports non-interrupt failures through the redacting logger", () =>
     Effect.gen(function* () {
       const lines: Array<string> = []

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -2,15 +2,12 @@ import { it as effectIt } from "@effect/vitest"
 import { Cause, Console, Effect, Logger, Redacted, Schema } from "effect"
 import { describe, expect, it } from "vitest"
 import type { RuntimeConfig } from "./env.ts"
-import {
-  configureSensitiveValues,
-  getErrorMessage,
-  redactSensitiveText,
-  revealSecret,
-} from "./log.ts"
-import { redactingLogger, reportUnhandledFailure } from "./once.ts"
+import { getErrorMessage, RedactionPolicy } from "./log.ts"
+import { makeRedactingLogger, reportUnhandledFailure } from "./once.ts"
 
 const secret = "hunter2-super-secret"
+const fintualSecret = "fintual-pass"
+const email2FASecret = "app-password"
 
 const runtimeConfig: RuntimeConfig = {
   actual: {
@@ -23,9 +20,16 @@ const runtimeConfig: RuntimeConfig = {
   },
   fintual: {
     email: "user@example.com",
-    password: Redacted.make("fintual-pass"),
+    password: Redacted.make(fintualSecret),
     goalId: "goal-42",
-    email2FA: null,
+    email2FA: {
+      userEmail: "2fa@example.com",
+      appPassword: Redacted.make(email2FASecret),
+      host: "imap.gmail.com",
+      port: 993,
+      debug: false,
+      sender: "notificaciones@fintual.com",
+    },
   },
 }
 
@@ -42,9 +46,8 @@ class UnexpectedFailure extends Schema.TaggedError<UnexpectedFailure>()("Unexpec
   }
 }
 
-function configureLoggingSecrets(): void {
-  configureSensitiveValues(runtimeConfig)
-  revealSecret(runtimeConfig.actual.password)
+function redactingLoggerFor(config: RuntimeConfig = runtimeConfig): Logger.Logger<unknown, void> {
+  return makeRedactingLogger(RedactionPolicy.fromConfig(config))
 }
 
 function captureConsole(lines: Array<string>): Console.Console {
@@ -71,19 +74,47 @@ function captureConsole(lines: Array<string>): Console.Console {
   }
 }
 
-it("registers redacted credentials when an adapter reveals them", () => {
-  configureSensitiveValues(runtimeConfig)
-  expect(redactSensitiveText(secret)).toBe(secret)
+describe("RedactionPolicy", () => {
+  it("redacts every sensitive configured value from the start, including Redacted passwords", () => {
+    const policy = RedactionPolicy.fromConfig(runtimeConfig)
 
-  revealSecret(runtimeConfig.actual.password)
+    expect(policy.redact(`actual ${secret} fintual ${fintualSecret} gmail ${email2FASecret}`)).toBe(
+      "actual [redacted] fintual [redacted] gmail [redacted]",
+    )
+  })
 
-  expect(redactSensitiveText(secret)).toBe("[redacted]")
+  it("redacts configured identifiers and email addresses", () => {
+    const policy = RedactionPolicy.fromConfig(runtimeConfig)
+
+    expect(
+      policy.redact(
+        "sync sync-1 account fintual-account goal goal-42 mail user@example.com 2fa 2fa@example.com other@example.com",
+      ),
+    ).toBe(
+      "sync [redacted] account [redacted] goal [redacted] mail [redacted] 2fa [redacted] [redacted email]",
+    )
+  })
+
+  it("keeps redaction state isolated between policies", () => {
+    const configured = RedactionPolicy.fromConfig(runtimeConfig)
+    const empty = RedactionPolicy.empty
+
+    expect(configured.redact(secret)).toBe("[redacted]")
+    expect(empty.redact(secret)).toBe(secret)
+  })
+
+  effectIt.effect("provides an immutable policy layer from the validated runtime config", () =>
+    Effect.gen(function* () {
+      const policy = yield* RedactionPolicy
+
+      expect(policy.redact(`secret ${secret} and goal-42`)).toBe("secret [redacted] and [redacted]")
+    }).pipe(Effect.provide(RedactionPolicy.layer(runtimeConfig))),
+  )
 })
 
 describe("redactingLogger", () => {
   effectIt.effect("renders timestamped, level-prefixed lines with sensitive values redacted", () =>
     Effect.gen(function* () {
-      configureLoggingSecrets()
       const lines: Array<string> = []
       const program = Effect.gen(function* () {
         yield* Effect.logInfo(`Connecting with password ${secret}`)
@@ -91,7 +122,7 @@ describe("redactingLogger", () => {
       })
 
       yield* program.pipe(
-        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provide(Logger.layer([redactingLoggerFor()])),
         Effect.provideService(Console.Console, captureConsole(lines)),
       )
 
@@ -108,14 +139,13 @@ describe("redactingLogger", () => {
 
   effectIt.effect("redacts annotation values", () =>
     Effect.gen(function* () {
-      configureLoggingSecrets()
       const lines: Array<string> = []
       const program = Effect.gen(function* () {
         yield* Effect.logInfo("creating goal").pipe(Effect.annotateLogs({ goalId: "goal-42" }))
       })
 
       yield* program.pipe(
-        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provide(Logger.layer([redactingLoggerFor()])),
         Effect.provideService(Console.Console, captureConsole(lines)),
       )
 
@@ -128,14 +158,13 @@ describe("redactingLogger", () => {
 
   effectIt.effect("redacts secrets split across message parts", () =>
     Effect.gen(function* () {
-      configureLoggingSecrets()
       const lines: Array<string> = []
       const program = Effect.gen(function* () {
         yield* Effect.logInfo("password is", secret, "on", "goal-42")
       })
 
       yield* program.pipe(
-        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provide(Logger.layer([redactingLoggerFor()])),
         Effect.provideService(Console.Console, captureConsole(lines)),
       )
 
@@ -150,7 +179,6 @@ describe("redactingLogger", () => {
 describe("reportUnhandledFailure", () => {
   effectIt.effect("reports non-interrupt failures through the redacting logger", () =>
     Effect.gen(function* () {
-      configureLoggingSecrets()
       const lines: Array<string> = []
       const program = Effect.fail(
         new UnexpectedFailure({ cause: new Error(`unexpected ${secret}`) }),
@@ -160,7 +188,7 @@ describe("reportUnhandledFailure", () => {
       )
 
       yield* program.pipe(
-        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provide(Logger.layer([redactingLoggerFor()])),
         Effect.provideService(Console.Console, captureConsole(lines)),
       )
 
@@ -174,7 +202,6 @@ describe("reportUnhandledFailure", () => {
 
   effectIt.effect("stays silent for interrupt-only causes", () =>
     Effect.gen(function* () {
-      configureLoggingSecrets()
       const lines: Array<string> = []
       const program = Effect.interrupt.pipe(
         Effect.tapCause(reportUnhandledFailure),
@@ -182,7 +209,7 @@ describe("reportUnhandledFailure", () => {
       )
 
       yield* program.pipe(
-        Effect.provide(Logger.layer([redactingLogger])),
+        Effect.provide(Logger.layer([redactingLoggerFor()])),
         Effect.provideService(Console.Console, captureConsole(lines)),
       )
 

--- a/src/once.ts
+++ b/src/once.ts
@@ -2,41 +2,58 @@ import { pathToFileURL } from "node:url"
 import { NodeRuntime } from "@effect/platform-node"
 import { config as loadDotEnv } from "dotenv"
 import { Array as EffectArray, Cause, Effect, Formatter, Logger, References } from "effect"
-import { resolveRuntimeConfig, type RuntimeConfigError } from "./env.ts"
+import { resolveRuntimeConfig, type RuntimeConfig, type RuntimeConfigError } from "./env.ts"
 import type { ActualError } from "./actual.ts"
 import type { FintualError } from "./fintual/fintual-error.ts"
 import { runJob } from "./job.ts"
-import { configureSensitiveValues, redactSensitiveText } from "./log.ts"
+import { RedactionPolicy } from "./log.ts"
 
 loadDotEnv()
 
-const main = Effect.fn("Once.main")(function* (): Effect.fn.Return<
-  void,
-  RuntimeConfigError | ActualError | FintualError
-> {
-  const runtimeConfig = yield* resolveRuntimeConfig(process.env)
-  configureSensitiveValues(runtimeConfig)
+const runOnce = Effect.fn("Once.runOnce")(function* (
+  runtimeConfig: RuntimeConfig,
+): Effect.fn.Return<void, ActualError | FintualError> {
   yield* Effect.logInfo("Running task once...")
   yield* runJob(runtimeConfig)
   yield* Effect.logInfo("Task completed.")
 })
 
-export const redactingLogger = Logger.withLeveledConsole(
-  Logger.make(({ cause, date, fiber, logLevel, message }) => {
-    const parts: Array<string> = []
-    for (const part of EffectArray.ensure(message)) {
-      parts.push(renderPlain(part))
-    }
-    if (cause.reasons.length > 0) {
-      parts.push(Cause.pretty(cause))
-    }
-    for (const [key, value] of Object.entries(fiber.getRef(References.CurrentLogAnnotations))) {
-      parts.push(`${key}: ${renderPlain(value)}`)
-    }
-    const line = `[${formatTimestamp(date)}] ${logLevel.toUpperCase()}: ${parts.join(" ")}`
-    return redactSensitiveText(line)
-  }),
-)
+const main = Effect.fn("Once.main")(function* (): Effect.fn.Return<
+  void,
+  RuntimeConfigError | ActualError | FintualError
+> {
+  const runtimeConfig = yield* resolveRuntimeConfig(process.env).pipe(
+    Effect.tapError((error) =>
+      reportUnhandledFailure(Cause.fail(error)).pipe(
+        Effect.provide(Logger.layer([makeRedactingLogger(RedactionPolicy.empty)])),
+      ),
+    ),
+  )
+  yield* runOnce(runtimeConfig).pipe(
+    Effect.tapCause(reportUnhandledFailure),
+    Effect.provide(Logger.layer([makeRedactingLogger(RedactionPolicy.fromConfig(runtimeConfig))])),
+  )
+})
+
+export const makeRedactingLogger = (
+  redactionPolicy: RedactionPolicy["Service"],
+): Logger.Logger<unknown, void> =>
+  Logger.withLeveledConsole(
+    Logger.make<unknown, string>(({ cause, date, fiber, logLevel, message }) => {
+      const parts: Array<string> = []
+      for (const part of EffectArray.ensure(message)) {
+        parts.push(renderPlain(part))
+      }
+      if (cause.reasons.length > 0) {
+        parts.push(Cause.pretty(cause))
+      }
+      for (const [key, value] of Object.entries(fiber.getRef(References.CurrentLogAnnotations))) {
+        parts.push(`${key}: ${renderPlain(value)}`)
+      }
+      const line = `[${formatTimestamp(date)}] ${logLevel.toUpperCase()}: ${parts.join(" ")}`
+      return redactionPolicy.redact(line)
+    }),
+  )
 
 export const reportUnhandledFailure = (cause: Cause.Cause<unknown>): Effect.Effect<void> =>
   Cause.hasInterruptsOnly(cause) ? Effect.void : Effect.logError(cause)
@@ -58,11 +75,5 @@ function isMainModule(): boolean {
 }
 
 if (isMainModule()) {
-  NodeRuntime.runMain(
-    main().pipe(
-      Effect.tapCause(reportUnhandledFailure),
-      Effect.provide(Logger.layer([redactingLogger])),
-    ),
-    { disableErrorReporting: true },
-  )
+  NodeRuntime.runMain(main(), { disableErrorReporting: true })
 }

--- a/src/once.ts
+++ b/src/once.ts
@@ -23,8 +23,8 @@ const main = Effect.fn("Once.main")(function* (): Effect.fn.Return<
   RuntimeConfigError | ActualError | FintualError
 > {
   const runtimeConfig = yield* resolveRuntimeConfig(process.env).pipe(
-    Effect.tapError((error) =>
-      reportUnhandledFailure(Cause.fail(error)).pipe(
+    Effect.tapCause((cause) =>
+      reportUnhandledFailure(cause).pipe(
         Effect.provide(Logger.layer([makeRedactingLogger(RedactionPolicy.empty)])),
       ),
     ),


### PR DESCRIPTION
## Summary

Replaces the mutable module-global redaction registry in `src/log.ts` with an explicit, immutable `RedactionPolicy` Effect service/layer, matching `docs/adr/0004-redaction-at-the-logging-render-edge.md`.

- `RedactionPolicy` is a `Context.Service` built from the validated `RuntimeConfig` at the composition root; its `layer(config)` is available for tests and future compositions.
- The policy now includes every sensitive configured value from process start, including the `Redacted` passwords (`ACTUAL_PASSWORD`, `FINTUAL_USER_PASSWORD`, `GMAIL_APP_PASSWORD`), plus the previously seeded identifiers and emails.
- `revealSecret` is removed; each external adapter obtains plaintext locally with `Redacted.value` where it must send the credential (Actual, Fintual login, Gmail IMAP). No adapter mutates redaction state.
- `getErrorMessage` no longer redacts during error construction; redaction happens once at the logging render edge, so causes keep their structured evidence.
- `src/once.ts` remains the thin one-shot composition root: it resolves config, builds the policy and logger, and runs the job. Config-resolution failures still pass through a redacting logger; one-shot exit behavior is unchanged.
- Redaction tests in `src/once.test.ts` now exercise the service/layer with isolated policy state per test.

## Scheduler impact

The scheduler work (#357) can now compose `RedactionPolicy.layer(config)` and `makeRedactingLogger(policy)` at its own composition root instead of importing `src/once.ts` or depending on module-global seeding. This PR deliberately keeps the render-edge shape (`makeRedactingLogger` + `reportUnhandledFailure`) in `once.ts` so #358 can extract it without reverting this change.

Fixes #363