### PR TITLE
docs: close parent specs when all tickets land

### DIFF
--- a/.agents/friction-log/20260811203610-matt-pocock-spec/friction.md
+++ b/.agents/friction-log/20260811203610-matt-pocock-spec/friction.md
@@ -5,8 +5,9 @@ severity: 'minor'
 
 ## Expected Behavior
 
-The parent spec issue closes once every child ticket it produced is closed
-through its merged PR.
+The parent spec issue closes once every child ticket it produced is closed:
+through its merged PR when the work ships, or explicitly when all children
+are closed without landing.
 
 ## Current Behavior
 

--- a/.agents/friction-log/20260811203610-matt-pocock-spec/friction.md
+++ b/.agents/friction-log/20260811203610-matt-pocock-spec/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'Matt Pocock spec flow never closes the parent spec after its tickets land'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+The parent spec issue closes once every child ticket it produced is closed.
+
+## Current Behavior
+
+The to-spec -> to-tickets -> implement flow closes each child ticket through its PR, but nothing closes the parent spec when all children are done. Example: #351 had all three children (#352, #353, #354) closed by merged PRs (#355, #356, #362) and remained open.
+
+## Possible Solution
+
+Document a spec lifecycle in docs/agents/issue-tracker.md and docs/agents/delivery-workflow.md, teach the final ticket PR to include Closes #spec, and add a parent-closure sweep to ask-matt-chain's session protocol.
+
+## Minimal Reproducible Example
+
+Run to-spec then to-tickets for a feature, implement and merge every child PR, then list open issues: the spec remains open.
+
+## Context
+
+Specs are plans, not backlog items; leaving them open makes ready-for-agent queries mix stale plans with actionable tickets.

--- a/.agents/friction-log/20260811203610-matt-pocock-spec/friction.md
+++ b/.agents/friction-log/20260811203610-matt-pocock-spec/friction.md
@@ -5,7 +5,8 @@ severity: 'minor'
 
 ## Expected Behavior
 
-The parent spec issue closes once every child ticket it produced is closed.
+The parent spec issue closes once every child ticket it produced is closed
+through its merged PR.
 
 ## Current Behavior
 

--- a/docs/agents/delivery-workflow.md
+++ b/docs/agents/delivery-workflow.md
@@ -59,8 +59,8 @@ child ticket is published, the parent spec becomes complete:
 - If this PR is the last open child, include `Closes #<spec>` alongside
   `Fixes #<child>` so merge closes both.
 - If the spec has no child tickets, its own PR closes it normally.
-- If the parent remains open after all children are closed, close it with a
-  comment listing the child issues and PRs.
+- If the parent remains open after all children are closed through merged PRs,
+  close it with a comment listing the child issues and PRs.
 
 ## Publish before resolving
 

--- a/docs/agents/delivery-workflow.md
+++ b/docs/agents/delivery-workflow.md
@@ -61,6 +61,11 @@ child ticket is published, the parent spec becomes complete:
 - If the spec has no child tickets, its own PR closes it normally.
 - If the parent remains open after all children are closed through merged PRs,
   close it with a comment listing the child issues and PRs.
+- If every child is closed without a merged PR, close the parent as
+  `not_planned` (or `duplicate` when it duplicates another spec) with a comment
+  rather than leaving a stale plan open.
+- If some children landed and the rest were closed without landing, close the
+  parent with a comment noting which work shipped and which was cancelled.
 
 ## Publish before resolving
 

--- a/docs/agents/delivery-workflow.md
+++ b/docs/agents/delivery-workflow.md
@@ -51,6 +51,17 @@ Use the repository's scoped formatting scripts. For files outside their scope,
 make a minimal edit and preserve the existing layout; do not run a broad
 formatter over unrelated configuration.
 
+## Close the parent spec
+
+A spec issue is a plan, not a backlog item. When the PR that closes the last
+child ticket is published, the parent spec becomes complete:
+
+- If this PR is the last open child, include `Closes #<spec>` alongside
+  `Fixes #<child>` so merge closes both.
+- If the spec has no child tickets, its own PR closes it normally.
+- If the parent remains open after all children are closed, close it with a
+  comment listing the child issues and PRs.
+
 ## Publish before resolving
 
 An implementation issue is not complete when its change exists only in a local

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -45,17 +45,21 @@ Run `gh issue view <number> --comments`.
 ## Spec lifecycle
 
 `/to-spec` publishes a plan; `/to-tickets` publishes the child tickets that
-implement it. A spec is done when every child ticket it produced is closed
-through its merged PR.
+implement it. A spec is resolved when every child ticket it produced is
+closed. Only a merged PR counts as landing; a child closed as `not_planned`
+or `duplicate` does not ship work.
 
 - Keep the spec open while any child ticket is open.
 - Each child closes through its PR with `Fixes #<child>` / `Closes #<child>`.
-- A child closed without landing (for example `not_planned` or `duplicate`)
-  does not complete the spec.
-- When the last child lands through a merged PR, close the parent spec. Prefer
-  putting `Closes #<spec>` in the final child's PR body so merge closes both.
-  If that was not done, close it explicitly:
+- When the last child lands through a merged PR, close the parent as complete.
+  Prefer putting `Closes #<spec>` in the final child's PR body so merge closes
+  both. If that was not done, close it explicitly:
   `gh issue close <spec> --comment "All tickets closed: #a (#pr-a), #b (#pr-b), #c (#pr-c)"`.
+- If every child is closed without landing, close the parent as `not_planned`
+  (or `duplicate` when it duplicates another spec) with a comment instead of
+  leaving a stale plan open.
+- If some children landed and the rest were closed without landing, close the
+  parent with a comment noting which work shipped and which was cancelled.
 - The `to-tickets` instruction "Do NOT close or modify any parent issue"
   applies while tickets are being created; it does not prevent the completion
   step above after all children land.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -45,14 +45,17 @@ Run `gh issue view <number> --comments`.
 ## Spec lifecycle
 
 `/to-spec` publishes a plan; `/to-tickets` publishes the child tickets that
-implement it. A spec is done when every child ticket it produced is closed.
+implement it. A spec is done when every child ticket it produced is closed
+through its merged PR.
 
 - Keep the spec open while any child ticket is open.
 - Each child closes through its PR with `Fixes #<child>` / `Closes #<child>`.
-- When the last open child is closed, close the parent spec. Prefer putting
-  `Closes #<spec>` in the final child's PR body so merge closes both. If that
-  was not done, close it explicitly:
-  `gh issue close <spec> --comment "All tickets closed: #a, #b, #c"`.
+- A child closed without landing (for example `not_planned` or `duplicate`)
+  does not complete the spec.
+- When the last child lands through a merged PR, close the parent spec. Prefer
+  putting `Closes #<spec>` in the final child's PR body so merge closes both.
+  If that was not done, close it explicitly:
+  `gh issue close <spec> --comment "All tickets closed: #a (#pr-a), #b (#pr-b), #c (#pr-c)"`.
 - The `to-tickets` instruction "Do NOT close or modify any parent issue"
   applies while tickets are being created; it does not prevent the completion
   step above after all children land.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -42,6 +42,21 @@ Create a GitHub issue.
 
 Run `gh issue view <number> --comments`.
 
+## Spec lifecycle
+
+`/to-spec` publishes a plan; `/to-tickets` publishes the child tickets that
+implement it. A spec is done when every child ticket it produced is closed.
+
+- Keep the spec open while any child ticket is open.
+- Each child closes through its PR with `Fixes #<child>` / `Closes #<child>`.
+- When the last open child is closed, close the parent spec. Prefer putting
+  `Closes #<spec>` in the final child's PR body so merge closes both. If that
+  was not done, close it explicitly:
+  `gh issue close <spec> --comment "All tickets closed: #a, #b, #c"`.
+- The `to-tickets` instruction "Do NOT close or modify any parent issue"
+  applies while tickets are being created; it does not prevent the completion
+  step above after all children land.
+
 ## Wayfinding operations
 
 Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.


### PR DESCRIPTION
## Problem

The `to-spec` -> `to-tickets` -> `implement` flow closes each child ticket through its PR, but nothing closes the parent spec when all children are done. Specs remain open forever and keep appearing in `ready-for-agent` queries. Example: #351 had all three children (#352, #353, #354) closed by merged PRs (#355, #356, #362) and remained open.

## Changes

- `docs/agents/issue-tracker.md`: document the spec lifecycle - keep a spec open while any child ticket is open, prefer `Closes #spec` on the final child PR, and close explicitly when all children have landed.
- `docs/agents/delivery-workflow.md`: tell agents to close the parent spec when publishing the PR that closes the last child.
- `.agents/friction-log/`: record the gap.

## Notes

The matching `ask-matt-chain` and `ask-matt` skill protocol edits live in `~/.agents/skills` and are intentionally not part of this repository PR. The repo docs are the durable source agents read every run.

Applied once as part of this work: closed #351 with a completion comment referencing its children and PRs.