### PR TITLE
feat: build in-process cron scheduler core (#359)

### DIFF
--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -1,0 +1,174 @@
+import { it } from "@effect/vitest"
+import {
+  Array as EffectArray,
+  Cause,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Formatter,
+  Logger,
+  Ref,
+  Schema,
+} from "effect"
+import { TestClock } from "effect/testing"
+import { describe, expect } from "vitest"
+import { InvalidScheduleError, runScheduler, type SchedulerOptions } from "./scheduler.ts"
+
+function schedulerOptions(overrides: Partial<SchedulerOptions> = {}): SchedulerOptions {
+  return { cron: "* * * * *", timezone: "UTC", noOverlap: false, ...overrides }
+}
+
+function capturingLogger(lines: Array<string>): Logger.Logger<unknown, void> {
+  return Logger.make(({ message }) => {
+    for (const part of EffectArray.ensure(message)) {
+      lines.push(typeof part === "string" ? part : Formatter.format(part))
+    }
+  })
+}
+
+class ScriptedJobFailure extends Schema.TaggedError<ScriptedJobFailure>()("ScriptedJobFailure", {
+  message: Schema.String,
+}) {}
+
+describe("runScheduler", () => {
+  it.effect("runs the job at each cron occurrence, not at startup", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0)
+      const job = Ref.update(attempts, (n) => n + 1)
+      const fiber = yield* Effect.forkChild(
+        runScheduler(job, schedulerOptions({ timezone: "America/Santiago" })),
+      )
+
+      expect(yield* Ref.get(attempts)).toBe(0)
+
+      yield* TestClock.adjust("1 minute")
+      expect(yield* Ref.get(attempts)).toBe(1)
+
+      yield* TestClock.adjust("1 minute")
+      expect(yield* Ref.get(attempts)).toBe(2)
+
+      yield* Fiber.interrupt(fiber)
+    }),
+  )
+
+  it.effect("fires according to the configured timezone", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse("2026-02-03T12:00:00Z"))
+
+      const utcAttempts = yield* Ref.make(0)
+      const kolkataAttempts = yield* Ref.make(0)
+      const utcJob = Ref.update(utcAttempts, (n) => n + 1)
+      const kolkataJob = Ref.update(kolkataAttempts, (n) => n + 1)
+      const utcFiber = yield* Effect.forkChild(
+        runScheduler(utcJob, schedulerOptions({ cron: "30 * * * *", timezone: "UTC" })),
+      )
+      const kolkataFiber = yield* Effect.forkChild(
+        runScheduler(
+          kolkataJob,
+          schedulerOptions({ cron: "30 * * * *", timezone: "Asia/Kolkata" }),
+        ),
+      )
+
+      yield* TestClock.adjust("30 minutes")
+
+      expect(yield* Ref.get(utcAttempts)).toBe(1)
+      expect(yield* Ref.get(kolkataAttempts)).toBe(0)
+
+      yield* TestClock.adjust("30 minutes")
+
+      expect(yield* Ref.get(utcAttempts)).toBe(1)
+      expect(yield* Ref.get(kolkataAttempts)).toBe(1)
+
+      yield* Fiber.interrupt(utcFiber)
+      yield* Fiber.interrupt(kolkataFiber)
+    }),
+  )
+
+  it.effect("logs a failed tick and continues to the next occurrence", () =>
+    Effect.gen(function* () {
+      const lines: Array<string> = []
+      const attempts = yield* Ref.make(0)
+      const job = Effect.gen(function* () {
+        const attempt = yield* Ref.updateAndGet(attempts, (n) => n + 1)
+        if (attempt === 1) return yield* new ScriptedJobFailure({ message: "boom" })
+      })
+      const fiber = yield* Effect.forkChild(
+        runScheduler(job, schedulerOptions()).pipe(
+          Effect.provide(Logger.layer([capturingLogger(lines)])),
+        ),
+      )
+
+      yield* TestClock.adjust("1 minute")
+      expect(yield* Ref.get(attempts)).toBe(1)
+
+      yield* TestClock.adjust("1 minute")
+      expect(yield* Ref.get(attempts)).toBe(2)
+      expect(lines.join("\n")).toContain("Scheduled run failed")
+
+      yield* Fiber.interrupt(fiber)
+    }),
+  )
+
+  it.effect("stops cleanly when interrupted", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0)
+      const job = Ref.update(attempts, (n) => n + 1)
+      const fiber = yield* Effect.forkChild(runScheduler(job, schedulerOptions()))
+
+      yield* TestClock.adjust("1 minute")
+      expect(yield* Ref.get(attempts)).toBe(1)
+
+      yield* Fiber.interrupt(fiber)
+      const exit = yield* Fiber.await(fiber)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true)
+      }
+      expect(yield* Ref.get(attempts)).toBe(1)
+    }),
+  )
+
+  it.effect("prevents a concurrent run when no-overlap is enabled", () =>
+    Effect.gen(function* () {
+      const attempts = yield* Ref.make(0)
+      const release = yield* Deferred.make<void>()
+      const job = Effect.gen(function* () {
+        yield* Ref.update(attempts, (n) => n + 1)
+        yield* Deferred.await(release)
+      })
+      const fiber = yield* Effect.forkChild(
+        runScheduler(job, schedulerOptions({ noOverlap: true })),
+      )
+
+      yield* TestClock.adjust("1 minute")
+      expect(yield* Ref.get(attempts)).toBe(1)
+
+      yield* TestClock.adjust("1 minute")
+      expect(yield* Ref.get(attempts)).toBe(1)
+
+      yield* Deferred.succeed(release, undefined)
+      yield* Effect.yieldNow
+
+      yield* TestClock.adjust("1 minute")
+      expect(yield* Ref.get(attempts)).toBe(2)
+
+      yield* Fiber.interrupt(fiber)
+    }),
+  )
+
+  it.effect("fails fast with InvalidScheduleError for an invalid cron expression", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        runScheduler(Effect.void, schedulerOptions({ cron: "not a cron" })),
+      )
+
+      expect(error).toBeInstanceOf(InvalidScheduleError)
+      expect(error).toMatchObject({
+        _tag: "InvalidScheduleError",
+        input: "not a cron",
+      })
+    }),
+  )
+})

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -19,11 +19,17 @@ function schedulerOptions(overrides: Partial<SchedulerOptions> = {}): SchedulerO
   return { cron: "* * * * *", timezone: "UTC", noOverlap: false, ...overrides }
 }
 
-function capturingLogger(lines: Array<string>): Logger.Logger<unknown, void> {
-  return Logger.make(({ message }) => {
-    for (const part of EffectArray.ensure(message)) {
-      lines.push(typeof part === "string" ? part : Formatter.format(part))
-    }
+interface CapturedLog {
+  readonly level: string
+  readonly message: string
+}
+
+function capturingLogger(lines: Array<CapturedLog>): Logger.Logger<unknown, void> {
+  return Logger.make(({ logLevel, message }) => {
+    const parts = EffectArray.ensure(message).map((part) =>
+      typeof part === "string" ? part : Formatter.format(part),
+    )
+    lines.push({ level: logLevel, message: parts.join(" ") })
   })
 }
 
@@ -87,7 +93,7 @@ describe("runScheduler", () => {
 
   it.effect("logs a failed tick and continues to the next occurrence", () =>
     Effect.gen(function* () {
-      const lines: Array<string> = []
+      const lines: Array<CapturedLog> = []
       const attempts = yield* Ref.make(0)
       const job = Effect.gen(function* () {
         const attempt = yield* Ref.updateAndGet(attempts, (n) => n + 1)
@@ -104,7 +110,7 @@ describe("runScheduler", () => {
 
       yield* TestClock.adjust("1 minute")
       expect(yield* Ref.get(attempts)).toBe(2)
-      expect(lines.join("\n")).toContain("Scheduled run failed")
+      expect(lines.map((line) => line.level)).toContain("Error")
 
       yield* Fiber.interrupt(fiber)
     }),
@@ -132,24 +138,33 @@ describe("runScheduler", () => {
 
   it.effect("prevents a concurrent run when no-overlap is enabled", () =>
     Effect.gen(function* () {
+      const lines: Array<CapturedLog> = []
       const attempts = yield* Ref.make(0)
+      const started = yield* Deferred.make<void>()
       const release = yield* Deferred.make<void>()
+      const done = yield* Deferred.make<void>()
       const job = Effect.gen(function* () {
         yield* Ref.update(attempts, (n) => n + 1)
+        yield* Deferred.succeed(started, undefined)
         yield* Deferred.await(release)
+        yield* Deferred.succeed(done, undefined)
       })
       const fiber = yield* Effect.forkChild(
-        runScheduler(job, schedulerOptions({ noOverlap: true })),
+        runScheduler(job, schedulerOptions({ noOverlap: true })).pipe(
+          Effect.provide(Logger.layer([capturingLogger(lines)])),
+        ),
       )
 
       yield* TestClock.adjust("1 minute")
+      yield* Deferred.await(started)
       expect(yield* Ref.get(attempts)).toBe(1)
 
       yield* TestClock.adjust("1 minute")
       expect(yield* Ref.get(attempts)).toBe(1)
+      expect(lines.map((line) => line.level)).toContain("Warn")
 
       yield* Deferred.succeed(release, undefined)
-      yield* Effect.yieldNow
+      yield* Deferred.await(done)
 
       yield* TestClock.adjust("1 minute")
       expect(yield* Ref.get(attempts)).toBe(2)

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,0 +1,56 @@
+import { Cause, Clock, Cron, Duration, Effect, Ref, Result, Schema } from "effect"
+
+export interface SchedulerOptions {
+  readonly cron: string
+  readonly timezone: string
+  readonly noOverlap: boolean
+}
+
+export class InvalidScheduleError extends Schema.TaggedError<InvalidScheduleError>()(
+  "InvalidScheduleError",
+  {
+    message: Schema.String,
+    input: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {}
+
+export const runScheduler = Effect.fn("Scheduler.run")(function* (
+  job: Effect.Effect<unknown, unknown>,
+  options: SchedulerOptions,
+): Effect.fn.Return<never, InvalidScheduleError> {
+  const parsed = Cron.parse(options.cron, options.timezone)
+  if (Result.isFailure(parsed)) {
+    return yield* new InvalidScheduleError({
+      message: parsed.failure.message,
+      input: parsed.failure.input ?? options.cron,
+      cause: parsed.failure,
+    })
+  }
+
+  const cron = parsed.success
+  const running = yield* Ref.make(false)
+
+  const tick = Effect.gen(function* () {
+    const now = yield* Clock.currentTimeMillis
+    const next = Cron.next(cron, new Date(now))
+    yield* Effect.sleep(Duration.millis(next.getTime() - now))
+
+    if (options.noOverlap && (yield* Ref.getAndSet(running, true))) {
+      yield* Effect.logWarning("Skipping scheduled run; a previous run is still in progress")
+      return
+    }
+
+    yield* job.pipe(
+      Effect.catchCause((cause) =>
+        // Interruption must stop the scheduler, so only non-interrupt causes are logged.
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.interrupt
+          : Effect.logError("Scheduled run failed", cause),
+      ),
+      Effect.ensuring(Ref.set(running, false)),
+    )
+  })
+
+  return yield* Effect.forever(tick)
+})

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,4 +1,16 @@
-import { Cause, Clock, Cron, Duration, Effect, Ref, Result, Schema } from "effect"
+import {
+  Cause,
+  Clock,
+  Cron,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Ref,
+  Result,
+  Schema,
+  Scope,
+} from "effect"
 
 export interface SchedulerOptions {
   readonly cron: string
@@ -15,7 +27,7 @@ export class InvalidScheduleError extends Schema.TaggedError<InvalidScheduleErro
   },
 ) {}
 
-export const runScheduler = Effect.fn("Scheduler.run")(function* (
+export const runScheduler = Effect.fn("runScheduler")(function* (
   job: Effect.Effect<unknown, unknown>,
   options: SchedulerOptions,
 ): Effect.fn.Return<never, InvalidScheduleError> {
@@ -29,28 +41,33 @@ export const runScheduler = Effect.fn("Scheduler.run")(function* (
   }
 
   const cron = parsed.success
+  const scope = yield* Scope.make()
   const running = yield* Ref.make(false)
 
   const tick = Effect.gen(function* () {
     const now = yield* Clock.currentTimeMillis
-    const next = Cron.next(cron, new Date(now))
-    yield* Effect.sleep(Duration.millis(next.getTime() - now))
+    const next = Cron.next(cron, now)
+    const timer = yield* Effect.forkIn(Effect.sleep(Duration.millis(next.getTime() - now)), scope)
+    yield* Fiber.join(timer)
 
     if (options.noOverlap && (yield* Ref.getAndSet(running, true))) {
       yield* Effect.logWarning("Skipping scheduled run; a previous run is still in progress")
       return
     }
 
-    yield* job.pipe(
-      Effect.catchCause((cause) =>
-        // Interruption must stop the scheduler, so only non-interrupt causes are logged.
-        Cause.hasInterruptsOnly(cause)
-          ? Effect.interrupt
-          : Effect.logError("Scheduled run failed", cause),
+    yield* Effect.forkIn(
+      job.pipe(
+        Effect.catchCause((cause) =>
+          // Interruption must stop the scheduler, so only non-interrupt causes are logged.
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.interrupt
+            : Effect.logError("Scheduled run failed", cause),
+        ),
+        Effect.ensuring(Ref.set(running, false)),
       ),
-      Effect.ensuring(Ref.set(running, false)),
+      scope,
     )
   })
 
-  return yield* Effect.forever(tick)
+  return yield* Effect.forever(tick).pipe(Effect.ensuring(Scope.close(scope, Exit.void)))
 })

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,16 +1,4 @@
-import {
-  Cause,
-  Clock,
-  Cron,
-  Duration,
-  Effect,
-  Exit,
-  Fiber,
-  Ref,
-  Result,
-  Schema,
-  Scope,
-} from "effect"
+import { Cause, Clock, Cron, Duration, Effect, Exit, Ref, Result, Schema, Scope } from "effect"
 
 export interface SchedulerOptions {
   readonly cron: string
@@ -27,7 +15,7 @@ export class InvalidScheduleError extends Schema.TaggedError<InvalidScheduleErro
   },
 ) {}
 
-export const runScheduler = Effect.fn("runScheduler")(function* (
+export const runScheduler = Effect.fn("Scheduler.run")(function* (
   job: Effect.Effect<unknown, unknown>,
   options: SchedulerOptions,
 ): Effect.fn.Return<never, InvalidScheduleError> {
@@ -47,8 +35,7 @@ export const runScheduler = Effect.fn("runScheduler")(function* (
   const tick = Effect.gen(function* () {
     const now = yield* Clock.currentTimeMillis
     const next = Cron.next(cron, now)
-    const timer = yield* Effect.forkIn(Effect.sleep(Duration.millis(next.getTime() - now)), scope)
-    yield* Fiber.join(timer)
+    yield* Effect.sleep(Duration.millis(next.getTime() - now))
 
     if (options.noOverlap && (yield* Ref.getAndSet(running, true))) {
       yield* Effect.logWarning("Skipping scheduled run; a previous run is still in progress")


### PR DESCRIPTION
Fixes #359

Adds the generic in-process cron scheduler core:

- `runScheduler(job, options)` sleeps to each `Cron.next` occurrence in the configured timezone, logs failed ticks through Effect logging without stopping the loop, stops on interruption, and skips ticks while a previous run is active when `noOverlap` is enabled.
- `InvalidScheduleError` fails fast when the cron expression or timezone does not parse.
- Colocated `src/scheduler.test.ts` covers every acceptance criterion with a scripted job and `TestClock`: occurrence timing (not startup), timezone behavior, failure continuation, clean interruption, and no-overlap.

No entrypoint, environment config, or composition wiring is included; those belong to #360 per the issue plan.