### PR TITLE
refactor: extract shared logging entrypoint seam (#358)

### DIFF
--- a/src/log-test-fixtures.ts
+++ b/src/log-test-fixtures.ts
@@ -1,0 +1,31 @@
+import { Redacted } from "effect"
+
+import type { RuntimeConfig } from "./env.ts"
+
+export const secret = "hunter2-super-secret"
+export const fintualSecret = "fintual-pass"
+export const email2FASecret = "app-password"
+
+export const runtimeConfig: RuntimeConfig = {
+  actual: {
+    serverUrl: "http://localhost:5006",
+    password: Redacted.make(secret),
+    syncId: "sync-1",
+    fintualAccount: "fintual-account",
+    startingDate: "2024-03-01",
+    payee: "Fintual",
+  },
+  fintual: {
+    email: "user@example.com",
+    password: Redacted.make(fintualSecret),
+    goalId: "goal-42",
+    email2FA: {
+      userEmail: "2fa@example.com",
+      appPassword: Redacted.make(email2FASecret),
+      host: "imap.gmail.com",
+      port: 993,
+      debug: false,
+      sender: "notificaciones@fintual.com",
+    },
+  },
+}

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -1,0 +1,71 @@
+import { it as effectIt } from "@effect/vitest"
+import { Effect, Redacted } from "effect"
+import { describe, expect, it } from "vitest"
+
+import type { RuntimeConfig } from "./env.ts"
+import { email2FASecret, fintualSecret, runtimeConfig, secret } from "./log-test-fixtures.ts"
+import { RedactionPolicy } from "./log.ts"
+
+describe("RedactionPolicy", () => {
+  it("redacts every sensitive configured value from the start, including Redacted passwords", () => {
+    const policy = RedactionPolicy.fromConfig(runtimeConfig)
+
+    expect(policy.redact(`actual ${secret} fintual ${fintualSecret} gmail ${email2FASecret}`)).toBe(
+      "actual [redacted] fintual [redacted] gmail [redacted]",
+    )
+  })
+
+  it("redacts configured identifiers and email addresses", () => {
+    const policy = RedactionPolicy.fromConfig(runtimeConfig)
+
+    expect(
+      policy.redact(
+        "sync sync-1 account fintual-account goal goal-42 mail user@example.com 2fa 2fa@example.com other@example.com",
+      ),
+    ).toBe(
+      "sync [redacted] account [redacted] goal [redacted] mail [redacted] 2fa [redacted] [redacted email]",
+    )
+  })
+
+  it("keeps redaction state isolated between policies", () => {
+    const configured = RedactionPolicy.fromConfig(runtimeConfig)
+    const empty = RedactionPolicy.empty
+
+    expect(configured.redact(secret)).toBe("[redacted]")
+    expect(empty.redact(secret)).toBe(secret)
+  })
+
+  it("captures the sensitive snapshot once when the policy is built", () => {
+    const config: RuntimeConfig = {
+      actual: {
+        serverUrl: "http://localhost:5006",
+        password: Redacted.make(secret),
+        syncId: "sync-before-build",
+        fintualAccount: "fintual-account",
+        startingDate: "2024-03-01",
+        payee: "Fintual",
+      },
+      fintual: {
+        email: "user@example.com",
+        password: Redacted.make("fintual-pass"),
+        goalId: "goal-42",
+        email2FA: null,
+      },
+    }
+    const policy = RedactionPolicy.fromConfig(config)
+
+    config.actual.syncId = "sync-added-after-build"
+
+    expect(policy.redact("sync-before-build sync-added-after-build")).toBe(
+      "[redacted] sync-added-after-build",
+    )
+  })
+
+  effectIt.effect("provides an immutable policy layer from the validated runtime config", () =>
+    Effect.gen(function* () {
+      const policy = yield* RedactionPolicy
+
+      expect(policy.redact(`secret ${secret} and goal-42`)).toBe("secret [redacted] and [redacted]")
+    }).pipe(Effect.provide(RedactionPolicy.layer(runtimeConfig))),
+  )
+})

--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest"
 
 import type { RuntimeConfig } from "./env.ts"
 import { getErrorMessage, RedactionPolicy } from "./log.ts"
-import { makeRedactingLogger, reportUnhandledFailure } from "./once.ts"
+import { makeRedactingLogger, reportUnhandledFailure } from "./logging.ts"
 
 const secret = "hunter2-super-secret"
 const fintualSecret = "fintual-pass"

--- a/src/logging.test.ts
+++ b/src/logging.test.ts
@@ -1,38 +1,11 @@
 import { it as effectIt } from "@effect/vitest"
-import { Cause, Console, Effect, Logger, Redacted, Schema } from "effect"
-import { describe, expect, it } from "vitest"
+import { Cause, Console, Effect, Logger, Schema } from "effect"
+import { describe, expect } from "vitest"
 
 import type { RuntimeConfig } from "./env.ts"
+import { runtimeConfig, secret } from "./log-test-fixtures.ts"
 import { getErrorMessage, RedactionPolicy } from "./log.ts"
 import { makeRedactingLogger, reportUnhandledFailure } from "./logging.ts"
-
-const secret = "hunter2-super-secret"
-const fintualSecret = "fintual-pass"
-const email2FASecret = "app-password"
-
-const runtimeConfig: RuntimeConfig = {
-  actual: {
-    serverUrl: "http://localhost:5006",
-    password: Redacted.make(secret),
-    syncId: "sync-1",
-    fintualAccount: "fintual-account",
-    startingDate: "2024-03-01",
-    payee: "Fintual",
-  },
-  fintual: {
-    email: "user@example.com",
-    password: Redacted.make(fintualSecret),
-    goalId: "goal-42",
-    email2FA: {
-      userEmail: "2fa@example.com",
-      appPassword: Redacted.make(email2FASecret),
-      host: "imap.gmail.com",
-      port: 993,
-      debug: false,
-      sender: "notificaciones@fintual.com",
-    },
-  },
-}
 
 class UnexpectedFailure extends Schema.TaggedError<UnexpectedFailure>()("UnexpectedFailure", {
   cause: Schema.Defect(),
@@ -74,70 +47,6 @@ function captureConsole(lines: Array<string>): Console.Console {
     warn: (line: string) => lines.push(line),
   }
 }
-
-describe("RedactionPolicy", () => {
-  it("redacts every sensitive configured value from the start, including Redacted passwords", () => {
-    const policy = RedactionPolicy.fromConfig(runtimeConfig)
-
-    expect(policy.redact(`actual ${secret} fintual ${fintualSecret} gmail ${email2FASecret}`)).toBe(
-      "actual [redacted] fintual [redacted] gmail [redacted]",
-    )
-  })
-
-  it("redacts configured identifiers and email addresses", () => {
-    const policy = RedactionPolicy.fromConfig(runtimeConfig)
-
-    expect(
-      policy.redact(
-        "sync sync-1 account fintual-account goal goal-42 mail user@example.com 2fa 2fa@example.com other@example.com",
-      ),
-    ).toBe(
-      "sync [redacted] account [redacted] goal [redacted] mail [redacted] 2fa [redacted] [redacted email]",
-    )
-  })
-
-  it("keeps redaction state isolated between policies", () => {
-    const configured = RedactionPolicy.fromConfig(runtimeConfig)
-    const empty = RedactionPolicy.empty
-
-    expect(configured.redact(secret)).toBe("[redacted]")
-    expect(empty.redact(secret)).toBe(secret)
-  })
-
-  it("captures the sensitive snapshot once when the policy is built", () => {
-    const config: RuntimeConfig = {
-      actual: {
-        serverUrl: "http://localhost:5006",
-        password: Redacted.make(secret),
-        syncId: "sync-before-build",
-        fintualAccount: "fintual-account",
-        startingDate: "2024-03-01",
-        payee: "Fintual",
-      },
-      fintual: {
-        email: "user@example.com",
-        password: Redacted.make("fintual-pass"),
-        goalId: "goal-42",
-        email2FA: null,
-      },
-    }
-    const policy = RedactionPolicy.fromConfig(config)
-
-    config.actual.syncId = "sync-added-after-build"
-
-    expect(policy.redact("sync-before-build sync-added-after-build")).toBe(
-      "[redacted] sync-added-after-build",
-    )
-  })
-
-  effectIt.effect("provides an immutable policy layer from the validated runtime config", () =>
-    Effect.gen(function* () {
-      const policy = yield* RedactionPolicy
-
-      expect(policy.redact(`secret ${secret} and goal-42`)).toBe("secret [redacted] and [redacted]")
-    }).pipe(Effect.provide(RedactionPolicy.layer(runtimeConfig))),
-  )
-})
 
 describe("redactingLogger", () => {
   effectIt.effect("renders timestamped, level-prefixed lines with sensitive values redacted", () =>

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,38 @@
+import { Array as EffectArray, Cause, Effect, Formatter, Logger, References } from "effect"
+
+import type { RedactionPolicy } from "./log.ts"
+
+export const makeRedactingLogger = (
+  redactionPolicy: RedactionPolicy["Service"],
+): Logger.Logger<unknown, void> =>
+  Logger.withLeveledConsole(
+    Logger.make<unknown, string>(({ cause, date, fiber, logLevel, message }) => {
+      const parts: Array<string> = []
+      for (const part of EffectArray.ensure(message)) {
+        parts.push(renderPlain(part))
+      }
+      if (cause.reasons.length > 0) {
+        parts.push(Cause.pretty(cause))
+      }
+      for (const [key, value] of Object.entries(fiber.getRef(References.CurrentLogAnnotations))) {
+        parts.push(`${key}: ${renderPlain(value)}`)
+      }
+      const line = `[${formatTimestamp(date)}] ${logLevel.toUpperCase()}: ${parts.join(" ")}`
+      return redactionPolicy.redact(line)
+    }),
+  )
+
+export const reportUnhandledFailure = (cause: Cause.Cause<unknown>): Effect.Effect<void> =>
+  Cause.hasInterruptsOnly(cause) ? Effect.void : Effect.logError(cause)
+
+function renderPlain(value: unknown): string {
+  return typeof value === "string" ? value : Formatter.format(value)
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (value: number, width: number): string => value.toString().padStart(width, "0")
+  return `${pad(date.getHours(), 2)}:${pad(date.getMinutes(), 2)}:${pad(
+    date.getSeconds(),
+    2,
+  )}.${pad(date.getMilliseconds(), 3)}`
+}

--- a/src/once.ts
+++ b/src/once.ts
@@ -2,13 +2,14 @@ import { pathToFileURL } from "node:url"
 
 import { NodeRuntime } from "@effect/platform-node"
 import { config as loadDotEnv } from "dotenv"
-import { Array as EffectArray, Cause, Effect, Formatter, Logger, References } from "effect"
+import { Effect, Logger } from "effect"
 
 import type { ActualError } from "./actual.ts"
 import { resolveRuntimeConfig, type RuntimeConfig, type RuntimeConfigError } from "./env.ts"
 import type { FintualError } from "./fintual/fintual-error.ts"
 import { runJob } from "./job.ts"
 import { RedactionPolicy } from "./log.ts"
+import { makeRedactingLogger, reportUnhandledFailure } from "./logging.ts"
 
 loadDotEnv()
 
@@ -36,41 +37,6 @@ const main = Effect.fn("Once.main")(function* (): Effect.fn.Return<
     Effect.provide(Logger.layer([makeRedactingLogger(RedactionPolicy.fromConfig(runtimeConfig))])),
   )
 })
-
-export const makeRedactingLogger = (
-  redactionPolicy: RedactionPolicy["Service"],
-): Logger.Logger<unknown, void> =>
-  Logger.withLeveledConsole(
-    Logger.make<unknown, string>(({ cause, date, fiber, logLevel, message }) => {
-      const parts: Array<string> = []
-      for (const part of EffectArray.ensure(message)) {
-        parts.push(renderPlain(part))
-      }
-      if (cause.reasons.length > 0) {
-        parts.push(Cause.pretty(cause))
-      }
-      for (const [key, value] of Object.entries(fiber.getRef(References.CurrentLogAnnotations))) {
-        parts.push(`${key}: ${renderPlain(value)}`)
-      }
-      const line = `[${formatTimestamp(date)}] ${logLevel.toUpperCase()}: ${parts.join(" ")}`
-      return redactionPolicy.redact(line)
-    }),
-  )
-
-export const reportUnhandledFailure = (cause: Cause.Cause<unknown>): Effect.Effect<void> =>
-  Cause.hasInterruptsOnly(cause) ? Effect.void : Effect.logError(cause)
-
-function renderPlain(value: unknown): string {
-  return typeof value === "string" ? value : Formatter.format(value)
-}
-
-function formatTimestamp(date: Date): string {
-  const pad = (value: number, width: number): string => value.toString().padStart(width, "0")
-  return `${pad(date.getHours(), 2)}:${pad(date.getMinutes(), 2)}:${pad(
-    date.getSeconds(),
-    2,
-  )}.${pad(date.getMilliseconds(), 3)}`
-}
 
 function isMainModule(): boolean {
   return import.meta.url === pathToFileURL(process.argv[1] ?? "").href


### PR DESCRIPTION
## Summary

Extracts the redacting logger and terminal-failure reporting from `src/once.ts` into a dedicated `src/logging.ts` so the one-shot and scheduled composition roots can share the same logging seam without importing the process entrypoint.

- `src/logging.ts` owns `makeRedactingLogger`, `reportUnhandledFailure`, and the private `renderPlain`/`formatTimestamp` helpers; it depends only on the redaction policy type from `src/log.ts`.
- `src/once.ts` consumes those pieces with no behavior change; the entrypoint no longer owns logger construction.
- `src/once.test.ts` moves to `src/logging.test.ts` so the logger rendering and failure-reporting suites live beside the extracted module.
- The redaction policy tests move to a colocated `src/log.test.ts`, with shared fixtures extracted to `src/log-test-fixtures.ts`.

## Commits

- `refactor: extract logging render edge into logging module`
- `test: colocate redaction policy tests with log module`

Fixes #358