### PR TITLE
chore: enable oxfmt import sorting

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -2,4 +2,5 @@
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "ignorePatterns": [],
   "semi": false,
+  "sortImports": true,
 }

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -17,16 +17,16 @@ const actualApiMock = vi.hoisted(() => ({
 
 vi.mock("@actual-app/api", () => actualApiMock)
 import { ActualConfigService, ActualSynchronization } from "./actual.ts"
+import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
 import {
   ActualBudgetDownloadFailure,
   ActualInitializationFailure,
   ActualTransactionCreationFailure,
 } from "./actual/actual-error.ts"
-import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
+import type { ActualError } from "./actual/actual-error.ts"
 import { ActualFileSystem } from "./actual/actual-file-system.ts"
 import { ActualHealthCheck } from "./actual/actual-health-check.ts"
 import { ActualRetryPolicy } from "./actual/retry-policy.ts"
-import type { ActualError } from "./actual/actual-error.ts"
 import type { ActualConfig } from "./env.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
 

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -1,13 +1,14 @@
 import { Context, DateTime, Duration, Effect, Layer, Option, Schedule } from "effect"
-import type { ActualConfig } from "./env.ts"
-import { getErrorMessage } from "./log.ts"
+
 import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
 import { ActualInvalidStartingDate } from "./actual/actual-error.ts"
 import type { ActualError, ActualPayeesReadFailure } from "./actual/actual-error.ts"
 import { ActualFileSystem } from "./actual/actual-file-system.ts"
 import { ActualHealthCheck } from "./actual/actual-health-check.ts"
-import { ActualRetryPolicy } from "./actual/retry-policy.ts"
 import { planReconciliation } from "./actual/reconciliation-policy.ts"
+import { ActualRetryPolicy } from "./actual/retry-policy.ts"
+import type { ActualConfig } from "./env.ts"
+import { getErrorMessage } from "./log.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
 
 export type { ActualError } from "./actual/actual-error.ts"

--- a/src/actual/actual-client.ts
+++ b/src/actual/actual-client.ts
@@ -1,10 +1,7 @@
 import * as api from "@actual-app/api"
 import { Context, Effect, Layer, Predicate, Redacted } from "effect"
+
 import type { ActualConfig } from "../env.ts"
-import type {
-  ExistingVariationTransaction,
-  VariationTransactionInput,
-} from "./reconciliation-policy.ts"
 import {
   ActualBudgetDownloadFailure,
   ActualDuplicateDeletionFailure,
@@ -16,6 +13,10 @@ import {
   ActualTransactionUpdateFailure,
   ActualTransactionsReadFailure,
 } from "./actual-error.ts"
+import type {
+  ExistingVariationTransaction,
+  VariationTransactionInput,
+} from "./reconciliation-policy.ts"
 
 const ACTUAL_DATA_DIR = "./tmp/actual-data"
 

--- a/src/actual/actual-error.ts
+++ b/src/actual/actual-error.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect"
+
 import { getErrorMessage } from "../log.ts"
 
 export class ActualDataDirectoryFailure extends Schema.TaggedError<ActualDataDirectoryFailure>()(

--- a/src/actual/actual-file-system.ts
+++ b/src/actual/actual-file-system.ts
@@ -1,5 +1,7 @@
 import * as fs from "node:fs"
+
 import { Context, Effect, Layer } from "effect"
+
 import { ActualDataDirectoryFailure } from "./actual-error.ts"
 
 const ACTUAL_DATA_DIR = "./tmp/actual-data"

--- a/src/actual/actual-health-check.ts
+++ b/src/actual/actual-health-check.ts
@@ -1,4 +1,5 @@
 import { Context, Effect, Layer } from "effect"
+
 import { ActualHealthCheckFailure } from "./actual-error.ts"
 
 const HEALTH_CHECK_TIMEOUT_MS = 10_000

--- a/src/actual/reconciliation-policy.test.ts
+++ b/src/actual/reconciliation-policy.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vitest"
+
 import {
   VARIATION_IMPORTED_ID_PREFIX,
   VARIATION_NOTES,

--- a/src/actual/retry-policy.ts
+++ b/src/actual/retry-policy.ts
@@ -1,4 +1,5 @@
 import { Context, Duration, Layer, Schedule } from "effect"
+
 import type { ActualError } from "./actual-error.ts"
 
 const MAX_SYNC_ATTEMPTS = 5

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,6 +1,7 @@
 import { it } from "@effect/vitest"
 import { Effect, Redacted, Result } from "effect"
 import { expect } from "vitest"
+
 import { resolveRuntimeConfig, RuntimeConfigError, type Environment } from "./env.ts"
 
 function requiredEnvironment(): Environment {

--- a/src/fintual/email-2fa-client.test.ts
+++ b/src/fintual/email-2fa-client.test.ts
@@ -2,6 +2,7 @@ import { it } from "@effect/vitest"
 import { Effect } from "effect"
 import { ImapFlow } from "imapflow"
 import { expect } from "vitest"
+
 import { ImapFlowClient, MissingServerExtension } from "./email-2fa-client.ts"
 
 it.effect("surfaces a MissingServerExtension search rejection as a typed error", () =>

--- a/src/fintual/email-2fa-client.ts
+++ b/src/fintual/email-2fa-client.ts
@@ -1,5 +1,6 @@
 import { Context, Effect, Layer, Predicate, Redacted, Schema } from "effect"
 import { ImapFlow, type SearchObject } from "imapflow"
+
 import type { Email2FAConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 

--- a/src/fintual/email-2fa.test.ts
+++ b/src/fintual/email-2fa.test.ts
@@ -1,8 +1,9 @@
 import { it } from "@effect/vitest"
 import { Cause, Effect, Exit, Fiber, Option, Redacted } from "effect"
 import { TestClock } from "effect/testing"
-import { describe, expect } from "vitest"
 import type { SearchObject } from "imapflow"
+import { describe, expect } from "vitest"
+
 import { FintualConfigService, type Email2FAConfig, type FintualConfig } from "../env.ts"
 import {
   ImapClientFactory,

--- a/src/fintual/email-2fa.ts
+++ b/src/fintual/email-2fa.ts
@@ -1,4 +1,5 @@
 import { Clock, Context, Effect, Layer, Option, Schedule, Schema } from "effect"
+
 import { FintualConfigService, type Email2FAConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import {

--- a/src/fintual/email-2fa/email-2fa-policy.test.ts
+++ b/src/fintual/email-2fa/email-2fa-policy.test.ts
@@ -1,7 +1,9 @@
 import { readFile } from "node:fs/promises"
+
 import { it } from "@effect/vitest"
 import { Effect } from "effect"
 import { expect, test } from "vitest"
+
 import {
   buildEmail2FASearchQueries,
   selectEmail2FACode,

--- a/src/fintual/email-2fa/email-2fa-policy.ts
+++ b/src/fintual/email-2fa/email-2fa-policy.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect"
 import type { SearchObject } from "imapflow"
 import { simpleParser } from "mailparser"
+
 import { getErrorMessage } from "../../log.ts"
 
 export interface Email2FASearchPolicy {

--- a/src/fintual/fintual-error.ts
+++ b/src/fintual/fintual-error.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect"
+
 import { getErrorMessage } from "../log.ts"
 
 export class UnexpectedHttpStatus extends Schema.TaggedError<UnexpectedHttpStatus>()(

--- a/src/fintual/fold.test.ts
+++ b/src/fintual/fold.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest"
-import type { GoalPerformanceData } from "./provider.ts"
+
 import { foldGoalPerformanceData } from "./fold.ts"
+import type { GoalPerformanceData } from "./provider.ts"
 
 test("folds reference and recent Goal Performance Data into a Performance Snapshot", () => {
   const snapshot = foldGoalPerformanceData(

--- a/src/fintual/performance.test.ts
+++ b/src/fintual/performance.test.ts
@@ -1,6 +1,7 @@
 import { it } from "@effect/vitest"
 import { Effect, Redacted } from "effect"
 import { describe, expect } from "vitest"
+
 import { FintualConfigService, type FintualConfig } from "../env.ts"
 import { SnapshotWriter, type PerformanceSnapshot } from "../performance-snapshot.ts"
 import { Email2FACode, Email2FAService, Operational, TimedOut } from "./email-2fa.ts"

--- a/src/fintual/performance.ts
+++ b/src/fintual/performance.ts
@@ -1,4 +1,5 @@
 import { Context, Effect, Layer, Option } from "effect"
+
 import { FintualConfigService, type Email2FAConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import {

--- a/src/fintual/provider.test.ts
+++ b/src/fintual/provider.test.ts
@@ -1,8 +1,9 @@
 import { it } from "@effect/vitest"
 import { Duration, Effect, Fiber, Redacted } from "effect"
-import { FetchHttpClient } from "effect/unstable/http"
 import { TestClock } from "effect/testing"
+import { FetchHttpClient } from "effect/unstable/http"
 import { expect } from "vitest"
+
 import { FintualConfigService, type FintualConfig } from "../env.ts"
 import { Email2FACode, Operational, TimedOut } from "./email-2fa.ts"
 import { FintualProvider } from "./provider.ts"

--- a/src/fintual/provider.ts
+++ b/src/fintual/provider.ts
@@ -17,6 +17,7 @@ import {
   HttpClientRequest,
   HttpClientResponse,
 } from "effect/unstable/http"
+
 import { FintualConfigService, type FintualConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import type { Email2FACode, Operational, TimedOut } from "./email-2fa.ts"

--- a/src/job.ts
+++ b/src/job.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect"
+
 import { main as mainActual } from "./actual.ts"
 import type { ActualError } from "./actual.ts"
 import { FintualConfigService, type RuntimeConfig } from "./env.ts"

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,7 @@
 import { inspect } from "node:util"
+
 import { Context, Layer, Predicate, Redacted } from "effect"
+
 import type { RuntimeConfig } from "./env.ts"
 
 const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi

--- a/src/once.test.ts
+++ b/src/once.test.ts
@@ -1,6 +1,7 @@
 import { it as effectIt } from "@effect/vitest"
 import { Cause, Console, Effect, Logger, Redacted, Schema } from "effect"
 import { describe, expect, it } from "vitest"
+
 import type { RuntimeConfig } from "./env.ts"
 import { getErrorMessage, RedactionPolicy } from "./log.ts"
 import { makeRedactingLogger, reportUnhandledFailure } from "./once.ts"

--- a/src/once.ts
+++ b/src/once.ts
@@ -1,9 +1,11 @@
 import { pathToFileURL } from "node:url"
+
 import { NodeRuntime } from "@effect/platform-node"
 import { config as loadDotEnv } from "dotenv"
 import { Array as EffectArray, Cause, Effect, Formatter, Logger, References } from "effect"
-import { resolveRuntimeConfig, type RuntimeConfig, type RuntimeConfigError } from "./env.ts"
+
 import type { ActualError } from "./actual.ts"
+import { resolveRuntimeConfig, type RuntimeConfig, type RuntimeConfigError } from "./env.ts"
 import type { FintualError } from "./fintual/fintual-error.ts"
 import { runJob } from "./job.ts"
 import { RedactionPolicy } from "./log.ts"

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -1,8 +1,10 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
+
 import { it } from "@effect/vitest"
 import { Effect } from "effect"
 import { expect } from "vitest"
+
 import { getErrorMessage } from "./log.ts"
 import {
   PERFORMANCE_SNAPSHOT_PATH,

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -1,7 +1,9 @@
 import * as fs from "node:fs"
+
 import { Context, Effect, Layer, Schema } from "effect"
-import { getErrorMessage } from "./log.ts"
+
 import { SnapshotWriteFailure } from "./fintual/fintual-error.ts"
+import { getErrorMessage } from "./log.ts"
 
 const SNAPSHOT_DATA_DIR = "./tmp/fintual-data"
 export const PERFORMANCE_SNAPSHOT_PATH = `${SNAPSHOT_DATA_DIR}/balance-2.json`

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -13,6 +13,7 @@ import {
 } from "effect"
 import { TestClock } from "effect/testing"
 import { describe, expect } from "vitest"
+
 import { InvalidScheduleError, runScheduler, type SchedulerOptions } from "./scheduler.ts"
 
 function schedulerOptions(overrides: Partial<SchedulerOptions> = {}): SchedulerOptions {


### PR DESCRIPTION
## Summary

Enables oxfmt's `sortImports` option so import ordering is enforced by the formatter instead of depending on manual review conventions.

- Adds `"sortImports": true` to `.oxfmtrc.json`.
- Applies the resulting mechanical reorder across `src` (groups sorted, with blank lines between groups).
- `oxfmt --check src`, `oxlint`, `tsc`, the full Vitest suite, and Fallow audit are all green.

This makes import-order nits (such as the one raised on #374) a formatter concern rather than a per-PR cosmetic review item.