### PR TITLE
feat: wire scheduler mode into config and entrypoint (#360)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,11 @@ GMAIL_IMAP_PORT=993
 # Optional Fintual 2FA email filters
 FINTUAL_2FA_SENDER=notificaciones@fintual.com
 FINTUAL_2FA_SUBJECT=Código para entrar
+
+# Run mode: once for a single synchronization, schedule for the cron worker
+RUN_MODE=once
+# Cron schedule in 5/6-field cron format and IANA timezone (schedule mode)
+SYNC_CRON=0 0 22 * * 1-5
+SYNC_TIMEZONE=America/Santiago
+# Set to true to skip a tick while a previous run is still in progress
+SYNC_NO_OVERLAP=false

--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,8 @@ GMAIL_IMAP_PORT=993
 FINTUAL_2FA_SENDER=notificaciones@fintual.com
 FINTUAL_2FA_SUBJECT=Código para entrar
 
-# Run mode: once for a single synchronization, schedule for the cron worker
-RUN_MODE=once
+# Run mode: schedule for the cron worker, once for a single diagnostic run
+RUN_MODE=schedule
 # Cron schedule in 5/6-field cron format and IANA timezone (schedule mode)
 SYNC_CRON=0 0 22 * * 1-5
 SYNC_TIMEZONE=America/Santiago

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/fallow/schema.json",
   "entry": [
     "src/once.ts",
+    "src/main.ts",
     "bin/**/*.mjs"
   ],
   "dynamicallyLoaded": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM node:24.19.0-slim AS runtime
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV RUN_MODE=schedule
 
 COPY --from=deps /app/node_modules ./node_modules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ COPY --from=deps /app/node_modules ./node_modules
 
 COPY . .
 
-RUN chmod +x ./bin/run-sync.sh
+RUN chmod +x ./bin/run-sync.sh ./bin/run-schedule.sh
 
-CMD ["./bin/run-sync.sh"]
+CMD ["./bin/run-schedule.sh"]

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The schedule comes from environment configuration:
 
 - `SYNC_CRON` defaults to `0 0 22 * * 1-5`
 - `SYNC_TIMEZONE` defaults to `America/Santiago`
-- `SYNC_NO_OVERLAP=false` skips a tick while a previous run is still in progress
+- `SYNC_NO_OVERLAP=true` skips a tick while a previous run is still in progress
 
 Mount `./tmp` if you want to inspect the generated files locally:
 
@@ -226,5 +226,10 @@ The scheduler mode is the container default. Configure the sync time with
 `docker exec` diagnostics. The compose migration away from Ofelia is a separate
 deployment change; the image remains backward compatible with one-shot
 invocations.
+
+The scheduler stops cleanly when the process is interrupted, including SIGTERM,
+and each in-flight run's scoped resources are closed. Configure the container
+restart policy (for example, `restart: unless-stopped`) so the worker comes back
+after a host restart.
 
 For homelab deployments, store `GMAIL_APP_PASSWORD` in your secret manager (for example, GCP Secret Manager) and inject it into the worker environment at runtime.

--- a/README.md
+++ b/README.md
@@ -137,11 +137,24 @@ hk check --all
 
 ## Docker Image
 
-The published container image is designed as a one-shot worker. Its default command runs the sync once:
+The published container image runs the in-process cron scheduler by default. The
+worker runs the synchronization at the configured schedule:
 
 ```bash
 docker run --rm --env-file .env docker.io/samaluk/fintual-api:latest
 ```
+
+Set `RUN_MODE=once` for a one-shot diagnostic run:
+
+```bash
+docker run --rm --env-file .env -e RUN_MODE=once docker.io/samaluk/fintual-api:latest
+```
+
+The schedule comes from environment configuration:
+
+- `SYNC_CRON` defaults to `0 0 22 * * 1-5`
+- `SYNC_TIMEZONE` defaults to `America/Santiago`
+- `SYNC_NO_OVERLAP=false` skips a tick while a previous run is still in progress
 
 Mount `./tmp` if you want to inspect the generated files locally:
 
@@ -203,15 +216,15 @@ The intended production model is:
 
 - GitHub Actions publishes the worker image to Docker Hub
 - the homelab compose stack pulls the image
-- a long-lived idle worker keeps secrets in its runtime environment
-- Ofelia schedules `job-exec` runs inside that worker
+- a long-lived worker runs the in-process scheduler and keeps secrets in its
+  runtime environment
 - Komodo deploys compose changes from the homelab repo
 
-Recommended Ofelia schedule for Santiago, Chile weekdays at 21:00:
-
-- cron: `0 21 * * 1-5`
-- timezone: `America/Santiago`
-
-Use an idle `fintual-api` worker plus an `ofelia` service that executes `./bin/run-sync.sh` on schedule.
+The scheduler mode is the container default. Configure the sync time with
+`SYNC_CRON` and `SYNC_TIMEZONE` (for example, `0 0 22 * * 1-5` in
+`America/Santiago`), and keep `RUN_MODE=once` available for manual
+`docker exec` diagnostics. The compose migration away from Ofelia is a separate
+deployment change; the image remains backward compatible with one-shot
+invocations.
 
 For homelab deployments, store `GMAIL_APP_PASSWORD` in your secret manager (for example, GCP Secret Manager) and inject it into the worker environment at runtime.

--- a/bin/run-schedule.sh
+++ b/bin/run-schedule.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec node src/main.ts

--- a/docs/adr/0006-in-process-effect-scheduler.md
+++ b/docs/adr/0006-in-process-effect-scheduler.md
@@ -1,0 +1,65 @@
+# In-process Effect scheduler replaces Ofelia
+
+## Status
+
+Accepted
+
+## Context
+
+Production scheduling previously depended on an external Ofelia container
+watching Docker labels, an idle worker kept alive with `sleep infinity`, and a
+second process capturing job output. That split observability across containers,
+required Docker socket access, and kept the only production scheduling path
+outside Effect's typed errors, redacting logger, and testable runtime.
+
+## Decision
+
+The application exposes two run modes selected from environment configuration:
+
+- `RUN_MODE=once` performs exactly one Synchronization Attempt and exits. It
+  remains available for manual `docker exec` diagnostics and CI-style runs.
+- `RUN_MODE=schedule` runs the existing Synchronization Attempt through the
+  in-process cron scheduler until interrupted. Each tick runs the job as a fresh
+  scoped unit, failures are logged through the shared redacting logger without
+  terminating the worker, and optional no-overlap protection skips a tick while
+  a previous run is still active.
+
+Schedule policy is decoded with Effect Config from `SYNC_CRON`, `SYNC_TIMEZONE`,
+and `SYNC_NO_OVERLAP`. The cron expression and IANA timezone are validated
+eagerly at config decode with `Cron.parse`, so an invalid schedule fails fast as
+a typed configuration error. The container image defaults to scheduler mode via
+`ENV RUN_MODE=schedule` and `bin/run-schedule.sh`; the one-shot path remains
+available as `bin/run-sync.sh` or `RUN_MODE=once`.
+
+The scheduler core owns the recurring program and its testable timing,
+failure-continuation, interruption, and no-overlap behavior. The composition
+root installs the redacting logger once and covers both modes. Catch-up or
+missed-run semantics beyond a plain cron schedule, and persistence of scheduler
+state across restarts, are out of scope.
+
+The homelab compose migration away from Ofelia is a separate deployment change;
+the application image remains backward compatible with the existing one-shot
+invocation until that adoption lands.
+
+## Considered options
+
+- **External Ofelia scheduler** — rejected because it requires a Docker socket
+  mount, an extra container, an idle worker, and a separate observability path
+  outside Effect's typed runtime.
+- **CLI subcommands or flags** — rejected because the application has one real
+  command plus scheduling; environment-selected modes keep the entrypoint thin
+  and deployment configuration as the source of truth.
+- **Scheduler as the runtime default** — rejected because keeping one-shot as
+  the runtime default preserves backward compatibility for existing invocations;
+  the container default is set explicitly at the Docker layer.
+
+## Consequences
+
+- The homelab stack can drop Ofelia, its Docker socket mount, scheduler labels,
+  and the idle sleep command when it adopts the new image.
+- Scheduled and one-shot runs share one Effect logging and redaction path.
+- The worker process contract changes from exit-after-once to run-forever in
+  scheduler mode; shutdown is interrupt-driven and the deployment should
+  configure a restart policy for the long-lived worker.
+- Invalid schedules are rejected before application work starts with typed,
+  readable errors.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"fallow:fix": "fallow fix --yes",
 		"dev": "node src/once.ts",
 		"once": "node src/once.ts",
+		"schedule": "node src/main.ts",
 		"capture:har": "sh bin/capture-fintual-har.sh",
 		"prepare": "if [ -x node_modules/.bin/effect-tsgo ]; then effect-tsgo patch --typescript; fi"
 	}

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -32,6 +32,12 @@ it.effect("normalizes runtime values and applies defaults once for every domain"
       goalId: "goal-id",
       email2FA: null,
     })
+    expect(configuration.schedule).toMatchObject({
+      mode: "once",
+      cron: "0 0 22 * * 1-5",
+      timezone: "America/Santiago",
+      noOverlap: false,
+    })
     // Redacted intentionally exposes a safe placeholder through String().
     // oxlint-disable-next-line typescript/no-base-to-string
     expect(String(configuration.actual.password)).toBe("<redacted>")
@@ -39,6 +45,76 @@ it.effect("normalizes runtime values and applies defaults once for every domain"
     // oxlint-disable-next-line typescript/no-base-to-string
     expect(String(configuration.fintual.password)).toBe("<redacted>")
     expect(Redacted.value(configuration.fintual.password)).toBe("fintual password")
+  }),
+)
+
+it.effect("selects scheduled mode and decodes the schedule policy", () =>
+  Effect.gen(function* () {
+    const configuration = yield* resolveRuntimeConfig({
+      ...requiredEnvironment(),
+      RUN_MODE: "schedule",
+      SYNC_CRON: "0 0 6 * * 1",
+      SYNC_TIMEZONE: "UTC",
+      SYNC_NO_OVERLAP: "true",
+    })
+
+    expect(configuration.schedule).toEqual({
+      mode: "schedule",
+      cron: "0 0 6 * * 1",
+      timezone: "UTC",
+      noOverlap: true,
+    })
+  }),
+)
+
+it.effect("rejects an invalid cron expression with a typed configuration error", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.result(
+      resolveRuntimeConfig({
+        ...requiredEnvironment(),
+        SYNC_CRON: "not a cron",
+      }),
+    )
+
+    expect(result._tag).toBe("Failure")
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(RuntimeConfigError)
+      expect(result.failure.message).toContain("cron expression")
+    }
+  }),
+)
+
+it.effect("rejects an invalid schedule timezone with a typed configuration error", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.result(
+      resolveRuntimeConfig({
+        ...requiredEnvironment(),
+        SYNC_TIMEZONE: "Not/AZone",
+      }),
+    )
+
+    expect(result._tag).toBe("Failure")
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(RuntimeConfigError)
+      expect(result.failure.message).toContain("time zone")
+    }
+  }),
+)
+
+it.effect("rejects an unknown run mode", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.result(
+      resolveRuntimeConfig({
+        ...requiredEnvironment(),
+        RUN_MODE: "forever",
+      }),
+    )
+
+    expect(result._tag).toBe("Failure")
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(RuntimeConfigError)
+      expect(result.failure.message).toContain("RUN_MODE")
+    }
   }),
 )
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,14 +1,6 @@
-import {
-  Config,
-  ConfigProvider,
-  Context,
-  Cron,
-  Effect,
-  Option,
-  Redacted,
-  Result,
-  Schema,
-} from "effect"
+import { Config, ConfigProvider, Context, Effect, Option, Redacted, Result, Schema } from "effect"
+
+import { parseSchedule, type SchedulerOptions } from "./scheduler.ts"
 
 export class RuntimeConfigError extends Schema.TaggedError<RuntimeConfigError>()(
   "RuntimeConfigError",
@@ -45,11 +37,8 @@ export interface FintualConfig {
 
 export type RunMode = "once" | "schedule"
 
-export interface ScheduleConfig {
+export interface ScheduleConfig extends SchedulerOptions {
   mode: RunMode
-  cron: string
-  timezone: string
-  noOverlap: boolean
 }
 
 export class FintualConfigService extends Context.Service<FintualConfigService, FintualConfig>()(
@@ -139,7 +128,7 @@ const resolveScheduleConfig = Effect.fn("RuntimeConfig.resolveScheduleConfig")(f
   readonly syncTimezone: string
   readonly syncNoOverlap: boolean
 }): Effect.fn.Return<ScheduleConfig, RuntimeConfigError> {
-  const parsed = Cron.parse(values.syncCron, values.syncTimezone)
+  const parsed = parseSchedule(values.syncCron, values.syncTimezone)
   if (Result.isFailure(parsed)) {
     return yield* new RuntimeConfigError({
       message: parsed.failure.message,

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,14 @@
-import { Config, ConfigProvider, Context, Effect, Option, Redacted, Schema } from "effect"
+import {
+  Config,
+  ConfigProvider,
+  Context,
+  Cron,
+  Effect,
+  Option,
+  Redacted,
+  Result,
+  Schema,
+} from "effect"
 
 export class RuntimeConfigError extends Schema.TaggedError<RuntimeConfigError>()(
   "RuntimeConfigError",
@@ -33,6 +43,15 @@ export interface FintualConfig {
   email2FA: Email2FAConfig | null
 }
 
+export type RunMode = "once" | "schedule"
+
+export interface ScheduleConfig {
+  mode: RunMode
+  cron: string
+  timezone: string
+  noOverlap: boolean
+}
+
 export class FintualConfigService extends Context.Service<FintualConfigService, FintualConfig>()(
   "FintualConfig",
 ) {}
@@ -40,6 +59,7 @@ export class FintualConfigService extends Context.Service<FintualConfigService, 
 export interface RuntimeConfig {
   actual: ActualConfig
   fintual: FintualConfig
+  schedule: ScheduleConfig
 }
 
 export type Environment = Readonly<Record<string, string | undefined>>
@@ -88,6 +108,7 @@ export const resolveRuntimeConfig = Effect.fn("RuntimeConfig.resolveRuntimeConfi
       goalId: values.fintualGoalId,
       email2FA,
     },
+    schedule: yield* resolveScheduleConfig(values),
   }
 })
 
@@ -106,6 +127,32 @@ const runtimeValueConfig = Config.all({
   fintualGoalId: Config.string("FINTUAL_GOAL_ID"),
   gmailUserEmail: Config.option(Config.string("GMAIL_USER_EMAIL")),
   gmailAppPassword: Config.option(Config.redacted("GMAIL_APP_PASSWORD")),
+  runMode: Config.literals(["once", "schedule"], "RUN_MODE").pipe(Config.withDefault("once")),
+  syncCron: Config.string("SYNC_CRON").pipe(Config.withDefault("0 0 22 * * 1-5")),
+  syncTimezone: Config.string("SYNC_TIMEZONE").pipe(Config.withDefault("America/Santiago")),
+  syncNoOverlap: Config.boolean("SYNC_NO_OVERLAP").pipe(Config.withDefault(false)),
+})
+
+const resolveScheduleConfig = Effect.fn("RuntimeConfig.resolveScheduleConfig")(function* (values: {
+  readonly runMode: RunMode
+  readonly syncCron: string
+  readonly syncTimezone: string
+  readonly syncNoOverlap: boolean
+}): Effect.fn.Return<ScheduleConfig, RuntimeConfigError> {
+  const parsed = Cron.parse(values.syncCron, values.syncTimezone)
+  if (Result.isFailure(parsed)) {
+    return yield* new RuntimeConfigError({
+      message: parsed.failure.message,
+      cause: parsed.failure,
+    })
+  }
+
+  return {
+    mode: values.runMode,
+    cron: values.syncCron,
+    timezone: values.syncTimezone,
+    noOverlap: values.syncNoOverlap,
+  }
 })
 
 const email2FAValueConfig = Config.all({

--- a/src/log-test-fixtures.ts
+++ b/src/log-test-fixtures.ts
@@ -28,4 +28,10 @@ export const runtimeConfig: RuntimeConfig = {
       sender: "notificaciones@fintual.com",
     },
   },
+  schedule: {
+    mode: "once",
+    cron: "0 0 22 * * 1-5",
+    timezone: "America/Santiago",
+    noOverlap: false,
+  },
 }

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -51,6 +51,12 @@ describe("RedactionPolicy", () => {
         goalId: "goal-42",
         email2FA: null,
       },
+      schedule: {
+        mode: "once",
+        cron: "0 0 22 * * 1-5",
+        timezone: "America/Santiago",
+        noOverlap: false,
+      },
     }
     const policy = RedactionPolicy.fromConfig(config)
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,70 @@
+import { it } from "@effect/vitest"
+import { Deferred, Effect, Fiber, Layer, Ref } from "effect"
+import { expect } from "vitest"
+
+import type { ActualError } from "./actual.ts"
+import type { RuntimeConfig } from "./env.ts"
+import type { FintualError } from "./fintual/fintual-error.ts"
+import { runtimeConfig } from "./log-test-fixtures.ts"
+import { RunJobService, runApplication, SchedulerService } from "./main.ts"
+import type { SchedulerOptions } from "./scheduler.ts"
+
+function runtimeConfigFor(mode: "once" | "schedule"): RuntimeConfig {
+  return {
+    ...runtimeConfig,
+    schedule: {
+      ...runtimeConfig.schedule,
+      mode,
+    },
+  }
+}
+
+it.effect("runs exactly one synchronization attempt in once mode", () =>
+  Effect.gen(function* () {
+    const attempts = yield* Ref.make(0)
+    const job = Layer.succeed(RunJobService, {
+      run: () => Ref.update(attempts, (n) => n + 1),
+    })
+    const scheduler = Layer.succeed(SchedulerService, {
+      run: (_job: Effect.Effect<void, ActualError | FintualError>, _options: SchedulerOptions) =>
+        Effect.never,
+    })
+
+    yield* runApplication(runtimeConfigFor("once")).pipe(
+      Effect.provide(job.pipe(Layer.merge(scheduler))),
+    )
+
+    expect(yield* Ref.get(attempts)).toBe(1)
+  }),
+)
+
+it.effect("delegates scheduled mode to the scheduler without running the job directly", () =>
+  Effect.gen(function* () {
+    const calls = yield* Ref.make(0)
+    const scheduledOptions = yield* Ref.make<SchedulerOptions | null>(null)
+    const attempts = yield* Ref.make(0)
+    const schedulerCalled = yield* Deferred.make<void>()
+    const scheduler = Layer.succeed(SchedulerService, {
+      run: (_job: Effect.Effect<void, ActualError | FintualError>, options: SchedulerOptions) =>
+        Ref.update(calls, (n) => n + 1).pipe(
+          Effect.andThen(Ref.set(scheduledOptions, options)),
+          Effect.andThen(Deferred.succeed(schedulerCalled, undefined)),
+          Effect.andThen(Effect.never),
+        ),
+    })
+    const job = Layer.succeed(RunJobService, {
+      run: () => Ref.update(attempts, (n) => n + 1),
+    })
+
+    const config = runtimeConfigFor("schedule")
+    const fiber = yield* Effect.forkChild(
+      runApplication(config).pipe(Effect.provide(scheduler.pipe(Layer.merge(job)))),
+    )
+    yield* Deferred.await(schedulerCalled)
+
+    expect(yield* Ref.get(attempts)).toBe(0)
+    expect(yield* Ref.get(calls)).toBe(1)
+    expect(yield* Ref.get(scheduledOptions)).toEqual(config.schedule)
+    yield* Fiber.interrupt(fiber)
+  }),
+)

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -3,13 +3,13 @@ import { Deferred, Effect, Fiber, Layer, Ref } from "effect"
 import { expect } from "vitest"
 
 import type { ActualError } from "./actual.ts"
-import type { RuntimeConfig } from "./env.ts"
+import type { RunMode, RuntimeConfig } from "./env.ts"
 import type { FintualError } from "./fintual/fintual-error.ts"
 import { runtimeConfig } from "./log-test-fixtures.ts"
-import { RunJobService, runApplication, SchedulerService } from "./main.ts"
+import { RunJobService, runApplication, runOnce, SchedulerService } from "./main.ts"
 import type { SchedulerOptions } from "./scheduler.ts"
 
-function runtimeConfigFor(mode: "once" | "schedule"): RuntimeConfig {
+function runtimeConfigFor(mode: RunMode): RuntimeConfig {
   return {
     ...runtimeConfig,
     schedule: {
@@ -33,6 +33,19 @@ it.effect("runs exactly one synchronization attempt in once mode", () =>
     yield* runApplication(runtimeConfigFor("once")).pipe(
       Effect.provide(job.pipe(Layer.merge(scheduler))),
     )
+
+    expect(yield* Ref.get(attempts)).toBe(1)
+  }),
+)
+
+it.effect("runs exactly one synchronization attempt through the one-shot program", () =>
+  Effect.gen(function* () {
+    const attempts = yield* Ref.make(0)
+    const job = Layer.succeed(RunJobService, {
+      run: () => Ref.update(attempts, (n) => n + 1),
+    })
+
+    yield* runOnce(runtimeConfigFor("once")).pipe(Effect.provide(job))
 
     expect(yield* Ref.get(attempts)).toBe(1)
   }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,10 +59,22 @@ export const runApplication = Effect.fn("Main.runApplication")(function* (
   yield* job.run(runtimeConfig)
 })
 
-const main = Effect.fn("Main.main")(function* (): Effect.fn.Return<
-  void,
-  RuntimeConfigError | RunApplicationError
-> {
+export const runOnce = Effect.fn("Once.runOnce")(function* (
+  runtimeConfig: RuntimeConfig,
+): Effect.fn.Return<void, ActualError | FintualError, RunJobService> {
+  yield* Effect.logInfo("Running task once...")
+  const job = yield* RunJobService
+  yield* job.run(runtimeConfig)
+  yield* Effect.logInfo("Task completed.")
+})
+
+type ApplicationProgram = (
+  runtimeConfig: RuntimeConfig,
+) => Effect.Effect<void, RunApplicationError, RunJobService | SchedulerService>
+
+const runProcess = Effect.fn("Main.runProcess")(function* (
+  buildProgram: ApplicationProgram,
+): Effect.fn.Return<void, RuntimeConfigError | RunApplicationError> {
   const runtimeConfig = yield* resolveRuntimeConfig(process.env).pipe(
     Effect.tapCause((cause) =>
       reportUnhandledFailure(cause).pipe(
@@ -70,7 +82,7 @@ const main = Effect.fn("Main.main")(function* (): Effect.fn.Return<
       ),
     ),
   )
-  yield* runApplication(runtimeConfig).pipe(
+  yield* buildProgram(runtimeConfig).pipe(
     Effect.tapCause(reportUnhandledFailure),
     Effect.provide(
       RunJobService.live.pipe(
@@ -79,6 +91,14 @@ const main = Effect.fn("Main.main")(function* (): Effect.fn.Return<
       ),
     ),
   )
+})
+
+export const main = Effect.fn("Main.main")(function* () {
+  return yield* runProcess(runApplication)
+})
+
+export const mainOnce = Effect.fn("Once.main")(function* () {
+  return yield* runProcess(runOnce)
 })
 
 function isMainModule(): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,90 @@
+import { pathToFileURL } from "node:url"
+
+import { NodeRuntime } from "@effect/platform-node"
+import { config as loadDotEnv } from "dotenv"
+import { Context, Effect, Layer, Logger } from "effect"
+
+import type { ActualError } from "./actual.ts"
+import { resolveRuntimeConfig, type RuntimeConfig, type RuntimeConfigError } from "./env.ts"
+import type { FintualError } from "./fintual/fintual-error.ts"
+import { runJob } from "./job.ts"
+import { RedactionPolicy } from "./log.ts"
+import { makeRedactingLogger, reportUnhandledFailure } from "./logging.ts"
+import { InvalidScheduleError, runScheduler, type SchedulerOptions } from "./scheduler.ts"
+
+type RunApplicationError = ActualError | FintualError | InvalidScheduleError
+
+loadDotEnv()
+
+export class RunJobService extends Context.Service<
+  RunJobService,
+  {
+    readonly run: (config: RuntimeConfig) => Effect.Effect<void, ActualError | FintualError>
+  }
+>()("RunJobService") {
+  static readonly live = Layer.succeed(
+    RunJobService,
+    RunJobService.of({
+      run: (config) => runJob(config),
+    }),
+  )
+}
+
+export class SchedulerService extends Context.Service<
+  SchedulerService,
+  {
+    readonly run: (
+      job: Effect.Effect<void, ActualError | FintualError>,
+      options: SchedulerOptions,
+    ) => Effect.Effect<never, InvalidScheduleError>
+  }
+>()("SchedulerService") {
+  static readonly live = Layer.succeed(
+    SchedulerService,
+    SchedulerService.of({
+      run: (job, options) => runScheduler(job, options),
+    }),
+  )
+}
+
+export const runApplication = Effect.fn("Main.runApplication")(function* (
+  runtimeConfig: RuntimeConfig,
+): Effect.fn.Return<void, RunApplicationError, RunJobService | SchedulerService> {
+  if (runtimeConfig.schedule.mode === "schedule") {
+    const scheduler = yield* SchedulerService
+    return yield* scheduler.run(runJob(runtimeConfig), runtimeConfig.schedule)
+  }
+
+  const job = yield* RunJobService
+  yield* job.run(runtimeConfig)
+})
+
+const main = Effect.fn("Main.main")(function* (): Effect.fn.Return<
+  void,
+  RuntimeConfigError | RunApplicationError
+> {
+  const runtimeConfig = yield* resolveRuntimeConfig(process.env).pipe(
+    Effect.tapCause((cause) =>
+      reportUnhandledFailure(cause).pipe(
+        Effect.provide(Logger.layer([makeRedactingLogger(RedactionPolicy.empty)])),
+      ),
+    ),
+  )
+  yield* runApplication(runtimeConfig).pipe(
+    Effect.tapCause(reportUnhandledFailure),
+    Effect.provide(
+      RunJobService.live.pipe(
+        Layer.merge(SchedulerService.live),
+        Layer.merge(Logger.layer([makeRedactingLogger(RedactionPolicy.fromConfig(runtimeConfig))])),
+      ),
+    ),
+  )
+})
+
+function isMainModule(): boolean {
+  return import.meta.url === pathToFileURL(process.argv[1] ?? "").href
+}
+
+if (isMainModule()) {
+  NodeRuntime.runMain(main(), { disableErrorReporting: true })
+}

--- a/src/once.ts
+++ b/src/once.ts
@@ -1,47 +1,13 @@
 import { pathToFileURL } from "node:url"
 
 import { NodeRuntime } from "@effect/platform-node"
-import { config as loadDotEnv } from "dotenv"
-import { Effect, Logger } from "effect"
 
-import type { ActualError } from "./actual.ts"
-import { resolveRuntimeConfig, type RuntimeConfig, type RuntimeConfigError } from "./env.ts"
-import type { FintualError } from "./fintual/fintual-error.ts"
-import { runJob } from "./job.ts"
-import { RedactionPolicy } from "./log.ts"
-import { makeRedactingLogger, reportUnhandledFailure } from "./logging.ts"
-
-loadDotEnv()
-
-const runOnce = Effect.fn("Once.runOnce")(function* (
-  runtimeConfig: RuntimeConfig,
-): Effect.fn.Return<void, ActualError | FintualError> {
-  yield* Effect.logInfo("Running task once...")
-  yield* runJob(runtimeConfig)
-  yield* Effect.logInfo("Task completed.")
-})
-
-const main = Effect.fn("Once.main")(function* (): Effect.fn.Return<
-  void,
-  RuntimeConfigError | ActualError | FintualError
-> {
-  const runtimeConfig = yield* resolveRuntimeConfig(process.env).pipe(
-    Effect.tapCause((cause) =>
-      reportUnhandledFailure(cause).pipe(
-        Effect.provide(Logger.layer([makeRedactingLogger(RedactionPolicy.empty)])),
-      ),
-    ),
-  )
-  yield* runOnce(runtimeConfig).pipe(
-    Effect.tapCause(reportUnhandledFailure),
-    Effect.provide(Logger.layer([makeRedactingLogger(RedactionPolicy.fromConfig(runtimeConfig))])),
-  )
-})
+import { mainOnce } from "./main.ts"
 
 function isMainModule(): boolean {
   return import.meta.url === pathToFileURL(process.argv[1] ?? "").href
 }
 
 if (isMainModule()) {
-  NodeRuntime.runMain(main(), { disableErrorReporting: true })
+  NodeRuntime.runMain(mainOnce(), { disableErrorReporting: true })
 }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -15,17 +15,30 @@ export class InvalidScheduleError extends Schema.TaggedError<InvalidScheduleErro
   },
 ) {}
 
+export const parseSchedule = (
+  cron: string,
+  timezone: string,
+): Result.Result<Cron.Cron, InvalidScheduleError> => {
+  const parsed = Cron.parse(cron, timezone)
+  if (Result.isFailure(parsed)) {
+    return Result.fail(
+      new InvalidScheduleError({
+        message: parsed.failure.message,
+        input: parsed.failure.input ?? cron,
+        cause: parsed.failure,
+      }),
+    )
+  }
+  return Result.succeed(parsed.success)
+}
+
 export const runScheduler = Effect.fn("Scheduler.run")(function* (
   job: Effect.Effect<unknown, unknown>,
   options: SchedulerOptions,
 ): Effect.fn.Return<never, InvalidScheduleError> {
-  const parsed = Cron.parse(options.cron, options.timezone)
+  const parsed = parseSchedule(options.cron, options.timezone)
   if (Result.isFailure(parsed)) {
-    return yield* new InvalidScheduleError({
-      message: parsed.failure.message,
-      input: parsed.failure.input ?? options.cron,
-      cause: parsed.failure,
-    })
+    return yield* parsed.failure
   }
 
   const cron = parsed.success


### PR DESCRIPTION
Fixes #360

Wires the scheduler core (#359) and logging seam (#358) into the process entrypoint and environment configuration.

- `src/env.ts` decodes `RUN_MODE` (default `once`), `SYNC_CRON` (default `0 0 22 * * 1-5`), `SYNC_TIMEZONE` (default `America/Santiago`), and `SYNC_NO_OVERLAP` (default `false`), validating the cron expression and IANA timezone eagerly with `Cron.parse` so invalid schedules fail fast as `RuntimeConfigError`.
- `src/main.ts` is the shared composition root: it installs the redacting logger once, dispatches to the one-shot Synchronization Attempt for `RUN_MODE=once`, and runs the existing job through the in-process scheduler on each tick for `RUN_MODE=schedule`. Scheduled failures are logged by the scheduler core without terminating the loop.
- `src/once.ts` is now a thin one-shot wrapper over the shared entrypoint, preserving the manual diagnostic path.
- The container defaults to scheduler mode (`ENV RUN_MODE=schedule` plus `bin/run-schedule.sh`), with `RUN_MODE=once` still available for diagnostics.
- ADR 0006 records the move from the external Ofelia scheduler to the in-process Effect scheduler, including shutdown and restart-policy guidance.
- Tests cover schedule defaults and mode selection, invalid cron/timezone/mode fast-fail, exactly one attempt in once mode, the one-shot program, and schedule-mode delegation with the configured policy.

## Commits

- `feat: decode schedule mode from runtime config`
- `feat: dispatch run mode from shared entrypoint`
- `feat: default container and scripts to scheduler mode`
- `refactor: share entrypoint composition and schedule parsing`
- `feat: default container and docs to scheduler mode`
- `docs: record in-process scheduler decision`
