### PR TITLE
docs: ship scheduler as breaking major version (#361)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,7 @@ jobs:
             type=raw,value=sha-${{ steps.source.outputs.short_sha }}
           labels: |
             org.opencontainers.image.title=fintual-api
-            org.opencontainers.image.description=One-shot worker that syncs Fintual investment data into Actual Budget
+            org.opencontainers.image.description=Scheduler worker that syncs Fintual investment data into Actual Budget
             org.opencontainers.image.revision=${{ steps.source.outputs.sha }}
 
       - name: Build and publish image

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # fintual-api
 
-`fintual-api` is a one-shot worker that logs into Fintual, fetches investment performance data, and imports the resulting variation transactions into Actual Budget.
+`fintual-api` is a worker that logs into Fintual, fetches investment performance data, and imports the resulting variation transactions into Actual Budget. In its default mode it runs the sync on a cron schedule from inside the container process; a one-shot mode remains for manual diagnostics.
 
-The repo intentionally supports only two flows:
+The repo intentionally supports only these flows:
 
+- `pnpm schedule` runs the sync on the configured cron schedule (the container default)
 - `pnpm once` runs the full sync once
 - unattended 2FA retrieval via Gmail IMAP + app password
 
@@ -137,6 +138,11 @@ hk check --all
 
 ## Docker Image
 
+> **Breaking change in the v3 major:** the image default command changed from
+> a one-shot sync (exit after running once) to a long-lived scheduler process
+> (run until interrupted). The previous invocation contract is not preserved
+> and there is no retro-compatibility shim. See [Release guidance](#release-guidance).
+
 The published container image runs the in-process cron scheduler by default. The
 worker runs the synchronization at the configured schedule:
 
@@ -223,9 +229,7 @@ The intended production model is:
 The scheduler mode is the container default. Configure the sync time with
 `SYNC_CRON` and `SYNC_TIMEZONE` (for example, `0 0 22 * * 1-5` in
 `America/Santiago`), and keep `RUN_MODE=once` available for manual
-`docker exec` diagnostics. The compose migration away from Ofelia is a separate
-deployment change; the image remains backward compatible with one-shot
-invocations.
+`docker exec` diagnostics.
 
 The scheduler stops cleanly when the process is interrupted, including SIGTERM,
 and each in-flight run's scoped resources are closed. Configure the container
@@ -233,3 +237,22 @@ restart policy (for example, `restart: unless-stopped`) so the worker comes back
 after a host restart.
 
 For homelab deployments, store `GMAIL_APP_PASSWORD` in your secret manager (for example, GCP Secret Manager) and inject it into the worker environment at runtime.
+
+## Release guidance
+
+Starting with the v3 major, the image default command runs the in-process
+scheduler instead of a one-shot sync. This is a breaking change to the
+container process contract:
+
+- The default command (`bin/run-schedule.sh`) no longer exits after one sync.
+  It runs the synchronization on the configured `SYNC_CRON` schedule until the
+  process is interrupted (for example, SIGTERM).
+- The previous invocation contract is not preserved: there is no
+  retro-compatibility shim, and images published under the v3 major and later
+  do not accept the old invocation.
+- One-shot invocations remain available explicitly via `RUN_MODE=once` or
+  `bin/run-sync.sh`, for manual `docker exec` diagnostics and CI-style runs.
+
+Publish the breaking change under a new major version tag (for example, `v3.0.0`);
+do not publish it under an existing v2 tag, because `latest` follows GitHub
+Releases and old tags must keep the previous behavior.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The repo intentionally supports only these flows:
 
-- `pnpm schedule` runs the sync on the configured cron schedule (the container default)
+- `pnpm schedule` runs the sync on the configured cron schedule when `RUN_MODE=schedule` is set (the container default)
 - `pnpm once` runs the full sync once
 - unattended 2FA retrieval via Gmail IMAP + app password
 

--- a/docs/adr/0006-in-process-effect-scheduler.md
+++ b/docs/adr/0006-in-process-effect-scheduler.md
@@ -37,9 +37,14 @@ root installs the redacting logger once and covers both modes. Catch-up or
 missed-run semantics beyond a plain cron schedule, and persistence of scheduler
 state across restarts, are out of scope.
 
-The homelab compose migration away from Ofelia is a separate deployment change;
-the application image remains backward compatible with the existing one-shot
-invocation until that adoption lands.
+The scheduler ships as a breaking major version (v3). The image default command
+becomes the long-lived scheduler process, changing the process contract from
+exit-after-once to run-until-interrupted. The previous invocation contract is
+**not** preserved: there is no retro-compatibility shim, and v3+ images do not
+accept the old invocation. Homelab adoption is intentionally later and outside
+this project's tracker; when the homelab stack adopts v3, it drops Ofelia, its
+Docker socket mount, the scheduler labels, and the idle sleep command as one
+deployment change.
 
 ## Considered options
 
@@ -49,17 +54,23 @@ invocation until that adoption lands.
 - **CLI subcommands or flags** — rejected because the application has one real
   command plus scheduling; environment-selected modes keep the entrypoint thin
   and deployment configuration as the source of truth.
-- **Scheduler as the runtime default** — rejected because keeping one-shot as
-  the runtime default preserves backward compatibility for existing invocations;
-  the container default is set explicitly at the Docker layer.
+- **Backward-compatible default with Ofelia removal later** — considered while
+  the scheduler landed, then rejected for the shipped major: the container
+  default now runs the scheduler, so the old contract cannot be preserved.
+  Keeping a compatibility shim would have to distinguish "one-shot by default"
+  from "one-shot on request" across invocations and would have delayed the
+  homelab migration without protecting any external consumer; the one-shot path
+  remains available explicitly via `RUN_MODE=once` and `bin/run-sync.sh`.
 
 ## Consequences
 
-- The homelab stack can drop Ofelia, its Docker socket mount, scheduler labels,
+- The homelab stack drops Ofelia, its Docker socket mount, scheduler labels,
   and the idle sleep command when it adopts the new image.
 - Scheduled and one-shot runs share one Effect logging and redaction path.
 - The worker process contract changes from exit-after-once to run-forever in
   scheduler mode; shutdown is interrupt-driven and the deployment should
   configure a restart policy for the long-lived worker.
+- The v3 major is a breaking release: existing invocations that rely on the
+  one-shot default must pass `RUN_MODE=once` explicitly or keep a v2 image.
 - Invalid schedules are rejected before application work starts with typed,
   readable errors.

--- a/src/performance-snapshot.test.ts
+++ b/src/performance-snapshot.test.ts
@@ -114,6 +114,9 @@ it.effect("fails when the Performance Snapshot cannot be written", () =>
     fs.mkdirSync(path.dirname(snapshotPath), { recursive: true })
 
     try {
+      if (originalContents !== null) {
+        fs.rmSync(snapshotPath)
+      }
       fs.mkdirSync(snapshotPath, { recursive: true })
       const error = yield* Effect.flip(writePerformanceSnapshot(performanceSnapshot()))
 


### PR DESCRIPTION
## Summary

Ships the in-process scheduler as a breaking major version (v3). The image
default command is already the scheduled worker (landed in #377 for #360);
this change completes the breaking-major contract:

- **README**: describes the scheduler-first worker, documents the breaking
  process-contract change with a callout on the Docker Image section, and adds
  a "Release guidance" section (v3 contract, no retro-compatibility shim,
  one-shot remains explicit via `RUN_MODE=once`, publish under a new major tag).
- **ADR 0006**: records the breaking v3 major, the no-retro-compatibility
  decision, and the rejected backward-compatible-default option.
- **publish.yml**: OCI description label now says "Scheduler worker" instead of
  "One-shot worker".
- **fix**: the `fails when the Performance Snapshot cannot be written` test
  failed on checkouts where a real sync left `tmp/fintual-data/balance-2.json`
  behind (`EEXIST` before the assertion). The test now moves a leftover
  artifact aside before creating the blocking directory; the existing `finally`
  already restores it.

## Notes

- Homelab adoption of the new image is intentionally out of scope.
- The worker stops cleanly on SIGTERM; each in-flight run's scoped resources
  are closed. Configure the container restart policy (`restart: unless-stopped`)
  so the worker comes back after a host restart.

Fixes #361
Closes #357
