### PR TITLE
refactor(actual): put the health check on Effect HttpClient

### DIFF
--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -16,7 +16,7 @@ const actualApiMock = vi.hoisted(() => ({
 }))
 
 vi.mock("@actual-app/api", () => actualApiMock)
-import { ActualConfigService, ActualSynchronization } from "./actual.ts"
+import { ActualSynchronization } from "./actual.ts"
 import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
 import {
   ActualBudgetDownloadFailure,
@@ -27,7 +27,7 @@ import type { ActualError } from "./actual/actual-error.ts"
 import { ActualFileSystem } from "./actual/actual-file-system.ts"
 import { ActualHealthCheck } from "./actual/actual-health-check.ts"
 import { ActualRetryPolicy } from "./actual/retry-policy.ts"
-import type { ActualConfig } from "./env.ts"
+import { ActualConfigService, type ActualConfig } from "./env.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
 
 afterEach(() => {

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -16,6 +16,8 @@ const actualApiMock = vi.hoisted(() => ({
 }))
 
 vi.mock("@actual-app/api", () => actualApiMock)
+import { FetchHttpClient } from "effect/unstable/http"
+
 import { ActualSynchronization } from "./actual.ts"
 import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
 import {
@@ -189,8 +191,12 @@ it.effect("health checks normalize the server URL and classify HTTP failures", (
     }
     const program = Effect.gen(function* () {
       const healthCheck = yield* ActualHealthCheck
-      yield* healthCheck.check("https://actual.example.test/")
-    }).pipe(Effect.provide(ActualHealthCheck.layer(fetchRequest)))
+      yield* healthCheck.check
+    }).pipe(
+      Effect.provide(ActualHealthCheck.live),
+      Effect.provideService(ActualConfigService, CONFIG),
+      Effect.provideService(FetchHttpClient.Fetch, fetchRequest),
+    )
 
     const error = yield* Effect.flip(program)
 
@@ -209,8 +215,12 @@ it.effect("health-check timeout is controlled by the Effect Clock", () =>
     const fetchRequest: typeof globalThis.fetch = async () => new Promise<Response>(() => {})
     const healthCheck = Effect.gen(function* () {
       const service = yield* ActualHealthCheck
-      yield* service.check("https://actual.example.test")
-    }).pipe(Effect.provide(ActualHealthCheck.layer(fetchRequest)))
+      yield* service.check
+    }).pipe(
+      Effect.provide(ActualHealthCheck.live),
+      Effect.provideService(ActualConfigService, CONFIG),
+      Effect.provideService(FetchHttpClient.Fetch, fetchRequest),
+    )
     const fiber = yield* Effect.forkChild(healthCheck)
     yield* TestClock.adjust(10_000)
     const result = yield* Effect.result(Fiber.join(fiber))
@@ -292,7 +302,7 @@ function synchronizationProgram(
       reset: Effect.sync(() => calls.push("reset")),
     }),
     Effect.provideService(ActualHealthCheck, {
-      check: () => Effect.sync(() => calls.push("health")),
+      check: Effect.sync(() => calls.push("health")),
     }),
     Effect.provideService(ActualRetryPolicy, { schedule }),
   )

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -193,7 +193,7 @@ it.effect("health checks normalize the server URL and classify HTTP failures", (
       const healthCheck = yield* ActualHealthCheck
       yield* healthCheck.check
     }).pipe(
-      Effect.provide(ActualHealthCheck.live),
+      Effect.provide(ActualHealthCheck.layer),
       Effect.provideService(ActualConfigService, CONFIG),
       Effect.provideService(FetchHttpClient.Fetch, fetchRequest),
     )
@@ -217,7 +217,7 @@ it.effect("health-check timeout is controlled by the Effect Clock", () =>
       const service = yield* ActualHealthCheck
       yield* service.check
     }).pipe(
-      Effect.provide(ActualHealthCheck.live),
+      Effect.provide(ActualHealthCheck.layer),
       Effect.provideService(ActualConfigService, CONFIG),
       Effect.provideService(FetchHttpClient.Fetch, fetchRequest),
     )

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -210,6 +210,30 @@ it.effect("health checks normalize the server URL and classify HTTP failures", (
   }),
 )
 
+it.effect("health checks map transport failures to a retryable failure", () =>
+  Effect.gen(function* () {
+    const fetchRequest: typeof globalThis.fetch = async () => {
+      throw new TypeError("network down")
+    }
+    const program = Effect.gen(function* () {
+      const healthCheck = yield* ActualHealthCheck
+      yield* healthCheck.check
+    }).pipe(
+      Effect.provide(ActualHealthCheck.layer),
+      Effect.provideService(ActualConfigService, CONFIG),
+      Effect.provideService(FetchHttpClient.Fetch, fetchRequest),
+    )
+
+    const error = yield* Effect.flip(program)
+
+    expect(error).toMatchObject({
+      _tag: "ActualHealthCheckFailure",
+      url: "https://actual.example.test/health",
+      retryable: true,
+    })
+  }),
+)
+
 it.effect("health-check timeout is controlled by the Effect Clock", () =>
   Effect.gen(function* () {
     const fetchRequest: typeof globalThis.fetch = async () => new Promise<Response>(() => {})

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -57,7 +57,7 @@ export class ActualSynchronization extends Context.Service<
   static readonly live = this.layer.pipe(
     Layer.provide(ActualClientFactory.live),
     Layer.provide(ActualFileSystem.live),
-    Layer.provide(ActualHealthCheck.layer((input, init) => globalThis.fetch(input, init))),
+    Layer.provide(ActualHealthCheck.live),
     Layer.provide(ActualRetryPolicy.live),
   )
 }
@@ -94,7 +94,7 @@ const runActualSyncAttempt = Effect.fn("ActualSynchronization.attempt")(function
   return yield* Effect.scoped(
     Effect.gen(function* () {
       yield* fileSystem.reset
-      yield* healthCheck.check(config.serverUrl)
+      yield* healthCheck.check
 
       const client = yield* Effect.acquireRelease(clientFactory.acquire(config), closeActualClient)
 

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -57,7 +57,7 @@ export class ActualSynchronization extends Context.Service<
   static readonly live = this.layer.pipe(
     Layer.provide(ActualClientFactory.live),
     Layer.provide(ActualFileSystem.live),
-    Layer.provide(ActualHealthCheck.live),
+    Layer.provide(ActualHealthCheck.layer),
     Layer.provide(ActualRetryPolicy.live),
   )
 }

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -7,7 +7,7 @@ import { ActualFileSystem } from "./actual/actual-file-system.ts"
 import { ActualHealthCheck } from "./actual/actual-health-check.ts"
 import { planReconciliation } from "./actual/reconciliation-policy.ts"
 import { ActualRetryPolicy } from "./actual/retry-policy.ts"
-import type { ActualConfig } from "./env.ts"
+import { ActualConfigService, type ActualConfig } from "./env.ts"
 import { getErrorMessage } from "./log.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
 
@@ -18,10 +18,6 @@ interface SyncCounts {
   readonly updated: number
   readonly deletedDuplicates: number
 }
-
-export class ActualConfigService extends Context.Service<ActualConfigService, ActualConfig>()(
-  "ActualConfig",
-) {}
 
 export class ActualSynchronization extends Context.Service<
   ActualSynchronization,

--- a/src/actual/actual-health-check.ts
+++ b/src/actual/actual-health-check.ts
@@ -12,7 +12,7 @@ export class ActualHealthCheck extends Context.Service<
     readonly check: Effect.Effect<void, ActualHealthCheckFailure>
   }
 >()("ActualHealthCheck") {
-  static readonly live = Layer.effect(
+  static readonly layer = Layer.effect(
     ActualHealthCheck,
     Effect.gen(function* () {
       const config = yield* ActualConfigService

--- a/src/actual/actual-health-check.ts
+++ b/src/actual/actual-health-check.ts
@@ -1,62 +1,64 @@
-import { Context, Effect, Layer } from "effect"
+import { Context, Duration, Effect, Layer } from "effect"
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 
+import { ActualConfigService } from "../env.ts"
 import { ActualHealthCheckFailure } from "./actual-error.ts"
 
-const HEALTH_CHECK_TIMEOUT_MS = 10_000
+const HEALTH_CHECK_TIMEOUT = Duration.millis(10_000)
 
 export class ActualHealthCheck extends Context.Service<
   ActualHealthCheck,
   {
-    readonly check: (serverUrl: string) => Effect.Effect<void, ActualHealthCheckFailure>
+    readonly check: Effect.Effect<void, ActualHealthCheckFailure>
   }
 >()("ActualHealthCheck") {
-  static readonly layer = (fetchRequest: typeof globalThis.fetch) =>
-    Layer.succeed(
-      ActualHealthCheck,
-      ActualHealthCheck.of({
-        check: Effect.fn("ActualHealthCheck.check")(function* (serverUrl: string) {
-          const healthUrl = getHealthUrl(serverUrl)
-          const response = yield* Effect.tryPromise({
-            try: (signal) =>
-              fetchRequest(healthUrl, {
-                method: "GET",
-                signal,
-              }),
-            catch: (cause) =>
+  static readonly live = Layer.effect(
+    ActualHealthCheck,
+    Effect.gen(function* () {
+      const config = yield* ActualConfigService
+      const client = yield* HttpClient.HttpClient
+
+      const check = Effect.fn("ActualHealthCheck.check")(function* () {
+        const healthUrl = getHealthUrl(config.serverUrl)
+        const response = yield* client.execute(HttpClientRequest.get(healthUrl)).pipe(
+          Effect.mapError(
+            (cause) =>
               new ActualHealthCheckFailure({
                 url: healthUrl,
                 cause,
                 retryable: true,
               }),
-          }).pipe(
-            Effect.timeoutOrElse({
-              duration: HEALTH_CHECK_TIMEOUT_MS,
-              orElse: () =>
-                Effect.fail(
-                  new ActualHealthCheckFailure({
-                    url: healthUrl,
-                    cause: new Error(
-                      `health endpoint timed out after ${HEALTH_CHECK_TIMEOUT_MS}ms`,
-                    ),
-                    retryable: true,
-                  }),
-                ),
-            }),
-          )
+          ),
+          Effect.timeoutOrElse({
+            duration: HEALTH_CHECK_TIMEOUT,
+            orElse: () =>
+              Effect.fail(
+                new ActualHealthCheckFailure({
+                  url: healthUrl,
+                  cause: new Error(
+                    `health endpoint timed out after ${Duration.toMillis(HEALTH_CHECK_TIMEOUT)}ms`,
+                  ),
+                  retryable: true,
+                }),
+              ),
+          }),
+        )
 
-          if (response.ok) {
-            return
-          }
+        if (response.status >= 200 && response.status < 300) {
+          return
+        }
 
-          return yield* new ActualHealthCheckFailure({
-            url: healthUrl,
-            status: response.status,
-            cause: new Error(`health endpoint returned HTTP ${response.status}`),
-            retryable: isRetryableStatus(response.status),
-          })
-        }),
-      }),
-    )
+        return yield* new ActualHealthCheckFailure({
+          url: healthUrl,
+          status: response.status,
+          cause: new Error(`health endpoint returned HTTP ${response.status}`),
+          retryable: isRetryableStatus(response.status),
+        })
+      })
+
+      return ActualHealthCheck.of({ check: check() })
+    }),
+  ).pipe(Layer.provide(FetchHttpClient.layer))
 }
 
 function getHealthUrl(serverUrl: string): string {

--- a/src/env.ts
+++ b/src/env.ts
@@ -19,6 +19,10 @@ export interface ActualConfig {
   payee: string
 }
 
+export class ActualConfigService extends Context.Service<ActualConfigService, ActualConfig>()(
+  "ActualConfig",
+) {}
+
 export interface Email2FAConfig {
   userEmail: string
   appPassword: Redacted.Redacted<string>


### PR DESCRIPTION
## What

Moves the Actual health check off raw `globalThis.fetch` onto the Effect `HttpClient` stack, clearing the last ADR-0000/ADR-0005 contradiction in the Actual side of the app.

The health check module now:
- acquires `HttpClient` + `ActualConfigService` at layer construction (`check()` is an argument-less Effect)
- keeps the 10s timeout as a module `Duration` on `Effect.timeoutOrElse` (TestClock-controllable)
- maps transport errors to `ActualHealthCheckFailure` with `retryable: true`
- self-provisions `FetchHttpClient.layer`, matching the `FintualProvider` pattern

## Why

The old module took a raw `fetch` function and the server URL per call, owned a second timeout/status-classification stack, and leaked configuration into the call signature. `provider.ts` already built this machinery on `HttpClient`; the health check was the duplicate.

## Changes

- **`refactor(actual): relocate ActualConfigService to env.ts`** — moves the service tag next to its `ActualConfig` type to avoid a module cycle (`actual.ts` ↔ `actual-health-check.ts`). No behavior change.
- **`refactor(actual): back the Actual health check with Effect HttpClient`** — the transport switch; tests provide `FetchHttpClient.layer` with a scripted `Fetch`, the established mocking idiom in `provider.test.ts`.

## Verification

- 122 tests pass (pre-push gate, including `@effect/vitest` deterministic HTTP tests)
- `tsc --noEmit` clean, oxfmt/oxlint clean