### PR TITLE
docs: define Effect service layer naming in ADR-0007

### DIFF
--- a/docs/adr/0007-effect-layer-naming.md
+++ b/docs/adr/0007-effect-layer-naming.md
@@ -1,0 +1,68 @@
+# Effect service layer naming
+
+## Status
+
+Accepted
+
+## Context
+
+Effect service modules expose one or more `Layer`s that a composition root wires
+together. The meaning of a layer's name has been implicit: `FintualProvider.layer`
+requires configuration and self-provisions its HTTP transport, while
+`ActualRetryPolicy.live` is a self-contained `Layer.succeed`. Reviewers have
+enforced the distinction without a written rule, so each one applies their own
+reading, and the codebase has drifted — `SnapshotWriter.layer` is a
+self-contained `Layer.sync`, the same shape as `ActualRetryPolicy.live`, named
+differently. This friction recurs on every new module.
+
+## Decision
+
+An Effect service module uses two static layer constructors:
+
+- **`.layer`** — construction. The layer may require dependencies from the
+  environment (config services, adapters, the Effect `HttpClient`) or take
+  configuration as an argument.
+- **`.live`** — composition-ready. The layer provides every module-internal
+  dependency (adapters, sub-services, transport) so the composition root supplies
+  only the app-level config services (`ActualConfigService`,
+  `FintualConfigService`).
+
+When a module needs both, `.live` composes `.layer`:
+
+```text
+static readonly layer = Layer.effect(Service, ...)
+static readonly live = this.layer.pipe(Layer.provide(<internal dependencies>))
+```
+
+Apply the rule by answering one question: does the layer need anything from the
+environment?
+
+- **Yes** — a single layer requiring config, adapters, or the `HttpClient` is
+  `.layer`. `FintualProvider.layer`, `ActualHealthCheck.layer`. A layer that
+  takes configuration as an argument is also `.layer` (`RedactionPolicy`).
+- **No** — a fully self-contained layer with no environment requirements is
+  `.live`, including `Layer.succeed` and `Layer.sync` layers.
+  `ActualRetryPolicy.live`, `ActualClientFactory.live`, `ActualFileSystem.live`.
+- **Both** — `.layer` builds from dependencies; `.live` wires them:
+  `ActualSynchronization`, `Email2FAService`, `FintualPerformance`.
+
+Layer constants are statics on the service class. Top-level exported `...Live`
+constants are not used (`ImapClientFactory.live`, not `ImapClientFactoryLive`).
+
+## Considered options
+
+- **Name every layer `.live`** — rejected: it erases the construction/composition
+  distinction and makes config-requiring layers look fully wired.
+- **Keep a separate `.test` layer convention** — rejected: test layers already
+  use direct `Effect.provideService` at the call site; no new name is needed.
+- **Document the convention without converging the codebase** — rejected: a norm
+  that existing code contradicts invites the same drift. `SnapshotWriter` and
+  `ImapClientFactory` were renamed as part of this ADR.
+
+## Consequences
+
+- New modules pick a name mechanically: environment requirements present → `.layer`,
+  absent → `.live`.
+- Reviewers apply the rule instead of re-deriving it.
+- `SnapshotWriter.layer` and `ImapClientFactoryLive` were renamed to `.live`
+  statics when this ADR landed; future deviations are fixed under this ADR.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -48,4 +48,4 @@ If the concept you need isn't in the glossary yet, that's a signal — either yo
 
 If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
 
-> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_
+> _Contradicts ADR-0099 (event-sourced orders) — but worth reopening because…_

--- a/src/fintual/email-2fa-client.ts
+++ b/src/fintual/email-2fa-client.ts
@@ -184,8 +184,8 @@ export class ImapClientFactory extends Context.Service<
   {
     readonly create: (config: Email2FAConfig) => ImapClient
   }
->()("Email2FA/ImapClientFactory") {}
-
-export const ImapClientFactoryLive = Layer.succeed(ImapClientFactory, {
-  create: createImapClient,
-})
+>()("Email2FA/ImapClientFactory") {
+  static readonly live = Layer.succeed(ImapClientFactory, {
+    create: createImapClient,
+  })
+}

--- a/src/fintual/email-2fa.ts
+++ b/src/fintual/email-2fa.ts
@@ -4,7 +4,6 @@ import { FintualConfigService, type Email2FAConfig } from "../env.ts"
 import { getErrorMessage } from "../log.ts"
 import {
   ImapClientFactory,
-  ImapClientFactoryLive,
   ImapMailboxLockFailure,
   ImapOperationFailure,
   MissingServerExtension,
@@ -78,7 +77,7 @@ export class Email2FAService extends Context.Service<
     }),
   )
 
-  static readonly live = Email2FAService.layer.pipe(Layer.provide(ImapClientFactoryLive))
+  static readonly live = Email2FAService.layer.pipe(Layer.provide(ImapClientFactory.live))
 }
 
 const retrieveEmail2FACode = Effect.fn("Email2FA.retrieveEmail2FACode")(function* (

--- a/src/fintual/performance.ts
+++ b/src/fintual/performance.ts
@@ -61,7 +61,7 @@ export class FintualPerformance extends Context.Service<
       return FintualPerformance.layer.pipe(
         Layer.provide(FintualProvider.layer),
         Layer.provide(config.email2FA ? Email2FAService.live : Layer.empty),
-        Layer.provide(SnapshotWriter.layer),
+        Layer.provide(SnapshotWriter.live),
       )
     }),
   )

--- a/src/performance-snapshot.ts
+++ b/src/performance-snapshot.ts
@@ -14,7 +14,7 @@ export class SnapshotWriter extends Context.Service<
     write: (snapshot: PerformanceSnapshot) => Effect.Effect<void, SnapshotWriteFailure>
   }
 >()("SnapshotWriter") {
-  static readonly layer = Layer.sync(SnapshotWriter, () =>
+  static readonly live = Layer.sync(SnapshotWriter, () =>
     SnapshotWriter.of({
       write: Effect.fn("SnapshotWriter.write")(function* (snapshot) {
         return yield* writePerformanceSnapshot(snapshot)


### PR DESCRIPTION
## What

Establishes the `.layer` / `.live` Effect layer naming convention as a written norm (ADR-0007) and converges the two existing deviations onto it.

## Why

The convention was real but undocumented and inconsistently applied. `SnapshotWriter.layer` was a self-contained `Layer.sync` named like a construction layer, and `ImapClientFactory` used a top-level `ImapClientFactoryLive` const — each reviewer ended up re-deriving the rule, which is the recurring naming friction this ADR removes.

## The standard (ADR-0007)

Answer one question: does the layer need anything from the environment?
- **Yes** → `.layer` (construction; config, adapters, or `HttpClient` required). e.g. `FintualProvider.layer`, `ActualHealthCheck.layer`, `RedactionPolicy.layer`.
- **No** → `.live` (composition-ready, self-contained). e.g. `ActualRetryPolicy.live`, `ActualClientFactory.live`.
- **Both** → `.layer` builds, `.live` wires: `ActualSynchronization`, `Email2FAService`, `FintualPerformance`.

Layer constants live as statics on the service class; no top-level `...Live` consts.

## Commits (atomic)

1. `docs: define Effect service layer naming in ADR-0007`
2. `refactor(snapshot): name the SnapshotWriter layer .live`
3. `refactor(fintual): expose ImapClientFactory.live instead of a top-level Live const`

## Verification

122 tests pass (pre-push gate), `tsc` clean, oxfmt/oxlint clean.