### PR TITLE
refactor(actual): decode Actual SDK rows at the boundary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,7 +29,7 @@ _Avoid_: OTP, verification code, security code
 ### Synchronization
 
 **Variation Transaction**:
-A balance-change transaction for one date, identified by the `fintual-variation:<date>` imported id, managed as a unit by the Actual sync.
+A balance-change transaction for one date, identified by the `fintual-variation:<date>` imported id, managed as a unit by the Actual sync. The Actual adapter resolves each existing transaction's date at the boundary, tolerating legacy numeric imported ids and stale date fields, so the reconciliation policy only sees well-formed values.
 _Avoid_: Balance transaction, sync entry
 
 **Reconciliation Plan**:

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -29,6 +29,7 @@ import type { ActualError } from "./actual/actual-error.ts"
 import { ActualFileSystem } from "./actual/actual-file-system.ts"
 import { ActualHealthCheck } from "./actual/actual-health-check.ts"
 import { ActualRetryPolicy } from "./actual/retry-policy.ts"
+import type { ExistingVariationTransaction } from "./actual/variation-transaction.ts"
 import { ActualConfigService, type ActualConfig } from "./env.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
 
@@ -335,13 +336,7 @@ function synchronizationProgram(
 function scriptedClient(
   calls: string[],
   options: {
-    transactions?: ReadonlyArray<{
-      id: string
-      date?: string
-      notes?: string
-      payee?: string | null
-      imported_id?: string
-    }>
+    transactions?: ReadonlyArray<ExistingVariationTransaction>
     create?: ActualClient["createTransaction"]
     download?: ActualClient["downloadBudget"]
     onTransactions?: (startDate: string, endDate: string) => void

--- a/src/actual/actual-client.test.ts
+++ b/src/actual/actual-client.test.ts
@@ -1,0 +1,181 @@
+import { it } from "@effect/vitest"
+import { Effect, Redacted } from "effect"
+import { afterEach, beforeEach, expect, vi } from "vitest"
+
+const actualApiMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  getTransactions: vi.fn(),
+  getPayees: vi.fn(),
+}))
+
+vi.mock("@actual-app/api", () => actualApiMock)
+
+import type { ActualConfig } from "../env.ts"
+import { ActualClientFactory } from "./actual-client.ts"
+
+beforeEach(() => {
+  actualApiMock.init.mockResolvedValue({})
+})
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+const CONFIG: ActualConfig = {
+  serverUrl: "https://actual.example.test/",
+  password: Redacted.make("secret"),
+  syncId: "sync-id",
+  fintualAccount: "account-id",
+  startingDate: "2026-01-01",
+  payee: "Fintual",
+}
+
+const acquireClient = Effect.gen(function* () {
+  const factory = yield* ActualClientFactory
+  return yield* factory.acquire(CONFIG)
+}).pipe(Effect.provide(ActualClientFactory.live))
+
+const canonicalImportedId = (date: string) => `fintual-variation:${date}`
+const numericImportedId = (date: string) => String(Date.parse(`${date}T00:00:00Z`))
+
+it.effect("decodes a canonical transaction row into a clean domain value", () =>
+  Effect.gen(function* () {
+    actualApiMock.getTransactions.mockResolvedValue([
+      {
+        id: "txn-1",
+        date: "2026-01-05",
+        notes: "Variation",
+        payee: "payee-1",
+        imported_id: canonicalImportedId("2026-01-05"),
+        account: "account-id",
+        amount: 1200,
+        category: "cat-1",
+      },
+    ])
+
+    const client = yield* acquireClient
+    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
+
+    expect(transactions).toEqual([
+      {
+        id: "txn-1",
+        date: "2026-01-05",
+        notes: "Variation",
+        payee: "payee-1",
+        imported_id: canonicalImportedId("2026-01-05"),
+      },
+    ])
+  }),
+)
+
+it.effect(
+  "decodes a legacy numeric imported id to its date even when the date field is stale",
+  () =>
+    Effect.gen(function* () {
+      actualApiMock.getTransactions.mockResolvedValue([
+        { id: "txn-1", date: "2020-01-01", imported_id: numericImportedId("2026-01-05") },
+      ])
+
+      const client = yield* acquireClient
+      const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
+
+      expect(transactions).toEqual([
+        { id: "txn-1", date: "2026-01-05", imported_id: numericImportedId("2026-01-05") },
+      ])
+    }),
+)
+
+it.effect("falls back to the ISO date field when no imported id carries a date", () =>
+  Effect.gen(function* () {
+    actualApiMock.getTransactions.mockResolvedValue([{ id: "txn-1", date: "2026-01-05" }])
+
+    const client = yield* acquireClient
+    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
+
+    expect(transactions).toEqual([{ id: "txn-1", date: "2026-01-05" }])
+  }),
+)
+
+it.effect("falls back to the date field when the prefixed imported id has no valid date", () =>
+  Effect.gen(function* () {
+    actualApiMock.getTransactions.mockResolvedValue([
+      { id: "txn-1", date: "2026-01-06", imported_id: "fintual-variation:not-a-date" },
+    ])
+
+    const client = yield* acquireClient
+    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
+
+    expect(transactions).toEqual([
+      { id: "txn-1", date: "2026-01-06", imported_id: "fintual-variation:not-a-date" },
+    ])
+  }),
+)
+
+it.effect("drops rows whose date cannot be derived", () =>
+  Effect.gen(function* () {
+    actualApiMock.getTransactions.mockResolvedValue([
+      { id: "txn-1", date: "not-a-date", imported_id: "not-a-date" },
+      { id: "txn-2" },
+    ])
+
+    const client = yield* acquireClient
+    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
+
+    expect(transactions).toEqual([])
+  }),
+)
+
+it.effect("coalesces null SDK fields into well-formed domain values", () =>
+  Effect.gen(function* () {
+    actualApiMock.getTransactions.mockResolvedValue([
+      {
+        id: "txn-1",
+        date: null,
+        notes: null,
+        payee: null,
+        imported_id: canonicalImportedId("2026-01-05"),
+      },
+    ])
+
+    const client = yield* acquireClient
+    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
+
+    expect(transactions).toEqual([
+      {
+        id: "txn-1",
+        date: "2026-01-05",
+        payee: null,
+        imported_id: canonicalImportedId("2026-01-05"),
+      },
+    ])
+  }),
+)
+
+it.effect("fails with a non-retryable read failure on a malformed row", () =>
+  Effect.gen(function* () {
+    actualApiMock.getTransactions.mockResolvedValue([{ date: "2026-01-05" }])
+
+    const client = yield* acquireClient
+    const failure = yield* Effect.flip(
+      client.getTransactions("account-id", "2026-01-01", "2026-01-31"),
+    )
+
+    expect(failure).toMatchObject({
+      _tag: "ActualTransactionsReadFailure",
+      retryable: false,
+    })
+  }),
+)
+
+it.effect("decodes payee rows into clean values", () =>
+  Effect.gen(function* () {
+    actualApiMock.getPayees.mockResolvedValue([
+      { id: "payee-1", name: "Fintual", transfer_acct: "acct-1", tombstone: false },
+    ])
+
+    const client = yield* acquireClient
+    const payees = yield* client.getPayees
+
+    expect(payees).toEqual([{ id: "payee-1", name: "Fintual" }])
+  }),
+)

--- a/src/actual/actual-client.ts
+++ b/src/actual/actual-client.ts
@@ -1,5 +1,5 @@
 import * as api from "@actual-app/api"
-import { Context, Effect, Layer, Predicate, Redacted } from "effect"
+import { Context, Effect, Layer, Predicate, Redacted, Schema } from "effect"
 
 import type { ActualConfig } from "../env.ts"
 import {
@@ -13,9 +13,10 @@ import {
   ActualTransactionUpdateFailure,
   ActualTransactionsReadFailure,
 } from "./actual-error.ts"
-import type {
-  ExistingVariationTransaction,
-  VariationTransactionInput,
+import {
+  VARIATION_IMPORTED_ID_PREFIX,
+  type ExistingVariationTransaction,
+  type VariationTransactionInput,
 } from "./variation-transaction.ts"
 
 const ACTUAL_DATA_DIR = "./tmp/actual-data"
@@ -98,7 +99,7 @@ const ActualClientLive: ActualClient = {
     startDate: string,
     endDate: string,
   ) {
-    return yield* Effect.tryPromise({
+    const rows = yield* Effect.tryPromise({
       try: () => api.getTransactions(accountId, startDate, endDate),
       catch: (cause) =>
         new ActualTransactionsReadFailure({
@@ -106,6 +107,8 @@ const ActualClientLive: ActualClient = {
           retryable: isRetryableActualCause(cause),
         }),
     })
+
+    return yield* decodeTransactions(rows)
   }),
 
   getPayees: Effect.tryPromise({
@@ -115,7 +118,10 @@ const ActualClientLive: ActualClient = {
         cause,
         retryable: isRetryableActualCause(cause),
       }),
-  }).pipe(Effect.withSpan("ActualClient.getPayees")),
+  }).pipe(
+    Effect.andThen((payees) => decodePayees(payees)),
+    Effect.withSpan("ActualClient.getPayees"),
+  ),
 
   createTransaction: Effect.fn("ActualClient.createTransaction")(function* (
     accountId: string,
@@ -177,4 +183,91 @@ function isRetryableActualCause(cause: unknown): boolean {
   }
 
   return cause.code === "network-failure" || cause.reason === "network-failure"
+}
+
+const sdkTransactionRowSchema = Schema.Struct({
+  id: Schema.String,
+  date: Schema.optional(Schema.NullOr(Schema.String)),
+  notes: Schema.optional(Schema.NullOr(Schema.String)),
+  payee: Schema.optional(Schema.NullOr(Schema.String)),
+  imported_id: Schema.optional(Schema.NullOr(Schema.String)),
+})
+
+const sdkPayeeSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+})
+
+const decodeTransactions = Effect.fn("ActualClient.decodeTransactions")(function* (
+  rows: unknown,
+): Effect.fn.Return<ReadonlyArray<ExistingVariationTransaction>, ActualTransactionsReadFailure> {
+  return yield* Schema.decodeUnknownEffect(Schema.Array(sdkTransactionRowSchema))(rows).pipe(
+    Effect.map((rows) =>
+      rows.flatMap((row) => {
+        const transaction = toExistingVariationTransaction(row)
+        return transaction ? [transaction] : []
+      }),
+    ),
+    Effect.mapError((cause) => new ActualTransactionsReadFailure({ cause, retryable: false })),
+  )
+})
+
+type SdkPayeeRow = Awaited<ReturnType<typeof api.getPayees>>[number]
+
+const decodePayees = Effect.fn("ActualClient.decodePayees")(function* (
+  payees: ReadonlyArray<SdkPayeeRow>,
+): Effect.fn.Return<ReadonlyArray<ActualPayee>, ActualPayeesReadFailure> {
+  return yield* Schema.decodeEffect(Schema.Array(sdkPayeeSchema))(payees).pipe(
+    Effect.mapError((cause) => new ActualPayeesReadFailure({ cause, retryable: false })),
+  )
+})
+
+function toExistingVariationTransaction(
+  row: Schema.Schema.Type<typeof sdkTransactionRowSchema>,
+): ExistingVariationTransaction | null {
+  const date = getVariationTransactionDate(row)
+  if (!date) {
+    return null
+  }
+
+  return {
+    id: row.id,
+    date,
+    notes: row.notes ?? undefined,
+    payee: row.payee,
+    imported_id: row.imported_id ?? undefined,
+  }
+}
+
+function getVariationTransactionDate(
+  row: Schema.Schema.Type<typeof sdkTransactionRowSchema>,
+): string | null {
+  if (row.imported_id?.startsWith(VARIATION_IMPORTED_ID_PREFIX)) {
+    const date = row.imported_id.slice(VARIATION_IMPORTED_ID_PREFIX.length)
+    if (isIsoDate(date)) {
+      return date
+    }
+  }
+
+  if (row.imported_id && isNumericTimestamp(row.imported_id)) {
+    return toIsoDate(Number(row.imported_id))
+  }
+
+  if (row.date && isIsoDate(row.date)) {
+    return row.date
+  }
+
+  return null
+}
+
+function toIsoDate(timestamp: number): string {
+  return new Date(timestamp).toISOString().split("T")[0]
+}
+
+function isIsoDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value)
+}
+
+function isNumericTimestamp(value: string): boolean {
+  return /^\d+$/.test(value)
 }

--- a/src/actual/actual-client.ts
+++ b/src/actual/actual-client.ts
@@ -16,7 +16,7 @@ import {
 import type {
   ExistingVariationTransaction,
   VariationTransactionInput,
-} from "./reconciliation-policy.ts"
+} from "./variation-transaction.ts"
 
 const ACTUAL_DATA_DIR = "./tmp/actual-data"
 

--- a/src/actual/reconciliation-policy.test.ts
+++ b/src/actual/reconciliation-policy.test.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "vitest"
 
+import { planReconciliation, type BalanceEntry } from "./reconciliation-policy.ts"
 import {
   VARIATION_IMPORTED_ID_PREFIX,
   VARIATION_NOTES,
-  planReconciliation,
-  type BalanceEntry,
   type ExistingVariationTransaction,
-} from "./reconciliation-policy.ts"
+} from "./variation-transaction.ts"
 
 function balanceEntry(date: string, realDifference: number, timestampOffsetMs = 0): BalanceEntry {
   return {

--- a/src/actual/reconciliation-policy.test.ts
+++ b/src/actual/reconciliation-policy.test.ts
@@ -174,16 +174,3 @@ test("keeps the latest timestamp when the balance file has duplicate dates", () 
       `${Date.parse("2026-01-05T00:00:00Z") + 3600_000}.`,
   ])
 })
-
-test("skips managed-looking transactions whose date cannot be derived", () => {
-  const plan = planReconciliation({
-    balanceEntries: [balanceEntry("2026-01-05", 2.49)],
-    existingTransactions: [
-      existingTransaction("undated-1", "not-a-date", {
-        importedId: "not-a-date",
-      }),
-    ],
-  })
-
-  expect(plan.actions).toEqual([create(variationTransaction("2026-01-05", 200))])
-})

--- a/src/actual/reconciliation-policy.test.ts
+++ b/src/actual/reconciliation-policy.test.ts
@@ -175,19 +175,6 @@ test("keeps the latest timestamp when the balance file has duplicate dates", () 
   ])
 })
 
-test("groups a legacy numeric imported id under its date even when the date field is stale", () => {
-  const plan = planReconciliation({
-    balanceEntries: [balanceEntry("2026-01-05", 2.49)],
-    existingTransactions: [
-      existingTransaction("legacy-1", "2020-01-01", {
-        importedId: String(Date.parse("2026-01-05T00:00:00Z")),
-      }),
-    ],
-  })
-
-  expect(plan.actions).toEqual([update("legacy-1", variationTransaction("2026-01-05", 200))])
-})
-
 test("skips managed-looking transactions whose date cannot be derived", () => {
   const plan = planReconciliation({
     balanceEntries: [balanceEntry("2026-01-05", 2.49)],

--- a/src/actual/reconciliation-policy.ts
+++ b/src/actual/reconciliation-policy.ts
@@ -1,26 +1,13 @@
-export const VARIATION_NOTES = "Variation"
-export const VARIATION_IMPORTED_ID_PREFIX = "fintual-variation:"
+import {
+  VARIATION_IMPORTED_ID_PREFIX,
+  VARIATION_NOTES,
+  type ExistingVariationTransaction,
+  type VariationTransactionInput,
+} from "./variation-transaction.ts"
 
 export interface BalanceEntry {
   date: number
   real_difference: number
-}
-
-export interface ExistingVariationTransaction {
-  id: string
-  date?: string
-  notes?: string
-  payee?: string | null
-  imported_id?: string
-}
-
-export interface VariationTransactionInput {
-  date: string
-  amount: number
-  payee?: string
-  notes: string
-  imported_id: string
-  cleared: boolean
 }
 
 export type ReconciliationAction =

--- a/src/actual/reconciliation-policy.ts
+++ b/src/actual/reconciliation-policy.ts
@@ -125,14 +125,9 @@ function groupVariationTransactionsByDate(
       continue
     }
 
-    const date = getVariationTransactionDate(transaction)
-    if (!date) {
-      continue
-    }
-
-    const dateTransactions = transactionsByDate.get(date) ?? []
+    const dateTransactions = transactionsByDate.get(transaction.date) ?? []
     dateTransactions.push(transaction)
-    transactionsByDate.set(date, dateTransactions)
+    transactionsByDate.set(transaction.date, dateTransactions)
   }
 
   return transactionsByDate
@@ -143,25 +138,6 @@ function isManagedVariationTransaction(
   payeeId: string | undefined,
 ): boolean {
   return transaction.notes === VARIATION_NOTES && (!payeeId || transaction.payee === payeeId)
-}
-
-function getVariationTransactionDate(transaction: ExistingVariationTransaction): string | null {
-  if (transaction.imported_id?.startsWith(VARIATION_IMPORTED_ID_PREFIX)) {
-    const date = transaction.imported_id.slice(VARIATION_IMPORTED_ID_PREFIX.length)
-    if (isIsoDate(date)) {
-      return date
-    }
-  }
-
-  if (transaction.imported_id && isNumericTimestamp(transaction.imported_id)) {
-    return toIsoDate(Number(transaction.imported_id))
-  }
-
-  if (transaction.date && isIsoDate(transaction.date)) {
-    return transaction.date
-  }
-
-  return null
 }
 
 function getCanonicalVariationTransaction(
@@ -185,12 +161,4 @@ function getDeleteActions(
 
 function toIsoDate(timestamp: number): string {
   return new Date(timestamp).toISOString().split("T")[0]
-}
-
-function isIsoDate(value: string): boolean {
-  return /^\d{4}-\d{2}-\d{2}$/.test(value)
-}
-
-function isNumericTimestamp(value: string): boolean {
-  return /^\d+$/.test(value)
 }

--- a/src/actual/variation-transaction.ts
+++ b/src/actual/variation-transaction.ts
@@ -3,7 +3,7 @@ export const VARIATION_IMPORTED_ID_PREFIX = "fintual-variation:"
 
 export interface ExistingVariationTransaction {
   id: string
-  date?: string
+  date: string
   notes?: string
   payee?: string | null
   imported_id?: string

--- a/src/actual/variation-transaction.ts
+++ b/src/actual/variation-transaction.ts
@@ -1,0 +1,19 @@
+export const VARIATION_NOTES = "Variation"
+export const VARIATION_IMPORTED_ID_PREFIX = "fintual-variation:"
+
+export interface ExistingVariationTransaction {
+  id: string
+  date?: string
+  notes?: string
+  payee?: string | null
+  imported_id?: string
+}
+
+export interface VariationTransactionInput {
+  date: string
+  amount: number
+  payee?: string
+  notes: string
+  imported_id: string
+  cleared: boolean
+}


### PR DESCRIPTION

## Summary

The Actual SDK boundary (`actual-client.ts`) returned un-decoded SDK rows, so the pure reconciliation policy carried Actual's wire reality: legacy numeric `imported_id`s, stale date fields, and date-format regexes. This moves that tolerance to the adapter, per ADR-0000 ("unknown SDK data is decoded with `Schema.decodeUnknownEffect` at the owning boundary").

- `ActualClient.getTransactions` decodes each SDK row with a tolerant Schema: the date is resolved from the canonical `fintual-variation:<date>` imported id, a legacy numeric timestamp, or the stale `date` field; rows whose date cannot be derived are dropped; decode failures map to non-retryable `ActualTransactionsReadFailure` while SDK transport failures keep their retryability classification.
- `getPayees` is decoded to clean `{ id, name }` values.
- `ExistingVariationTransaction` / `VariationTransactionInput` now live in a neutral module (`variation-transaction.ts`) consumed by both adapter and policy — the adapter no longer imports from the policy.
- The policy keeps only decision logic over well-formed values; grouping uses the resolved `date` directly.

## Commits

1. `93b17f7` refactor(actual): own variation transaction shapes in a neutral module — pure relocation, zero behavior change
2. `5ea5242` refactor(actual): decode Actual SDK rows at the boundary — the tolerance move, boundary tests, glossary note

## Verification

- Every existing `reconciliation-policy` case passes unchanged except the stale-date case, which moved to new boundary tests (`actual-client.test.ts`, 8 cases)
- Full suite: 130/130 passing; `tsc` clean; pre-push gates (oxfmt, oxlint, tests, Fallow) green

Fixes #382