### PR TITLE
ci: add self-hosted runner toggle via USE_SELF_HOSTED_RUNNERS

### DIFF
--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -19,7 +19,8 @@ jobs:
     if: >-
       (github.event_name != 'push' || github.ref_name == github.event.repository.default_branch) &&
       (github.event_name != 'issues' || github.event.issue.user.login == 'github-actions[bot]')
-    runs-on: ubuntu-latest
+    # USE_SELF_HOSTED_RUNNERS repo variable (Settings → Actions → Variables)
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest' }}
     permissions:
       # Creates and updates the frog/sync cleanup branch.
       contents: write

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,7 +15,8 @@ concurrency:
 jobs:
   check:
     name: Lint, format & test
-    runs-on: ubuntu-latest
+    # USE_SELF_HOSTED_RUNNERS repo variable (Settings → Actions → Variables)
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || (vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest') }}
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/pr-docker.yml
+++ b/.github/workflows/pr-docker.yml
@@ -11,7 +11,8 @@ concurrency:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-latest
+    # USE_SELF_HOSTED_RUNNERS repo variable (Settings → Actions → Variables)
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || (vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest') }}
     permissions:
       contents: read
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,8 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    # USE_SELF_HOSTED_RUNNERS repo variable (Settings → Actions → Variables)
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest' }}
     permissions:
       contents: read
     env:

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -29,39 +29,3 @@ jobs:
         uses: pullfrog/pullfrog@9397c1a891ef1fb961807498e12d2891bcd934a7 # v0.1.53
         with:
           prompt: ${{ inputs.prompt }}
-        env:
-          # add at least one provider API key
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY:
-            ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-          MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          
-          # for Amazon Bedrock (https://docs.pullfrog.com/bedrock)
-          # AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
-          # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # AWS_REGION: us-east-1
-          # BEDROCK_MODEL_ID: <bedrock-model-id>
-          
-          # for Google Vertex AI (https://docs.pullfrog.com/vertex)
-          # VERTEX_SERVICE_ACCOUNT_JSON: >-
-          #   ${{ secrets.VERTEX_SERVICE_ACCOUNT_JSON }}
-          # GOOGLE_CLOUD_PROJECT: my-project
-          # VERTEX_LOCATION: global
-          # VERTEX_MODEL_ID: <vertex-model-id>
-
-          # for any OpenAI-compatible endpoint — LiteLLM, Cloudflare AI Gateway,
-          # self-hosted vLLM (https://docs.pullfrog.com/openai-compatible)
-          # OPENAI_COMPATIBLE_BASE_URL: https://litellm.example.com/v1
-          # OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
-          # OPENAI_COMPATIBLE_MODEL: <model-id>
-          # both limits are required — set them to the real limits of that model
-          # OPENAI_COMPATIBLE_CONTEXT: "128000"
-          # OPENAI_COMPATIBLE_MAX_OUTPUT: "16384"

--- a/.github/workflows/renovate-actual-api-auto-merge.yml
+++ b/.github/workflows/renovate-actual-api-auto-merge.yml
@@ -13,7 +13,8 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    runs-on: ubuntu-latest
+    # USE_SELF_HOSTED_RUNNERS repo variable (Settings → Actions → Variables)
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || (vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest') }}
     if: github.event.pull_request.user.login == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository
 
     steps:

--- a/.github/workflows/renovate-actual-api-auto-merge.yml
+++ b/.github/workflows/renovate-actual-api-auto-merge.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   enable-auto-merge:
     # USE_SELF_HOSTED_RUNNERS repo variable (Settings → Actions → Variables)
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || (vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest') }}
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest' }}
     if: github.event.pull_request.user.login == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository
 
     steps:

--- a/.github/workflows/renovate-actual-api-release.yml
+++ b/.github/workflows/renovate-actual-api-release.yml
@@ -11,7 +11,8 @@ permissions:
 
 jobs:
   create-release:
-    runs-on: ubuntu-latest
+    # USE_SELF_HOSTED_RUNNERS repo variable (Settings → Actions → Variables)
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || (vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest') }}
     if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository
 
     steps:

--- a/.github/workflows/renovate-actual-api-release.yml
+++ b/.github/workflows/renovate-actual-api-release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   create-release:
     # USE_SELF_HOSTED_RUNNERS repo variable (Settings → Actions → Variables)
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || (vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest') }}
+    runs-on: ${{ vars.USE_SELF_HOSTED_RUNNERS == 'true' && (vars.SELF_HOSTED_RUNNER_LABELS != '' && fromJSON(vars.SELF_HOSTED_RUNNER_LABELS) || fromJSON('["self-hosted"]')) || 'ubuntu-latest' }}
     if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository
 
     steps:


### PR DESCRIPTION
## Summary

Adds a repo-level `USE_SELF_HOSTED_RUNNERS` toggle so workflows can route jobs to self-hosted runners without editing workflow files. The pullfrog workflow is kept, now running without provider API keys.

### runs-on conversions
- `pr-check.yml`, `pr-docker.yml`, `publish.yml`, `renovate-actual-api-auto-merge.yml`, `renovate-actual-api-release.yml`, `friction-log.yml`: hardcoded labels → the `USE_SELF_HOSTED_RUNNERS` expression (fallback preserves the original label).
- Set `USE_SELF_HOSTED_RUNNERS=true` to route jobs to self-hosted runners. `SELF_HOSTED_RUNNER_LABELS` is an optional JSON array of labels, e.g. `["self-hosted", "linux"]` (default `["self-hosted"]`); it must be valid JSON, not a plain label. Unset/false keeps GitHub-hosted runners.

### Fork PRs (defense-in-depth, not a security boundary)
- `pr-check.yml` and `pr-docker.yml` keep fork pull requests on GitHub-hosted runners via `github.event.pull_request.head.repo.fork`. This only stops honest/accidental fork jobs: a malicious fork controls its own workflow file on `pull_request` events, so it could strip the guard. The real boundary is runner registration scope (repo-level, or org-level restricted to approved repositories) and treating the runner machine as untrusted.

### Pullfrog
- `.github/workflows/pullfrog.yml` is kept, with the provider API-key `env:` block removed. Pullfrog runs on its own bundled keys, so the repo no longer injects secrets into the action. It stays on `ubuntu-latest` and is unaffected by the toggle.

### How to flip it
Register and label a self-hosted runner **before** setting the variable — jobs queue until a runner with matching labels appears and fail after ~24h otherwise.

```bash
gh variable set USE_SELF_HOSTED_RUNNERS -b true -R samaluk/fintual-api
```
