### PR TITLE
chore(renovate): group Effect packages into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,14 @@
 	"packageRules": [
 		{
 			"matchPackageNames": [
+				"effect",
+				"@effect/platform-node",
+				"@effect/vitest"
+			],
+			"groupName": "Effect packages"
+		},
+		{
+			"matchPackageNames": [
 				"mcuadros/ofelia"
 			],
 			"allowedVersions": "!/^v3\\.0\\.8$/"


### PR DESCRIPTION
## Why

Renovate raises three separate PRs whenever Effect releases a new beta
(effect, @effect/platform-node, @effect/vitest). Effect v4 beta packages are
released in lockstep from a single repository ("One Version, One Ecosystem"),
so they should be updated together.

Renovate's built-in monorepo grouping for Effect (`repoGroups` entry pointing
at Effect-TS/effect-smol) no longer matches the npm source URL: the beta
packages switched their npm `repository` metadata back to Effect-TS/effect
starting at 4.0.0-beta.99 (2026-07-17). Grouping locally through the config
avoids depending on an upstream fix.

## What

Add a `groupName` package rule for `effect`, `@effect/platform-node`, and
`@effect/vitest` so future updates land as a single PR.

`@effect/tsgo` is intentionally excluded: it lives in its own repository and
follows a different version train.