### PR TITLE
chore(fallow): adopt near-miss duplication detection

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -23,6 +23,7 @@
   },
   "duplicates": {
     "mode": "semantic",
+    "near": true,
     "minLines": 8,
     "minTokens": 60,
     "minOccurrences": 3,

--- a/docs/fallow.md
+++ b/docs/fallow.md
@@ -7,7 +7,7 @@
 `.fallowrc.json` declares the analysis surface and the audit gate:
 
 - `entry` — runtime entry points (`src/once.ts`, `bin/**/*.mjs`)
-- `duplicates` — semantic mode, `minLines: 8`, `minTokens: 60`, `minOccurrences: 3`
+- `duplicates` — semantic mode with near-miss detection, `minLines: 8`, `minTokens: 60`, `minOccurrences: 3`
 - `health` — cyclomatic (13), cognitive (16), CRAP (157), unit size (60)
 - `audit` — `gate: new-only` with baselines for dead code, health, and duplication; scoped to `origin/main` via `FALLOW_AUDIT_BASE` so local runs match CI (the branch's own upstream would exclude files changed in earlier pushes)
 - `typeAware` — TypeScript semantic analysis (symbol use, API surface, type coupling) runs for `dead-code`, `health`, `fix`, and the audit gate


### PR DESCRIPTION
Stacks on #393 (fallow 3.15.0), which added `duplicates.near` for detecting function-scoped clones with small structural edits.

Adopts the new config:

- `.fallowrc.json` — enable `duplicates.near: true` alongside the existing semantic mode
- `docs/fallow.md` — sync the config summary

`fallow dupes` with near detection reports no clone groups, so `fallow-baselines/dupes.json` is unchanged and the `new-only` audit gate still passes.