### PR TITLE
ci: run docker build on PRs to any base branch

### DIFF
--- a/.github/workflows/pr-docker.yml
+++ b/.github/workflows/pr-docker.yml
@@ -2,8 +2,6 @@ name: PR Docker
 
 on:
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: pr-docker-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The PR Docker workflow filters `pull_request` to base `main`, so stacked PRs targeting dependency-update branches (e.g. #396 on top of #393) never get a `docker-build` check.

Dropping the filter makes every PR build the image; rebase the stack after merge to pick it up.