### PR TITLE
ci: parallelize checks and require fallow review

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,9 +13,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
-    # Keep this stable: the main-branch ruleset requires this exact check name.
-    name: Lint, format & test
+  # Static quality checks, tests, and the two Fallow passes run as parallel jobs
+  # so pull requests go green as fast as possible. Each is its own required
+  # status check (the main-branch ruleset lists these exact names), so every one
+  # must pass for a merge.
+  static:
+    name: Lint, typecheck & format
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -26,26 +29,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: .node-version
-
-      - name: Read pnpm version
-        id: pnpm
-        run: |
-          version="$(node -p "require('./package.json').packageManager.replace(/^pnpm@/, '')")"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Install pnpm
+      - name: Setup pnpm and Node.js
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          version: ${{ steps.pnpm.outputs.version }}
+          runtime: node
           cache: true
-          install: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm lint
@@ -56,21 +44,74 @@ jobs:
       - name: Format check
         run: pnpm format:check
 
-      # Generates coverage/coverage-final.json; fallow health/CRAP and the
-      # audit gate below consume it, so tests must run first.
+  test:
+    name: Test with coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          runtime: node
+          cache: true
+
+      # Generates coverage/coverage-final.json; both Fallow jobs consume it, so
+      # tests must run before they start.
       - name: Test with coverage
         run: pnpm test:coverage
 
-      # Authoritative Fallow gate: strict changed-file audit plus strict
-      # project-wide dead-code, duplication, and health checks. Mirrors
-      # `pnpm fallow:ci` run locally.
+      # Shared with the two Fallow jobs below so they do not reinstall and
+      # re-run the suite just to score the same evidence.
+      - name: Upload coverage
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage
+          path: coverage/coverage-final.json
+          if-no-files-found: error
+          retention-days: 1
+
+  gate:
+    name: Fallow gate
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup pnpm and Node.js
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        with:
+          runtime: node
+          cache: true
+
+      - name: Download coverage
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: coverage
+          path: coverage
+
+      # Authoritative strict Fallow gate: changed-file audit plus project-wide
+      # dead-code, duplication, and health checks. Mirrors `pnpm fallow:ci`.
       - name: Fallow CI gate
         run: pnpm fallow:ci
         env:
           FALLOW_AUDIT_BASE: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || 'origin/main' }}
 
-  fallow:
+  review:
     name: Fallow PR review
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -85,30 +126,25 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: .node-version
-
-      - name: Read pnpm version
-        id: pnpm
-        run: |
-          version="$(node -p "require('./package.json').packageManager.replace(/^pnpm@/, '')")"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Install pnpm
+      - name: Setup pnpm and Node.js
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          version: ${{ steps.pnpm.outputs.version }}
+          runtime: node
           cache: true
-          install: false
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      # Fallow installs its CLI globally with npm. The runtime managed by
+      # pnpm/setup can use a different npm prefix, so expose that bin directory.
+      - name: Expose npm global binaries
+        run: echo "$(npm config get prefix)/bin" >> "$GITHUB_PATH"
 
-      # Same coverage evidence the check job uses, so audit CRAP scoring matches.
-      - name: Test with coverage
-        run: pnpm test:coverage
+      # Same coverage evidence the test job produced, so audit CRAP scoring
+      # matches — downloaded rather than regenerated to avoid a second
+      # install + test run.
+      - name: Download coverage
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: coverage
+          path: coverage
 
       # One authoritative audit: the Action analyzes once, then renders native
       # type-aware PR feedback from the saved JSON envelope — a sticky summary
@@ -116,7 +152,9 @@ jobs:
       # (`review-comments`). No second analysis, no SARIF. Code Scanning is not
       # used: its two-run upload needed manual splitting, and the Check Run,
       # summary comment, and review comments already surface the same findings
-      # on the PR. The check job owns the strict project-wide gates.
+      # on the PR. This job is a required check (fail-on-issues is on), so
+      # Fallow findings block the merge. The gate job owns the strict
+      # project-wide gates.
       - name: Fallow audit
         id: fallow
         # Pinned to the v3.17.0 release commit; the `version` input keeps the

--- a/docs/fallow.md
+++ b/docs/fallow.md
@@ -85,19 +85,21 @@ coverage-aware commands.
 
 ## CI and PR feedback
 
-`.github/workflows/pr-check.yml` has two complementary jobs:
+`.github/workflows/pr-check.yml` has four complementary jobs:
 
-- `Lint, format & test` runs lint, typecheck, format, tests with coverage, and
-  the authoritative `pnpm fallow:ci` gate.
+- `Lint, typecheck & format` runs the static checks.
+- `Test with coverage` runs the suite once and uploads the shared coverage
+  evidence.
+- `Fallow gate` runs the authoritative `pnpm fallow:ci` gate using that evidence.
 - `Fallow PR review` runs one type-aware, coverage-aware audit through the
   pinned official Action. Fallow 3.17 renders the saved JSON envelope natively
   as a compact sticky summary, a Check Run, inline review comments, and review
   guidance. It does not perform a second analysis and does not use SARIF or
   GitHub Code Scanning.
 
-Both jobs analyze with `gate: all`, semantic/near duplication, and the same
-Istanbul coverage evidence. The Action receives the GitHub workspace as
-`coverage-root`; native audit forwards the evidence to base analysis so HEAD
+The two Fallow jobs analyze with `gate: all`, semantic/near duplication, and
+the same Istanbul coverage evidence. The Action receives the GitHub workspace
+as `coverage-root`; native audit forwards the evidence to base analysis so HEAD
 and base use the same coverage model.
 
 ## Git hooks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
 	"name": "fintual-api",
 	"packageManager": "pnpm@11.21.0",
+	"devEngines": {
+		"runtime": {
+			"name": "node",
+			"version": "24.19.0",
+			"onFail": "download"
+		}
+	},
 	"type": "module",
 	"devDependencies": {
 		"@effect/tsgo": "0.36.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       fallow:
         specifier: 3.17.0
         version: 3.17.0
+      node:
+        specifier: runtime:24.19.0
+        version: runtime:24.19.0
       oxfmt:
         specifier: 0.63.0
         version: 0.63.0
@@ -1225,6 +1228,127 @@ packages:
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+
+  node@runtime:24.19.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-9ONcExZd5ogMqiVYwKpIyoitpH/iI0vtB9Ztu4CkfI0=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-gpS3qpsDmXSBwGur8eiycMhZNY8n2lehFQmv5TesOB0=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-0bXpmdsVjGL+j3JnpEdrA12L2TsaYFusJKPw3RZuMxY=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-0oyKW/CoCPDtQ0odzoxUrpjwNxwL2GrFirxhP3PmZD8=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-sxqMTLxYn5FS8y/bQxhGl1nhZViltdk7f/L7KHsBPbI=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-s6tqQ5KCjbn9TtloOY1VGIKSvMFYGVQtU74LEQDjMvw=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-9iXZfNcH30/5YlSRb7xf8BTwnAnv/loeDKj21BqHidQ=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-hQL0pQtFjUzDjtjyABVWws0jnUZJIPdAF5Jsyx4cFX8=
+            prefix: node-v24.19.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-V/cas2UueX2ErN3HnIHMn/HG3bKhl0zbg/AP7pv/THM=
+            prefix: node-v24.19.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-IIJOTTWUj65bM33M70eBOwTYmVMS9Z33OG8iVtn5q34=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64-musl.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+              libc: musl
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-xgIjeG3xSl0j4iDruOYDGPUyJkCmL5Dm2eVNOhjaUy4=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+    version: 24.19.0
     hasBin: true
 
   nodemailer@9.0.5:
@@ -2488,6 +2612,8 @@ snapshots:
     dependencies:
       detect-libc: 2.1.2
     optional: true
+
+  node@runtime:24.19.0: {}
 
   nodemailer@9.0.5: {}
 


### PR DESCRIPTION
## Summary

Parallelizes the CI workflow and makes the Fallow PR review a required check.

The single sequential `check` job previously ran `lint → typecheck → format → test:coverage → fallow:ci` on one runner. It is now split into parallel jobs, each a required status check, so pull requests go green sooner. The two Fallow passes reuse the test job's coverage artifact instead of reinstalling and re-running the suite a second time.

## Changes

- **`Lint, typecheck & format`** — static checks, runs in parallel with tests.
- **`Test with coverage`** — runs the suite once and uploads `coverage/coverage-final.json` as a short-lived artifact.
- **`Fallow gate`** — strict `pnpm fallow:ci` (audit + dead-code + dupes + health), consumes the shared coverage.
- **`Fallow PR review`** — the Fallow action (`fail-on-issues` is on). Now a **required** check, so Fallow findings block merges.
- **`docker-build`** — unchanged.

The main-branch ruleset was updated via the GitHub API (not a repo file) to require `Lint, typecheck & format`, `Test with coverage`, `Fallow gate`, and `Fallow PR review` alongside the existing `docker-build`, replacing the old required `Lint, format & test` check.

## Why

This removes a full duplicate install + test run on every PR, and moves lint/typecheck/format off the critical path (they now run concurrently with tests). Making Fallow review required ensures findings gate merges rather than merely annotating.

No runtime code changed.