### PR TITLE
keep Pullfrog on major-version tags

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run agent
-        uses: pullfrog/pullfrog@991f983efe1f4d9a04406f7a9fcc9a62780705f4 # v0.1.56
+        uses: pullfrog/pullfrog@v0
         with:
           prompt: ${{ inputs.prompt }}
         env:

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,13 @@
 			"minimumReleaseAge": "0 days",
 			"automerge": true,
 			"platformAutomerge": true
+		},
+		{
+			"description": "Keep Pullfrog on major-version tags",
+			"matchDepTypes": ["action"],
+			"matchPackageNames": ["pullfrog/pullfrog"],
+			"pinDigests": false,
+			"rangeStrategy": "replace"
 		}
 	]
 }


### PR DESCRIPTION
## Summary
- switch `pullfrog/pullfrog` to the documented `@v0` major tag
- retain digest pinning for every other GitHub Action
- add a Pullfrog-only Renovate exception while preserving the existing Effect, Ofelia, and Actual API rules

## Why
Pullfrog's documented workflow uses the mutable major tag. This lets patch/minor Pullfrog releases flow through `v0`, while Renovate only needs to edit the workflow for a future major.

## Validation
- Pullfrog workflow behavior and provider configuration are unchanged
- global `helpers:pinGitHubActionDigests` remains enabled
- existing Renovate package rules are preserved