### PR TITLE
refactor: replace dotenv with native Effect ConfigProvider

### DIFF
--- a/bin/capture-fintual-har.sh
+++ b/bin/capture-fintual-har.sh
@@ -14,7 +14,7 @@ if ! command -v agent-browser >/dev/null 2>&1; then
 	exit 1
 fi
 
-# Load only FINTUAL_* from .env via dotenv (single-quoted values so $ in passwords is not expanded).
+# Load only FINTUAL_* from .env (single-quoted values so $ in passwords is not expanded).
 if [ -f .env ]; then
 	# shellcheck disable=SC1090
 	eval "$(node "$ROOT_DIR/bin/load-fintual-env-for-capture.mjs")"

--- a/bin/load-fintual-env-for-capture.mjs
+++ b/bin/load-fintual-env-for-capture.mjs
@@ -1,16 +1,31 @@
 /**
  * Prints `export VAR='...'` lines for capture script (single-quoted values).
  */
-import { config } from "dotenv"
-import { resolve } from "node:path"
+import { NodeFileSystem } from "@effect/platform-node"
+import { ConfigProvider, Effect } from "effect"
 
 function shSingleQuoted(value) {
 	return "'" + value.replace(/'/g, "'\\''") + "'"
 }
 
-config({ path: resolve(process.cwd(), ".env"), quiet: true })
-const keys = ["FINTUAL_USER_EMAIL", "FINTUAL_USER_PASSWORD", "FINTUAL_GOAL_ID"]
-for (const k of keys) {
-	const v = process.env[k]
-	if (v != null && v !== "") process.stdout.write(`export ${k}=${shSingleQuoted(v)}\n`)
-}
+const dotEnv = ConfigProvider.fromDotEnv().pipe(
+	Effect.provide(NodeFileSystem.layer),
+	Effect.orElseSucceed(() => ConfigProvider.fromUnknown({})),
+)
+
+const exportKey = (provider, key) =>
+	Effect.gen(function* () {
+		const node = yield* provider.load([key])
+		if (node?.value) {
+			process.stdout.write(`export ${key}=${shSingleQuoted(node.value)}\n`)
+		}
+	})
+
+const program = Effect.gen(function* () {
+	const provider = ConfigProvider.orElse(ConfigProvider.fromEnv(), yield* dotEnv)
+	yield* Effect.forEach(["FINTUAL_USER_EMAIL", "FINTUAL_USER_PASSWORD", "FINTUAL_GOAL_ID"], (key) =>
+		exportKey(provider, key),
+	)
+})
+
+Effect.runPromise(program)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 	"dependencies": {
 		"@actual-app/api": "26.8.1",
 		"@effect/platform-node": "4.0.0-rc.109",
-		"dotenv": "17.4.2",
 		"effect": "4.0.0-rc.109",
 		"imapflow": "1.7.1",
 		"mailparser": "3.9.15"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@effect/platform-node':
         specifier: 4.0.0-rc.109
         version: 4.0.0-rc.109(effect@4.0.0-rc.109)(redis@6.2.1)
-      dotenv:
-        specifier: 17.4.2
-        version: 17.4.2
       effect:
         specifier: 4.0.0-rc.109
         version: 4.0.0-rc.109
@@ -932,10 +929,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dotenv@17.4.2:
-    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
-    engines: {node: '>=12'}
 
   effect@4.0.0-rc.109:
     resolution: {integrity: sha512-6ubcOCtfdbmFO5+vgcT2HsTw5s+n3aMUj4eAIbVpUxP7+VYCwXxxcBHgiWgizOrGO1eGmuOBFek3mM0dFcwaWA==}
@@ -2329,8 +2322,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  dotenv@17.4.2: {}
 
   effect@4.0.0-rc.109:
     dependencies:

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -285,14 +285,3 @@ it.effect("ignores email 2FA settings when automatic retrieval is disabled", () 
     expect(configuration.email2FA).toBeNull()
   }),
 )
-
-it.effect("supports resolving runtime config without explicit environment", () =>
-  Effect.gen(function* () {
-    const result = yield* Effect.result(resolveRuntimeConfig())
-    if (Result.isFailure(result)) {
-      expect(result.failure).toBeInstanceOf(RuntimeConfigError)
-    } else {
-      expect(result.success.actual.serverUrl).toBeDefined()
-    }
-  }),
-)

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -285,3 +285,14 @@ it.effect("ignores email 2FA settings when automatic retrieval is disabled", () 
     expect(configuration.email2FA).toBeNull()
   }),
 )
+
+it.effect("supports resolving runtime config without explicit environment", () =>
+  Effect.gen(function* () {
+    const result = yield* Effect.result(resolveRuntimeConfig())
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(RuntimeConfigError)
+    } else {
+      expect(result.success.actual.serverUrl).toBeDefined()
+    }
+  }),
+)

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,3 +1,4 @@
+import { NodeFileSystem } from "@effect/platform-node"
 import {
   Config,
   ConfigProvider,
@@ -78,18 +79,12 @@ export interface RuntimeConfig {
 export type Environment = Readonly<Record<string, string | undefined>>
 
 export const resolveRuntimeConfig = Effect.fn("RuntimeConfig.resolveRuntimeConfig")(function* (
-  environment: Environment,
+  environment?: Environment,
 ): Effect.fn.Return<RuntimeConfig, RuntimeConfigError> {
-  const provider = ConfigProvider.fromUnknown(
-    Object.fromEntries(
-      Object.entries(environment).flatMap(([name, value]) =>
-        value === undefined || (value === "" && !isGmailCredential(name))
-          ? []
-          : [[name, normalizeEnvValue(value)]],
-      ),
-    ),
-    { preserveEmptyStrings: true },
-  )
+  const provider =
+    environment !== undefined
+      ? configProviderFromEnvironment(environment)
+      : yield* liveConfigProvider
   const values = yield* runtimeValueConfig.pipe(
     Effect.provideService(ConfigProvider.ConfigProvider, provider),
     Effect.mapError(
@@ -124,6 +119,28 @@ export const resolveRuntimeConfig = Effect.fn("RuntimeConfig.resolveRuntimeConfi
     schedule: yield* resolveScheduleConfig(values),
   }
 })
+
+const liveConfigProvider = Effect.gen(function* () {
+  const dotEnvProvider = yield* ConfigProvider.fromDotEnv().pipe(
+    Effect.provide(NodeFileSystem.layer),
+    Effect.orElseSucceed(() => ConfigProvider.fromUnknown({})),
+  )
+  const envProvider = configProviderFromEnvironment(process.env)
+  return ConfigProvider.orElse(envProvider, dotEnvProvider)
+})
+
+function configProviderFromEnvironment(environment: Environment): ConfigProvider.ConfigProvider {
+  return ConfigProvider.fromUnknown(
+    Object.fromEntries(
+      Object.entries(environment).flatMap(([name, value]) =>
+        value === undefined || (value === "" && !isGmailCredential(name))
+          ? []
+          : [[name, normalizeEnvValue(value)]],
+      ),
+    ),
+    { preserveEmptyStrings: true },
+  )
+}
 
 const runtimeValueConfig = Config.all({
   actualServerUrl: Config.string("ACTUAL_SERVER_URL"),

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import { pathToFileURL } from "node:url"
 
 import { NodeRuntime } from "@effect/platform-node"
-import { config as loadDotEnv } from "dotenv"
 import { Effect, Option } from "effect"
 
 import { runApplication } from "./app.ts"
@@ -17,13 +16,11 @@ import {
 import { Job, type JobError } from "./job.ts"
 import { RedactingLogger, reportUnhandledFailure } from "./logging.ts"
 
-loadDotEnv()
-
 const main = Effect.fn("Main.main")(function* (): Effect.fn.Return<
   void,
   RuntimeConfigError | JobError
 > {
-  const runtimeConfig = yield* resolveRuntimeConfig(process.env).pipe(
+  const runtimeConfig = yield* resolveRuntimeConfig().pipe(
     Effect.tapCause((cause) =>
       reportUnhandledFailure(cause).pipe(Effect.provide(RedactingLogger.empty)),
     ),


### PR DESCRIPTION
## Summary

Replaces the external `dotenv` dependency with Effect's native `ConfigProvider` APIs (`ConfigProvider.fromDotEnv`, `ConfigProvider.fromEnv`, and `ConfigProvider.orElse`).

## Changes

1. **Runtime Configuration (`src/env.ts`, `src/main.ts`):**
   - Updated `resolveRuntimeConfig` to accept optional `environment?: Environment`.
   - When `environment` is omitted (CLI entrypoint), resolves via a live provider that attempts to load `.env` via `ConfigProvider.fromDotEnv()` (backed by `NodeFileSystem.layer`) falling back to an empty provider if not present, and merges with `ConfigProvider.fromEnv()`.
   - When `environment` is provided (e.g. unit tests), resolves from the supplied record deterministically.
   - Removed `import { config as loadDotEnv } from "dotenv"` and `loadDotEnv()` from `src/main.ts`.

2. **HAR Capture Script (`bin/load-fintual-env-for-capture.mjs`, `bin/capture-fintual-har.sh`):**
   - Migrated `bin/load-fintual-env-for-capture.mjs` to load credentials using Effect's `ConfigProvider`.
   - Updated comments in `bin/capture-fintual-har.sh`.

3. **Dependencies (`package.json`, `pnpm-lock.yaml`):**
   - Removed `dotenv` from `dependencies`.

## Commits

- `516c3ab` `refactor(config): use native Effect ConfigProvider for runtime env and dotenv loading`
- `2ba5b17` `chore(deps): remove dotenv and migrate scripts to Effect ConfigProvider`