### PR TITLE
refactor: remove startup shell scripts in favor of package.json scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV RUN_MODE=schedule
 
+RUN corepack enable
+
 COPY --from=deps /app/node_modules ./node_modules
 
 COPY . .
 
-RUN chmod +x ./bin/run-sync.sh ./bin/run-schedule.sh
-
-CMD ["./bin/run-schedule.sh"]
+CMD ["pnpm", "schedule"]

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The local compose file keeps the worker container idle so you can run the sync m
 
 ```bash
 docker compose --env-file .compose.env up -d --build
-docker exec -it fintual-api-local ./bin/run-sync.sh
+docker exec -it fintual-api-local pnpm once
 ```
 
 The compose stack also starts `ofelia`, so you can test the scheduled `job-exec` path and inspect scheduler logs:
@@ -199,7 +199,7 @@ Useful commands while debugging:
 docker logs -f fintual-api-local
 docker logs -f fintual-api-ofelia
 docker exec -it fintual-api-local sh
-docker exec -it fintual-api-local ./bin/run-sync.sh
+docker exec -it fintual-api-local pnpm once
 docker compose --env-file .compose.env down
 ```
 
@@ -246,14 +246,14 @@ Starting with the v3 major, the image default command runs the in-process
 scheduler instead of a one-shot sync. This is a breaking change to the
 container process contract:
 
-- The default command (`bin/run-schedule.sh`) no longer exits after one sync.
+- The default command (`pnpm schedule`) no longer exits after one sync.
   It runs the synchronization on the configured `SYNC_CRON` schedule until the
   process is interrupted (for example, SIGTERM).
 - The previous invocation contract is not preserved: there is no
   retro-compatibility shim, and images published under the v3 major and later
   do not accept the old invocation.
 - One-shot invocations remain available explicitly via `RUN_MODE=once` or
-  `bin/run-sync.sh`, for manual `docker exec` diagnostics and CI-style runs.
+  `pnpm once`, for manual `docker exec` diagnostics and CI-style runs.
 
 Publish the breaking change under a new major version tag (for example, `v3.0.0`);
 do not publish it under an existing v2 tag, because `latest` follows GitHub

--- a/bin/run-schedule.sh
+++ b/bin/run-schedule.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-set -eu
-
-exec env RUN_MODE=schedule node src/main.ts

--- a/bin/run-sync.sh
+++ b/bin/run-sync.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-set -eu
-
-exec env RUN_MODE=once node src/main.ts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     labels:
       ofelia.enabled: "true"
       ofelia.job-exec.fintual-sync.schedule: "${OFELIA_SYNC_SCHEDULE:-0 0 21 * * 1-5}"
-      ofelia.job-exec.fintual-sync.command: "./bin/run-sync.sh"
+      ofelia.job-exec.fintual-sync.command: "pnpm once"
       ofelia.job-exec.fintual-sync.no-overlap: "true"
     restart: unless-stopped
 

--- a/docs/adr/0006-in-process-effect-scheduler.md
+++ b/docs/adr/0006-in-process-effect-scheduler.md
@@ -26,7 +26,7 @@ The application exposes two run modes selected from environment configuration:
 
 The once and schedule modes share one Effect-native process entrypoint. The
 `RUN_MODE` value selects the application program after configuration is decoded;
-`bin/run-sync.sh` and `bin/run-schedule.sh` both invoke `src/main.ts` with their
+`pnpm once` and `pnpm schedule` both invoke `src/main.ts` with their
 respective mode explicitly. This keeps the deployment distinction in
 environment configuration rather than maintaining parallel entry modules.
 
@@ -34,8 +34,8 @@ Schedule policy is decoded with Effect Config from `SYNC_CRON`, `SYNC_TIMEZONE`,
 and `SYNC_NO_OVERLAP`. The cron expression and IANA timezone are validated
 eagerly at config decode with `Cron.parse`, so an invalid schedule fails fast as
 a typed configuration error. The container image defaults to scheduler mode via
-`ENV RUN_MODE=schedule` and `bin/run-schedule.sh`; the one-shot path remains
-available as `bin/run-sync.sh` or `RUN_MODE=once`.
+`ENV RUN_MODE=schedule` and `pnpm schedule`; the one-shot path remains
+available as `pnpm once` or `RUN_MODE=once`.
 
 The scheduler core owns the recurring program and its testable timing,
 failure-continuation, interruption, and no-overlap behavior. The composition
@@ -66,7 +66,7 @@ deployment change.
   Keeping a compatibility shim would have to distinguish "one-shot by default"
   from "one-shot on request" across invocations and would have delayed the
   homelab migration without protecting any external consumer; the one-shot path
-  remains available explicitly via `RUN_MODE=once` and `bin/run-sync.sh`.
+  remains available explicitly via `RUN_MODE=once` and `pnpm once`.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

Removes redundant startup shell scripts (`bin/run-sync.sh` and `bin/run-schedule.sh`) that duplicated the existing `pnpm once` and `pnpm schedule` scripts in `package.json`. Updates `Dockerfile`, `docker-compose.yml`, `README.md`, and ADR 0006 to use the `pnpm` scripts directly.

## Changes

1. **Startup Scripts Removal & Docker Config:**
   - Deleted `bin/run-sync.sh` and `bin/run-schedule.sh`.
   - Updated `Dockerfile` to enable `corepack` in the runtime stage and set the default `CMD` to `["pnpm", "schedule"]`.
   - Updated `docker-compose.yml` to use `pnpm once` for the `ofelia` job execution command.

2. **Documentation & ADR Updates:**
   - Updated `README.md` to reference `pnpm once` and `pnpm schedule` instead of the shell script paths.
   - Updated `docs/adr/0006-in-process-effect-scheduler.md` to reference `pnpm once` and `pnpm schedule`.

## Commits

- `a8c6919` `refactor(docker): remove startup shell scripts in favor of package.json scripts`
- `85df799` `docs: replace startup shell script references with package.json scripts`