### PR TITLE
refactor: deepen ActualClient and collapse SDK shallowness

### DIFF
--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -20,7 +20,11 @@ vi.mock("@actual-app/api", () => actualApiMock)
 
 import { ActualSynchronization } from "./actual.ts"
 import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
-import { ActualInitializationFailure, ActualOperationFailure } from "./actual/actual-error.ts"
+import {
+  ActualInitializationFailure,
+  ActualInvalidStartingDate,
+  ActualOperationFailure,
+} from "./actual/actual-error.ts"
 import { ActualConfigService, type ActualConfig } from "./env.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
 
@@ -130,7 +134,6 @@ it.effect("the live Actual adapter preserves stable SDK network codes", () =>
         const client = yield* factory.acquire(CONFIG)
         return yield* client.reconcile(SNAPSHOT, {
           startingDate: CONFIG.startingDate,
-          startingTimestamp: Date.parse(`${CONFIG.startingDate}T00:00:00Z`),
           accountId: CONFIG.fintualAccount,
           payeeName: CONFIG.payee,
         })
@@ -261,7 +264,17 @@ it.effect("health-check timeout is controlled by the Effect Clock", () =>
 it.effect("rejects an invalid starting date with a non-retryable failure", () =>
   Effect.gen(function* () {
     const calls: string[] = []
-    const client = scriptedClient(calls)
+    const client = scriptedClient(calls, {
+      reconcile: (_snapshot, options) =>
+        options.startingDate === "not-a-date"
+          ? Effect.fail(
+              new ActualInvalidStartingDate({
+                startingDate: options.startingDate,
+                retryable: false,
+              }),
+            )
+          : Effect.succeed({ created: 1, updated: 0, deletedDuplicates: 0 }),
+    })
     const invalidConfig = { ...CONFIG, startingDate: "not-a-date" }
 
     const error = yield* Effect.flip(

--- a/src/actual.test.ts
+++ b/src/actual.test.ts
@@ -20,12 +20,7 @@ vi.mock("@actual-app/api", () => actualApiMock)
 
 import { ActualSynchronization } from "./actual.ts"
 import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
-import {
-  ActualBudgetDownloadFailure,
-  ActualInitializationFailure,
-  ActualTransactionCreationFailure,
-} from "./actual/actual-error.ts"
-import type { ExistingVariationTransaction } from "./actual/reconciliation-policy.ts"
+import { ActualInitializationFailure, ActualOperationFailure } from "./actual/actual-error.ts"
 import { ActualConfigService, type ActualConfig } from "./env.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
 
@@ -67,44 +62,25 @@ it.effect("synchronizes through one service and shuts down the Actual session on
 
     yield* synchronizationProgram([client], calls)
 
-    expect(calls).toEqual([
-      "health",
-      "download",
-      "transactions",
-      "payees",
-      "create:2026-01-05",
-      "sync",
-      "shutdown",
-    ])
+    expect(calls).toEqual(["health", "reconcile", "shutdown"])
   }),
 )
 
 it.effect("retries a failed mutation as a fresh Synchronization Attempt", () =>
   Effect.gen(function* () {
     const calls: string[] = []
-    const importedTransaction = {
-      id: "created-after-timeout",
-      date: "2026-01-05",
-      notes: "Variation",
-      payee: "payee-id",
-      imported_id: "fintual-variation:2026-01-05",
-    }
-    const secondAttemptTransactions: Array<typeof importedTransaction> = []
     const firstAttempt = scriptedClient(calls, {
-      create: (_accountId, transaction) => {
-        calls.push(`create:${transaction.date}`)
-        secondAttemptTransactions.push(importedTransaction)
-        return Effect.fail(
-          new ActualTransactionCreationFailure({
+      reconcile: () =>
+        Effect.gen(function* () {
+          calls.push("reconcile")
+          return yield* new ActualOperationFailure({
+            operation: "create_transaction",
             cause: { code: "network-failure" },
             retryable: true,
-          }),
-        )
-      },
+          })
+        }),
     })
-    const secondAttempt = scriptedClient(calls, {
-      transactions: secondAttemptTransactions,
-    })
+    const secondAttempt = scriptedClient(calls)
 
     const fiber = yield* Effect.forkChild(
       synchronizationProgram([firstAttempt, secondAttempt], calls),
@@ -112,21 +88,7 @@ it.effect("retries a failed mutation as a fresh Synchronization Attempt", () =>
     yield* TestClock.adjust("10 seconds")
     yield* Fiber.join(fiber)
 
-    expect(calls).toEqual([
-      "health",
-      "download",
-      "transactions",
-      "payees",
-      "create:2026-01-05",
-      "shutdown",
-      "health",
-      "download",
-      "transactions",
-      "payees",
-      "update:created-after-timeout",
-      "sync",
-      "shutdown",
-    ])
+    expect(calls).toEqual(["health", "reconcile", "shutdown", "health", "reconcile", "shutdown"])
   }),
 )
 
@@ -135,10 +97,11 @@ it.effect("does not retry a non-retryable Actual failure", () =>
     const calls: string[] = []
     const client: ActualClient = {
       ...scriptedClient(calls),
-      downloadBudget: () =>
+      reconcile: () =>
         Effect.gen(function* () {
-          calls.push("download")
-          return yield* new ActualBudgetDownloadFailure({
+          calls.push("reconcile")
+          return yield* new ActualOperationFailure({
+            operation: "download_budget",
             cause: { code: "budget-not-found" },
             retryable: false,
           })
@@ -148,10 +111,11 @@ it.effect("does not retry a non-retryable Actual failure", () =>
     const error = yield* Effect.flip(synchronizationProgram([client], calls))
 
     expect(error).toMatchObject({
-      _tag: "ActualBudgetDownloadFailure",
+      _tag: "ActualOperationFailure",
+      operation: "download_budget",
       retryable: false,
     })
-    expect(calls).toEqual(["health", "download", "shutdown"])
+    expect(calls).toEqual(["health", "reconcile", "shutdown"])
   }),
 )
 
@@ -164,7 +128,12 @@ it.effect("the live Actual adapter preserves stable SDK network codes", () =>
       Effect.gen(function* () {
         const factory = yield* ActualClientFactory
         const client = yield* factory.acquire(CONFIG)
-        return yield* client.downloadBudget(CONFIG.syncId)
+        return yield* client.reconcile(SNAPSHOT, {
+          startingDate: CONFIG.startingDate,
+          startingTimestamp: Date.parse(`${CONFIG.startingDate}T00:00:00Z`),
+          accountId: CONFIG.fintualAccount,
+          payeeName: CONFIG.payee,
+        })
       }).pipe(Effect.provide(ActualClientFactory.live)),
     )
 
@@ -172,7 +141,8 @@ it.effect("the live Actual adapter preserves stable SDK network codes", () =>
     expect(actualApiMock.init).toHaveBeenCalledWith(expect.objectContaining({ password: "secret" }))
     if (Result.isFailure(result)) {
       expect(result.failure).toMatchObject({
-        _tag: "ActualBudgetDownloadFailure",
+        _tag: "ActualOperationFailure",
+        operation: "download_budget",
         cause: { code: "network-failure" },
         retryable: true,
       })
@@ -288,41 +258,54 @@ it.effect("health-check timeout is controlled by the Effect Clock", () =>
   }),
 )
 
-it.effect("uses the Effect Clock for the transaction end date", () =>
+it.effect("rejects an invalid starting date with a non-retryable failure", () =>
   Effect.gen(function* () {
     const calls: string[] = []
-    const endingDates: string[] = []
-    const client = scriptedClient(calls, {
-      onTransactions: (_startDate, endDate) => endingDates.push(endDate),
+    const client = scriptedClient(calls)
+    const invalidConfig = { ...CONFIG, startingDate: "not-a-date" }
+
+    const error = yield* Effect.flip(
+      Effect.gen(function* () {
+        const service = yield* ActualSynchronization
+        yield* service.synchronize(SNAPSHOT)
+      }).pipe(
+        Effect.provide(ActualSynchronization.layer),
+        Effect.provideService(ActualConfigService, invalidConfig),
+        Effect.provideService(ActualClientFactory, {
+          acquire: () => Effect.succeed(client),
+        }),
+        Effect.provideService(FetchHttpClient.Fetch, async () => new Response("", { status: 200 })),
+      ),
+    )
+
+    expect(error).toMatchObject({
+      _tag: "ActualInvalidStartingDate",
+      startingDate: "not-a-date",
+      retryable: false,
     })
-
-    yield* TestClock.setTime(Date.parse("2026-02-03T12:00:00Z"))
-    yield* synchronizationProgram([client], calls)
-
-    expect(endingDates).toEqual(["2026-02-03"])
   }),
 )
 
 it.effect("shuts down the scoped Actual session when the workflow is interrupted", () =>
   Effect.gen(function* () {
     const calls: string[] = []
-    let resolveDownloadStarted!: () => void
-    const downloadStarted = new Promise<void>((resolve) => {
-      resolveDownloadStarted = resolve
+    let resolveReconcileStarted!: () => void
+    const reconcileStarted = new Promise<void>((resolve) => {
+      resolveReconcileStarted = resolve
     })
     const client = scriptedClient(calls, {
-      download: () =>
+      reconcile: () =>
         Effect.gen(function* () {
-          calls.push("download")
-          resolveDownloadStarted()
+          calls.push("reconcile")
+          resolveReconcileStarted()
           return yield* Effect.never
         }),
     })
     const fiber = yield* Effect.forkChild(synchronizationProgram([client], calls))
-    yield* Effect.promise(() => downloadStarted)
+    yield* Effect.promise(() => reconcileStarted)
     yield* Fiber.interrupt(fiber)
 
-    expect(calls).toEqual(["health", "download", "shutdown"])
+    expect(calls).toEqual(["health", "reconcile", "shutdown"])
   }),
 )
 
@@ -367,30 +350,22 @@ function synchronizationProgram(
 function scriptedClient(
   calls: string[],
   options: {
-    transactions?: ReadonlyArray<ExistingVariationTransaction>
-    create?: ActualClient["createTransaction"]
-    download?: ActualClient["downloadBudget"]
-    onTransactions?: (startDate: string, endDate: string) => void
+    reconcile?: ActualClient["reconcile"]
+    shutdown?: ActualClient["shutdown"]
   } = {},
 ): ActualClient {
   return {
-    downloadBudget: options.download ?? (() => Effect.sync(() => calls.push("download"))),
-    getTransactions: (_accountId, startDate, endDate) =>
+    reconcile:
+      options.reconcile ??
+      ((_snapshot, _opts) =>
+        Effect.sync(() => {
+          calls.push("reconcile")
+          return { created: 1, updated: 0, deletedDuplicates: 0 }
+        })),
+    shutdown:
+      options.shutdown ??
       Effect.sync(() => {
-        calls.push("transactions")
-        options.onTransactions?.(startDate, endDate)
-        return options.transactions ?? []
+        calls.push("shutdown")
       }),
-    getPayees: Effect.sync(() => {
-      calls.push("payees")
-      return [{ id: "payee-id", name: "Fintual" }]
-    }),
-    createTransaction:
-      options.create ??
-      ((_accountId, transaction) => Effect.sync(() => calls.push(`create:${transaction.date}`))),
-    updateTransaction: (id) => Effect.sync(() => calls.push(`update:${id}`)),
-    deleteTransaction: (id) => Effect.sync(() => calls.push(`delete:${id}`)),
-    sync: Effect.sync(() => calls.push("sync")),
-    shutdown: Effect.sync(() => calls.push("shutdown")),
   }
 }

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -3,15 +3,13 @@ import * as fs from "node:fs"
 import { Context, DateTime, Duration, Effect, Layer, Option, Schedule } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 
-import { ActualClientFactory, type ActualClient } from "./actual/actual-client.ts"
+import { ActualClientFactory, type ActualClient, type SyncCounts } from "./actual/actual-client.ts"
 import {
   ActualDataDirectoryFailure,
   ActualHealthCheckFailure,
   ActualInvalidStartingDate,
   type ActualError,
-  type ActualPayeesReadFailure,
 } from "./actual/actual-error.ts"
-import { planReconciliation } from "./actual/reconciliation-policy.ts"
 import { ActualConfigService, type ActualConfig } from "./env.ts"
 import { getErrorMessage } from "./logging.ts"
 import type { PerformanceSnapshot } from "./performance-snapshot.ts"
@@ -34,12 +32,6 @@ const actualRetrySchedule: ActualRetrySchedule = Schedule.max([
   ]),
   Schedule.recurs(MAX_SYNC_ATTEMPTS - 1),
 ]).pipe(Schedule.jittered, Schedule.setInputType<ActualError>())
-
-interface SyncCounts {
-  readonly created: number
-  readonly updated: number
-  readonly deletedDuplicates: number
-}
 
 export class ActualSynchronization extends Context.Service<
   ActualSynchronization,
@@ -106,10 +98,23 @@ const runActualSyncAttempt = Effect.fn("ActualSynchronization.attempt")(function
       yield* resetDataDirectory()
       yield* checkHealth(httpClient, config.serverUrl)
 
+      const startingDate = DateTime.make(config.startingDate)
+      if (Option.isNone(startingDate)) {
+        return yield* new ActualInvalidStartingDate({
+          startingDate: config.startingDate,
+          retryable: false,
+        })
+      }
+      const startingTimestamp = DateTime.toEpochMillis(startingDate.value)
+
       const client = yield* Effect.acquireRelease(clientFactory.acquire(config), closeActualClient)
 
-      yield* client.downloadBudget(config.syncId)
-      return yield* syncDailyVariationTransactions(client, config, snapshot)
+      return yield* client.reconcile(snapshot, {
+        startingDate: config.startingDate,
+        startingTimestamp,
+        accountId: config.fintualAccount,
+        payeeName: config.payee,
+      })
     }),
   )
 })
@@ -174,86 +179,6 @@ const checkHealth = Effect.fn("ActualSynchronization.checkHealth")(function* (
     cause: new Error(`health endpoint returned HTTP ${response.status}`),
     retryable: isRetryableStatus(response.status),
   })
-})
-
-const syncDailyVariationTransactions = Effect.fn(
-  "ActualSynchronization.syncDailyVariationTransactions",
-)(function* (
-  client: ActualClient,
-  config: ActualConfig,
-  snapshot: PerformanceSnapshot,
-): Effect.fn.Return<SyncCounts, ActualError> {
-  const endingDate = DateTime.formatIsoDateUtc(yield* DateTime.now)
-  const startingDate = DateTime.make(config.startingDate)
-
-  if (Option.isNone(startingDate)) {
-    return yield* new ActualInvalidStartingDate({
-      startingDate: config.startingDate,
-      retryable: false,
-    })
-  }
-
-  const startingTimestamp = DateTime.toEpochMillis(startingDate.value)
-  const balanceEntries = snapshot.balance.filter((entry) => entry.date >= startingTimestamp)
-  const transactions = yield* client.getTransactions(
-    config.fintualAccount,
-    config.startingDate,
-    endingDate,
-  )
-  const payeeId = yield* resolvePayeeId(client, config.payee)
-  const plan = planReconciliation({
-    balanceEntries,
-    existingTransactions: transactions,
-    payeeId,
-  })
-
-  for (const warning of plan.warnings) {
-    yield* Effect.logWarning(warning)
-  }
-
-  const syncCounts = {
-    created: 0,
-    updated: 0,
-    deletedDuplicates: 0,
-  }
-
-  for (const action of plan.actions) {
-    switch (action.type) {
-      case "create": {
-        yield* client.createTransaction(config.fintualAccount, action.transaction)
-        syncCounts.created += 1
-        break
-      }
-      case "update": {
-        yield* client.updateTransaction(action.id, action.transaction)
-        syncCounts.updated += 1
-        break
-      }
-      case "delete": {
-        yield* client.deleteTransaction(action.id)
-        syncCounts.deletedDuplicates += 1
-        break
-      }
-    }
-  }
-
-  yield* client.sync
-  return syncCounts
-})
-
-const resolvePayeeId = Effect.fn("ActualSynchronization.resolvePayeeId")(function* (
-  client: ActualClient,
-  configuredPayee: string,
-): Effect.fn.Return<string | undefined, ActualPayeesReadFailure> {
-  const payees = yield* client.getPayees
-  const payee = payees.find((candidate) => candidate.name === configuredPayee)
-
-  if (!payee) {
-    yield* Effect.logInfo("Configured payee not found")
-    return undefined
-  }
-
-  return payee.id
 })
 
 const closeActualClient = Effect.fn("ActualSynchronization.closeClient")(function* (

--- a/src/actual.ts
+++ b/src/actual.ts
@@ -1,13 +1,12 @@
 import * as fs from "node:fs"
 
-import { Context, DateTime, Duration, Effect, Layer, Option, Schedule } from "effect"
+import { Context, Duration, Effect, Layer, Schedule } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 
 import { ActualClientFactory, type ActualClient, type SyncCounts } from "./actual/actual-client.ts"
 import {
   ActualDataDirectoryFailure,
   ActualHealthCheckFailure,
-  ActualInvalidStartingDate,
   type ActualError,
 } from "./actual/actual-error.ts"
 import { ActualConfigService, type ActualConfig } from "./env.ts"
@@ -98,20 +97,10 @@ const runActualSyncAttempt = Effect.fn("ActualSynchronization.attempt")(function
       yield* resetDataDirectory()
       yield* checkHealth(httpClient, config.serverUrl)
 
-      const startingDate = DateTime.make(config.startingDate)
-      if (Option.isNone(startingDate)) {
-        return yield* new ActualInvalidStartingDate({
-          startingDate: config.startingDate,
-          retryable: false,
-        })
-      }
-      const startingTimestamp = DateTime.toEpochMillis(startingDate.value)
-
       const client = yield* Effect.acquireRelease(clientFactory.acquire(config), closeActualClient)
 
       return yield* client.reconcile(snapshot, {
         startingDate: config.startingDate,
-        startingTimestamp,
         accountId: config.fintualAccount,
         payeeName: config.payee,
       })

--- a/src/actual/actual-client.test.ts
+++ b/src/actual/actual-client.test.ts
@@ -72,7 +72,6 @@ const acquireClient = Effect.gen(function* () {
 const reconcileSnapshot = (client: ActualClient) =>
   client.reconcile(SNAPSHOT, {
     startingDate: CONFIG.startingDate,
-    startingTimestamp: Date.parse(`${CONFIG.startingDate}T00:00:00Z`),
     accountId: CONFIG.fintualAccount,
     payeeName: CONFIG.payee,
   })
@@ -187,6 +186,25 @@ it.effect("uses the Effect Clock for the transaction end date", () =>
       "2026-01-01",
       "2026-02-03",
     )
+  }),
+)
+
+it.effect("fails with a non-retryable failure on an invalid starting date", () =>
+  Effect.gen(function* () {
+    const client = yield* acquireClient
+    const failure = yield* Effect.flip(
+      client.reconcile(SNAPSHOT, {
+        startingDate: "not-a-date",
+        accountId: CONFIG.fintualAccount,
+        payeeName: CONFIG.payee,
+      }),
+    )
+
+    expect(failure).toMatchObject({
+      _tag: "ActualInvalidStartingDate",
+      startingDate: "not-a-date",
+      retryable: false,
+    })
   }),
 )
 

--- a/src/actual/actual-client.test.ts
+++ b/src/actual/actual-client.test.ts
@@ -1,20 +1,36 @@
 import { it } from "@effect/vitest"
 import { Effect, Redacted } from "effect"
+import { TestClock } from "effect/testing"
 import { afterEach, beforeEach, expect, vi } from "vitest"
 
 const actualApiMock = vi.hoisted(() => ({
   init: vi.fn(),
+  downloadBudget: vi.fn(),
   getTransactions: vi.fn(),
   getPayees: vi.fn(),
+  addTransactions: vi.fn(),
+  updateTransaction: vi.fn(),
+  deleteTransaction: vi.fn(),
+  sync: vi.fn(),
+  shutdown: vi.fn(),
 }))
 
 vi.mock("@actual-app/api", () => actualApiMock)
 
 import type { ActualConfig } from "../env.ts"
-import { ActualClientFactory } from "./actual-client.ts"
+import type { PerformanceSnapshot } from "../performance-snapshot.ts"
+import { ActualClientFactory, type ActualClient } from "./actual-client.ts"
 
 beforeEach(() => {
   actualApiMock.init.mockResolvedValue({})
+  actualApiMock.downloadBudget.mockResolvedValue({})
+  actualApiMock.getTransactions.mockResolvedValue([])
+  actualApiMock.getPayees.mockResolvedValue([{ id: "payee-1", name: "Fintual" }])
+  actualApiMock.addTransactions.mockResolvedValue({})
+  actualApiMock.updateTransaction.mockResolvedValue({})
+  actualApiMock.deleteTransaction.mockResolvedValue({})
+  actualApiMock.sync.mockResolvedValue({})
+  actualApiMock.shutdown.mockResolvedValue({})
 })
 
 afterEach(() => {
@@ -30,152 +46,185 @@ const CONFIG: ActualConfig = {
   payee: "Fintual",
 }
 
+const SNAPSHOT: PerformanceSnapshot = {
+  balance: [
+    {
+      date: Date.parse("2026-01-05T00:00:00Z"),
+      value: 1_100,
+      difference: 50,
+      real_difference: 12.49,
+    },
+  ],
+  deposits: [
+    {
+      date: Date.parse("2026-01-05T00:00:00Z"),
+      value: 1_000,
+      difference: 25,
+    },
+  ],
+}
+
 const acquireClient = Effect.gen(function* () {
   const factory = yield* ActualClientFactory
   return yield* factory.acquire(CONFIG)
 }).pipe(Effect.provide(ActualClientFactory.live))
 
-const canonicalImportedId = (date: string) => `fintual-variation:${date}`
-const numericImportedId = (date: string) => String(Date.parse(`${date}T00:00:00Z`))
+const reconcileSnapshot = (client: ActualClient) =>
+  client.reconcile(SNAPSHOT, {
+    startingDate: CONFIG.startingDate,
+    startingTimestamp: Date.parse(`${CONFIG.startingDate}T00:00:00Z`),
+    accountId: CONFIG.fintualAccount,
+    payeeName: CONFIG.payee,
+  })
 
-it.effect("decodes a canonical transaction row into a clean domain value", () =>
+it.effect("reconciles by downloading budget, planning, creating transactions, and syncing", () =>
   Effect.gen(function* () {
-    actualApiMock.getTransactions.mockResolvedValue([
-      {
-        id: "txn-1",
+    const client = yield* acquireClient
+    const counts = yield* reconcileSnapshot(client)
+
+    expect(counts).toEqual({ created: 1, updated: 0, deletedDuplicates: 0 })
+    expect(actualApiMock.downloadBudget).toHaveBeenCalledWith("sync-id")
+    expect(actualApiMock.getTransactions).toHaveBeenCalledWith(
+      "account-id",
+      "2026-01-01",
+      expect.any(String),
+    )
+    expect(actualApiMock.getPayees).toHaveBeenCalled()
+    expect(actualApiMock.addTransactions).toHaveBeenCalledWith("account-id", [
+      expect.objectContaining({
         date: "2026-01-05",
-        notes: "Variation",
-        payee: "payee-1",
-        imported_id: canonicalImportedId("2026-01-05"),
-        account: "account-id",
         amount: 1200,
-        category: "cat-1",
-      },
+        payee: "payee-1",
+        notes: "Variation",
+        imported_id: "fintual-variation:2026-01-05",
+      }),
     ])
+    expect(actualApiMock.sync).toHaveBeenCalled()
+  }),
+)
 
-    const client = yield* acquireClient
-    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
-
-    expect(transactions).toEqual([
+it.effect("updates canonical existing transactions and deletes legacy duplicates", () =>
+  Effect.gen(function* () {
+    actualApiMock.getTransactions.mockResolvedValue([
       {
-        id: "txn-1",
+        id: "legacy-1",
         date: "2026-01-05",
         notes: "Variation",
         payee: "payee-1",
-        imported_id: canonicalImportedId("2026-01-05"),
+        imported_id: String(Date.parse("2026-01-05T00:00:00Z")),
       },
-    ])
-  }),
-)
-
-it.effect(
-  "decodes a legacy numeric imported id to its date even when the date field is stale",
-  () =>
-    Effect.gen(function* () {
-      actualApiMock.getTransactions.mockResolvedValue([
-        { id: "txn-1", date: "2020-01-01", imported_id: numericImportedId("2026-01-05") },
-      ])
-
-      const client = yield* acquireClient
-      const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
-
-      expect(transactions).toEqual([
-        { id: "txn-1", date: "2026-01-05", imported_id: numericImportedId("2026-01-05") },
-      ])
-    }),
-)
-
-it.effect("falls back to the ISO date field when no imported id carries a date", () =>
-  Effect.gen(function* () {
-    actualApiMock.getTransactions.mockResolvedValue([{ id: "txn-1", date: "2026-01-05" }])
-
-    const client = yield* acquireClient
-    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
-
-    expect(transactions).toEqual([{ id: "txn-1", date: "2026-01-05" }])
-  }),
-)
-
-it.effect("falls back to the date field when the prefixed imported id has no valid date", () =>
-  Effect.gen(function* () {
-    actualApiMock.getTransactions.mockResolvedValue([
-      { id: "txn-1", date: "2026-01-06", imported_id: "fintual-variation:not-a-date" },
-    ])
-
-    const client = yield* acquireClient
-    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
-
-    expect(transactions).toEqual([
-      { id: "txn-1", date: "2026-01-06", imported_id: "fintual-variation:not-a-date" },
-    ])
-  }),
-)
-
-it.effect("drops rows whose date cannot be derived", () =>
-  Effect.gen(function* () {
-    actualApiMock.getTransactions.mockResolvedValue([
-      { id: "txn-1", date: "not-a-date", imported_id: "not-a-date" },
-      { id: "txn-2" },
-    ])
-
-    const client = yield* acquireClient
-    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
-
-    expect(transactions).toEqual([])
-  }),
-)
-
-it.effect("coalesces null SDK fields into well-formed domain values", () =>
-  Effect.gen(function* () {
-    actualApiMock.getTransactions.mockResolvedValue([
       {
-        id: "txn-1",
-        date: null,
-        notes: null,
-        payee: null,
-        imported_id: canonicalImportedId("2026-01-05"),
-      },
-    ])
-
-    const client = yield* acquireClient
-    const transactions = yield* client.getTransactions("account-id", "2026-01-01", "2026-01-31")
-
-    expect(transactions).toEqual([
-      {
-        id: "txn-1",
+        id: "canon-1",
         date: "2026-01-05",
-        payee: null,
-        imported_id: canonicalImportedId("2026-01-05"),
+        notes: "Variation",
+        payee: "payee-1",
+        imported_id: "fintual-variation:2026-01-05",
       },
+    ])
+
+    const client = yield* acquireClient
+    const counts = yield* reconcileSnapshot(client)
+
+    expect(counts).toEqual({ created: 0, updated: 1, deletedDuplicates: 1 })
+    expect(actualApiMock.updateTransaction).toHaveBeenCalledWith(
+      "canon-1",
+      expect.objectContaining({ date: "2026-01-05", amount: 1200 }),
+    )
+    expect(actualApiMock.deleteTransaction).toHaveBeenCalledWith("legacy-1")
+    expect(actualApiMock.sync).toHaveBeenCalled()
+  }),
+)
+
+it.effect("decodes a legacy numeric imported id to its date even when date field is stale", () =>
+  Effect.gen(function* () {
+    actualApiMock.getTransactions.mockResolvedValue([
+      {
+        id: "txn-1",
+        date: "2020-01-01",
+        notes: "Variation",
+        payee: "payee-1",
+        imported_id: String(Date.parse("2026-01-05T00:00:00Z")),
+      },
+    ])
+
+    const client = yield* acquireClient
+    const counts = yield* reconcileSnapshot(client)
+
+    expect(counts).toEqual({ created: 0, updated: 1, deletedDuplicates: 0 })
+    expect(actualApiMock.updateTransaction).toHaveBeenCalledWith(
+      "txn-1",
+      expect.objectContaining({ date: "2026-01-05", amount: 1200 }),
+    )
+  }),
+)
+
+it.effect("handles missing payee gracefully and still reconciles", () =>
+  Effect.gen(function* () {
+    actualApiMock.getPayees.mockResolvedValue([{ id: "other-payee", name: "Someone Else" }])
+
+    const client = yield* acquireClient
+    const counts = yield* reconcileSnapshot(client)
+
+    expect(counts).toEqual({ created: 1, updated: 0, deletedDuplicates: 0 })
+    expect(actualApiMock.addTransactions).toHaveBeenCalledWith("account-id", [
+      expect.objectContaining({
+        date: "2026-01-05",
+        payee: undefined,
+      }),
     ])
   }),
 )
 
-it.effect("fails with a non-retryable read failure on a malformed row", () =>
+it.effect("uses the Effect Clock for the transaction end date", () =>
+  Effect.gen(function* () {
+    yield* TestClock.setTime(Date.parse("2026-02-03T12:00:00Z"))
+
+    const client = yield* acquireClient
+    yield* reconcileSnapshot(client)
+
+    expect(actualApiMock.getTransactions).toHaveBeenCalledWith(
+      "account-id",
+      "2026-01-01",
+      "2026-02-03",
+    )
+  }),
+)
+
+it.effect("fails with a non-retryable failure on a malformed transaction row", () =>
   Effect.gen(function* () {
     actualApiMock.getTransactions.mockResolvedValue([{ date: "2026-01-05" }])
 
     const client = yield* acquireClient
-    const failure = yield* Effect.flip(
-      client.getTransactions("account-id", "2026-01-01", "2026-01-31"),
-    )
+    const failure = yield* Effect.flip(reconcileSnapshot(client))
 
     expect(failure).toMatchObject({
-      _tag: "ActualTransactionsReadFailure",
+      _tag: "ActualOperationFailure",
+      operation: "get_transactions",
       retryable: false,
     })
   }),
 )
 
-it.effect("decodes payee rows into clean values", () =>
+it.effect("fails with a retryable failure on network failure during download", () =>
   Effect.gen(function* () {
-    actualApiMock.getPayees.mockResolvedValue([
-      { id: "payee-1", name: "Fintual", transfer_acct: "acct-1", tombstone: false },
-    ])
+    actualApiMock.downloadBudget.mockRejectedValue({ code: "network-failure" })
 
     const client = yield* acquireClient
-    const payees = yield* client.getPayees
+    const failure = yield* Effect.flip(reconcileSnapshot(client))
 
-    expect(payees).toEqual([{ id: "payee-1", name: "Fintual" }])
+    expect(failure).toMatchObject({
+      _tag: "ActualOperationFailure",
+      operation: "download_budget",
+      retryable: true,
+    })
+  }),
+)
+
+it.effect("shuts down the Actual API cleanly", () =>
+  Effect.gen(function* () {
+    const client = yield* acquireClient
+    yield* client.shutdown
+
+    expect(actualApiMock.shutdown).toHaveBeenCalled()
   }),
 )

--- a/src/actual/actual-client.ts
+++ b/src/actual/actual-client.ts
@@ -1,10 +1,11 @@
 import * as api from "@actual-app/api"
-import { Context, DateTime, Effect, Layer, Predicate, Redacted, Schema } from "effect"
+import { Context, DateTime, Effect, Layer, Option, Predicate, Redacted, Schema } from "effect"
 
 import type { ActualConfig } from "../env.ts"
 import type { PerformanceSnapshot } from "../performance-snapshot.ts"
 import {
   ActualInitializationFailure,
+  ActualInvalidStartingDate,
   ActualOperationFailure,
   type ActualError,
 } from "./actual-error.ts"
@@ -31,7 +32,6 @@ export interface SyncCounts {
 
 export interface ActualReconcileOptions {
   readonly startingDate: string
-  readonly startingTimestamp: number
   readonly accountId: string
   readonly payeeName: string
 }
@@ -83,6 +83,15 @@ function makeActualClient(syncId: string): ActualClient {
       snapshot: PerformanceSnapshot,
       options: ActualReconcileOptions,
     ): Effect.fn.Return<SyncCounts, ActualError> {
+      const startingDate = DateTime.make(options.startingDate)
+      if (Option.isNone(startingDate)) {
+        return yield* new ActualInvalidStartingDate({
+          startingDate: options.startingDate,
+          retryable: false,
+        })
+      }
+      const startingTimestamp = DateTime.toEpochMillis(startingDate.value)
+
       yield* Effect.tryPromise({
         try: () => api.downloadBudget(syncId),
         catch: (cause) =>
@@ -121,9 +130,7 @@ function makeActualClient(syncId: string): ActualClient {
       }
       const payeeId = matchedPayee?.id
 
-      const balanceEntries = snapshot.balance.filter(
-        (entry) => entry.date >= options.startingTimestamp,
-      )
+      const balanceEntries = snapshot.balance.filter((entry) => entry.date >= startingTimestamp)
       const plan = planReconciliation({
         balanceEntries,
         existingTransactions: transactions,

--- a/src/actual/actual-client.ts
+++ b/src/actual/actual-client.ts
@@ -1,52 +1,47 @@
 import * as api from "@actual-app/api"
-import { Context, Effect, Layer, Predicate, Redacted, Schema } from "effect"
+import { Context, DateTime, Effect, Layer, Predicate, Redacted, Schema } from "effect"
 
 import type { ActualConfig } from "../env.ts"
+import type { PerformanceSnapshot } from "../performance-snapshot.ts"
 import {
-  ActualBudgetDownloadFailure,
-  ActualDuplicateDeletionFailure,
   ActualInitializationFailure,
-  ActualPayeesReadFailure,
-  ActualShutdownFailure,
-  ActualSyncFailure,
-  ActualTransactionCreationFailure,
-  ActualTransactionUpdateFailure,
-  ActualTransactionsReadFailure,
+  ActualOperationFailure,
+  type ActualError,
 } from "./actual-error.ts"
 import {
   VARIATION_IMPORTED_ID_PREFIX,
+  planReconciliation,
   type ExistingVariationTransaction,
-  type VariationTransactionInput,
 } from "./reconciliation-policy.ts"
 
 const ACTUAL_DATA_DIR = "./tmp/actual-data"
 
 type ActualInitConfig = Parameters<typeof api.init>[0]
 
-export interface ActualPayee {
+interface ActualPayee {
   readonly id: string
   readonly name: string
 }
 
+export interface SyncCounts {
+  readonly created: number
+  readonly updated: number
+  readonly deletedDuplicates: number
+}
+
+export interface ActualReconcileOptions {
+  readonly startingDate: string
+  readonly startingTimestamp: number
+  readonly accountId: string
+  readonly payeeName: string
+}
+
 export interface ActualClient {
-  readonly downloadBudget: (syncId: string) => Effect.Effect<void, ActualBudgetDownloadFailure>
-  readonly getTransactions: (
-    accountId: string,
-    startDate: string,
-    endDate: string,
-  ) => Effect.Effect<ReadonlyArray<ExistingVariationTransaction>, ActualTransactionsReadFailure>
-  readonly getPayees: Effect.Effect<ReadonlyArray<ActualPayee>, ActualPayeesReadFailure>
-  readonly createTransaction: (
-    accountId: string,
-    transaction: VariationTransactionInput,
-  ) => Effect.Effect<void, ActualTransactionCreationFailure>
-  readonly updateTransaction: (
-    id: string,
-    transaction: VariationTransactionInput,
-  ) => Effect.Effect<void, ActualTransactionUpdateFailure>
-  readonly deleteTransaction: (id: string) => Effect.Effect<void, ActualDuplicateDeletionFailure>
-  readonly sync: Effect.Effect<void, ActualSyncFailure>
-  readonly shutdown: Effect.Effect<void, ActualShutdownFailure>
+  readonly reconcile: (
+    snapshot: PerformanceSnapshot,
+    options: ActualReconcileOptions,
+  ) => Effect.Effect<SyncCounts, ActualError>
+  readonly shutdown: Effect.Effect<void, ActualOperationFailure>
 }
 
 export class ActualClientFactory extends Context.Service<
@@ -76,105 +71,142 @@ export class ActualClientFactory extends Context.Service<
             }),
         })
 
-        return ActualClientLive
+        return makeActualClient(config.syncId)
       }),
     }),
   )
 }
 
-const ActualClientLive: ActualClient = {
-  downloadBudget: Effect.fn("ActualClient.downloadBudget")(function* (syncId: string) {
-    yield* Effect.tryPromise({
-      try: () => api.downloadBudget(syncId),
+function makeActualClient(syncId: string): ActualClient {
+  return {
+    reconcile: Effect.fn("ActualClient.reconcile")(function* (
+      snapshot: PerformanceSnapshot,
+      options: ActualReconcileOptions,
+    ): Effect.fn.Return<SyncCounts, ActualError> {
+      yield* Effect.tryPromise({
+        try: () => api.downloadBudget(syncId),
+        catch: (cause) =>
+          new ActualOperationFailure({
+            operation: "download_budget",
+            cause,
+            retryable: isRetryableActualCause(cause),
+          }),
+      })
+
+      const endingDate = DateTime.formatIsoDateUtc(yield* DateTime.now)
+      const rows = yield* Effect.tryPromise({
+        try: () => api.getTransactions(options.accountId, options.startingDate, endingDate),
+        catch: (cause) =>
+          new ActualOperationFailure({
+            operation: "get_transactions",
+            cause,
+            retryable: isRetryableActualCause(cause),
+          }),
+      })
+      const transactions = yield* decodeTransactions(rows)
+
+      const payees = yield* Effect.tryPromise({
+        try: () => api.getPayees(),
+        catch: (cause) =>
+          new ActualOperationFailure({
+            operation: "get_payees",
+            cause,
+            retryable: isRetryableActualCause(cause),
+          }),
+      }).pipe(Effect.andThen(decodePayees))
+
+      const matchedPayee = payees.find((candidate) => candidate.name === options.payeeName)
+      if (!matchedPayee) {
+        yield* Effect.logInfo("Configured payee not found")
+      }
+      const payeeId = matchedPayee?.id
+
+      const balanceEntries = snapshot.balance.filter(
+        (entry) => entry.date >= options.startingTimestamp,
+      )
+      const plan = planReconciliation({
+        balanceEntries,
+        existingTransactions: transactions,
+        payeeId,
+      })
+
+      for (const warning of plan.warnings) {
+        yield* Effect.logWarning(warning)
+      }
+
+      const syncCounts = {
+        created: 0,
+        updated: 0,
+        deletedDuplicates: 0,
+      }
+
+      for (const action of plan.actions) {
+        switch (action.type) {
+          case "create": {
+            yield* Effect.tryPromise({
+              try: () => api.addTransactions(options.accountId, [action.transaction]),
+              catch: (cause) =>
+                new ActualOperationFailure({
+                  operation: "create_transaction",
+                  cause,
+                  retryable: isRetryableActualCause(cause),
+                }),
+            })
+            syncCounts.created += 1
+            break
+          }
+          case "update": {
+            yield* Effect.tryPromise({
+              try: () => api.updateTransaction(action.id, action.transaction),
+              catch: (cause) =>
+                new ActualOperationFailure({
+                  operation: "update_transaction",
+                  cause,
+                  retryable: isRetryableActualCause(cause),
+                }),
+            })
+            syncCounts.updated += 1
+            break
+          }
+          case "delete": {
+            yield* Effect.tryPromise({
+              try: () => api.deleteTransaction(action.id),
+              catch: (cause) =>
+                new ActualOperationFailure({
+                  operation: "delete_transaction",
+                  cause,
+                  retryable: isRetryableActualCause(cause),
+                }),
+            })
+            syncCounts.deletedDuplicates += 1
+            break
+          }
+        }
+      }
+
+      yield* Effect.tryPromise({
+        try: () => api.sync(),
+        catch: (cause) =>
+          new ActualOperationFailure({
+            operation: "sync",
+            cause,
+            retryable: isRetryableActualCause(cause),
+          }),
+      })
+
+      return syncCounts
+    }),
+
+    shutdown: Effect.tryPromise({
+      try: () => api.shutdown(),
       catch: (cause) =>
-        new ActualBudgetDownloadFailure({
+        new ActualOperationFailure({
+          operation: "shutdown",
           cause,
-          retryable: isRetryableActualCause(cause),
+          retryable: false,
         }),
-    })
-  }),
-
-  getTransactions: Effect.fn("ActualClient.getTransactions")(function* (
-    accountId: string,
-    startDate: string,
-    endDate: string,
-  ) {
-    const rows = yield* Effect.tryPromise({
-      try: () => api.getTransactions(accountId, startDate, endDate),
-      catch: (cause) =>
-        new ActualTransactionsReadFailure({
-          cause,
-          retryable: isRetryableActualCause(cause),
-        }),
-    })
-
-    return yield* decodeTransactions(rows)
-  }),
-
-  getPayees: Effect.tryPromise({
-    try: () => api.getPayees(),
-    catch: (cause) =>
-      new ActualPayeesReadFailure({
-        cause,
-        retryable: isRetryableActualCause(cause),
-      }),
-  }).pipe(
-    Effect.andThen((payees) => decodePayees(payees)),
-    Effect.withSpan("ActualClient.getPayees"),
-  ),
-
-  createTransaction: Effect.fn("ActualClient.createTransaction")(function* (
-    accountId: string,
-    transaction: VariationTransactionInput,
-  ) {
-    yield* Effect.tryPromise({
-      try: () => api.addTransactions(accountId, [transaction]),
-      catch: (cause) =>
-        new ActualTransactionCreationFailure({
-          cause,
-          retryable: isRetryableActualCause(cause),
-        }),
-    })
-  }),
-
-  updateTransaction: Effect.fn("ActualClient.updateTransaction")(function* (
-    id: string,
-    transaction: VariationTransactionInput,
-  ) {
-    yield* Effect.tryPromise({
-      try: () => api.updateTransaction(id, transaction),
-      catch: (cause) =>
-        new ActualTransactionUpdateFailure({
-          cause,
-          retryable: isRetryableActualCause(cause),
-        }),
-    })
-  }),
-
-  deleteTransaction: Effect.fn("ActualClient.deleteTransaction")(function* (id: string) {
-    yield* Effect.tryPromise({
-      try: () => api.deleteTransaction(id),
-      catch: (cause) =>
-        new ActualDuplicateDeletionFailure({
-          cause,
-          retryable: isRetryableActualCause(cause),
-        }),
-    })
-  }),
-
-  sync: Effect.tryPromise({
-    try: () => api.sync(),
-    catch: (cause) =>
-      new ActualSyncFailure({
-        cause,
-        retryable: isRetryableActualCause(cause),
-      }),
-  }).pipe(Effect.withSpan("ActualClient.sync")),
-
-  shutdown: Effect.tryPromise({
-    try: () => api.shutdown(),
-    catch: (cause) => new ActualShutdownFailure({ cause, retryable: false }),
-  }).pipe(Effect.withSpan("ActualClient.shutdown")),
+    }).pipe(Effect.withSpan("ActualClient.shutdown")),
+  }
 }
 
 function isRetryableActualCause(cause: unknown): boolean {
@@ -200,7 +232,7 @@ const sdkPayeeSchema = Schema.Struct({
 
 const decodeTransactions = Effect.fn("ActualClient.decodeTransactions")(function* (
   rows: unknown,
-): Effect.fn.Return<ReadonlyArray<ExistingVariationTransaction>, ActualTransactionsReadFailure> {
+): Effect.fn.Return<ReadonlyArray<ExistingVariationTransaction>, ActualOperationFailure> {
   return yield* Schema.decodeUnknownEffect(Schema.Array(sdkTransactionRowSchema))(rows).pipe(
     Effect.map((rows) =>
       rows.flatMap((row) => {
@@ -208,7 +240,14 @@ const decodeTransactions = Effect.fn("ActualClient.decodeTransactions")(function
         return transaction ? [transaction] : []
       }),
     ),
-    Effect.mapError((cause) => new ActualTransactionsReadFailure({ cause, retryable: false })),
+    Effect.mapError(
+      (cause) =>
+        new ActualOperationFailure({
+          operation: "get_transactions",
+          cause,
+          retryable: false,
+        }),
+    ),
   )
 })
 
@@ -216,9 +255,16 @@ type SdkPayeeRow = Awaited<ReturnType<typeof api.getPayees>>[number]
 
 const decodePayees = Effect.fn("ActualClient.decodePayees")(function* (
   payees: ReadonlyArray<SdkPayeeRow>,
-): Effect.fn.Return<ReadonlyArray<ActualPayee>, ActualPayeesReadFailure> {
+): Effect.fn.Return<ReadonlyArray<ActualPayee>, ActualOperationFailure> {
   return yield* Schema.decodeEffect(Schema.Array(sdkPayeeSchema))(payees).pipe(
-    Effect.mapError((cause) => new ActualPayeesReadFailure({ cause, retryable: false })),
+    Effect.mapError(
+      (cause) =>
+        new ActualOperationFailure({
+          operation: "get_payees",
+          cause,
+          retryable: false,
+        }),
+    ),
   )
 })
 

--- a/src/actual/actual-error.ts
+++ b/src/actual/actual-error.ts
@@ -5,6 +5,7 @@ import { getErrorMessage } from "../logging.ts"
 export class ActualDataDirectoryFailure extends Schema.TaggedError<ActualDataDirectoryFailure>()(
   "ActualDataDirectoryFailure",
   {
+    path: Schema.optional(Schema.String),
     cause: Schema.Defect(),
     retryable: Schema.Boolean,
   },
@@ -31,108 +32,13 @@ export class ActualHealthCheckFailure extends Schema.TaggedError<ActualHealthChe
 export class ActualInitializationFailure extends Schema.TaggedError<ActualInitializationFailure>()(
   "ActualInitializationFailure",
   {
+    serverUrl: Schema.optional(Schema.String),
     cause: Schema.Defect(),
     retryable: Schema.Boolean,
   },
 ) {
   override get message(): string {
     return `Failed to initialize Actual API: ${getErrorMessage(this.cause)}`
-  }
-}
-
-export class ActualBudgetDownloadFailure extends Schema.TaggedError<ActualBudgetDownloadFailure>()(
-  "ActualBudgetDownloadFailure",
-  {
-    cause: Schema.Defect(),
-    retryable: Schema.Boolean,
-  },
-) {
-  override get message(): string {
-    return `Failed to download Actual budget: ${getErrorMessage(this.cause)}`
-  }
-}
-
-export class ActualTransactionsReadFailure extends Schema.TaggedError<ActualTransactionsReadFailure>()(
-  "ActualTransactionsReadFailure",
-  {
-    cause: Schema.Defect(),
-    retryable: Schema.Boolean,
-  },
-) {
-  override get message(): string {
-    return `Failed to fetch Actual transactions: ${getErrorMessage(this.cause)}`
-  }
-}
-
-export class ActualPayeesReadFailure extends Schema.TaggedError<ActualPayeesReadFailure>()(
-  "ActualPayeesReadFailure",
-  {
-    cause: Schema.Defect(),
-    retryable: Schema.Boolean,
-  },
-) {
-  override get message(): string {
-    return `Failed to fetch Actual payees: ${getErrorMessage(this.cause)}`
-  }
-}
-
-export class ActualTransactionCreationFailure extends Schema.TaggedError<ActualTransactionCreationFailure>()(
-  "ActualTransactionCreationFailure",
-  {
-    cause: Schema.Defect(),
-    retryable: Schema.Boolean,
-  },
-) {
-  override get message(): string {
-    return `Failed to add Actual transaction: ${getErrorMessage(this.cause)}`
-  }
-}
-
-export class ActualTransactionUpdateFailure extends Schema.TaggedError<ActualTransactionUpdateFailure>()(
-  "ActualTransactionUpdateFailure",
-  {
-    cause: Schema.Defect(),
-    retryable: Schema.Boolean,
-  },
-) {
-  override get message(): string {
-    return `Failed to update Actual transaction: ${getErrorMessage(this.cause)}`
-  }
-}
-
-export class ActualDuplicateDeletionFailure extends Schema.TaggedError<ActualDuplicateDeletionFailure>()(
-  "ActualDuplicateDeletionFailure",
-  {
-    cause: Schema.Defect(),
-    retryable: Schema.Boolean,
-  },
-) {
-  override get message(): string {
-    return `Failed to delete duplicate Actual transaction: ${getErrorMessage(this.cause)}`
-  }
-}
-
-export class ActualSyncFailure extends Schema.TaggedError<ActualSyncFailure>()(
-  "ActualSyncFailure",
-  {
-    cause: Schema.Defect(),
-    retryable: Schema.Boolean,
-  },
-) {
-  override get message(): string {
-    return `Failed to sync Actual budget: ${getErrorMessage(this.cause)}`
-  }
-}
-
-export class ActualShutdownFailure extends Schema.TaggedError<ActualShutdownFailure>()(
-  "ActualShutdownFailure",
-  {
-    cause: Schema.Defect(),
-    retryable: Schema.Boolean,
-  },
-) {
-  override get message(): string {
-    return `Failed to shutdown Actual API: ${getErrorMessage(this.cause)}`
   }
 }
 
@@ -148,15 +54,31 @@ export class ActualInvalidStartingDate extends Schema.TaggedError<ActualInvalidS
   }
 }
 
+export class ActualOperationFailure extends Schema.TaggedError<ActualOperationFailure>()(
+  "ActualOperationFailure",
+  {
+    operation: Schema.Literals([
+      "download_budget",
+      "get_transactions",
+      "get_payees",
+      "create_transaction",
+      "update_transaction",
+      "delete_transaction",
+      "sync",
+      "shutdown",
+    ]),
+    cause: Schema.Defect(),
+    retryable: Schema.Boolean,
+  },
+) {
+  override get message(): string {
+    return `Actual ${this.operation} failed: ${getErrorMessage(this.cause)}`
+  }
+}
+
 export type ActualError =
   | ActualDataDirectoryFailure
   | ActualHealthCheckFailure
   | ActualInitializationFailure
-  | ActualBudgetDownloadFailure
-  | ActualTransactionsReadFailure
-  | ActualPayeesReadFailure
-  | ActualTransactionCreationFailure
-  | ActualTransactionUpdateFailure
-  | ActualDuplicateDeletionFailure
-  | ActualSyncFailure
   | ActualInvalidStartingDate
+  | ActualOperationFailure

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -91,14 +91,11 @@ it.effect("runs the assembled Fintual-to-Actual workflow once", () =>
       response("", 200),
     ])
     const actualClient: ActualClient = {
-      downloadBudget: () => Effect.void,
-      getTransactions: () => Effect.succeed([]),
-      getPayees: Effect.succeed([{ id: "payee-id", name: "Fintual" }]),
-      createTransaction: (_accountId, transaction) =>
-        Effect.sync(() => calls.push(`create:${transaction.date}`)),
-      updateTransaction: () => Effect.void,
-      deleteTransaction: () => Effect.void,
-      sync: Effect.void,
+      reconcile: (snapshot, options) =>
+        Effect.sync(() => {
+          calls.push(`reconcile:${snapshot.balance.length}:${options.accountId}`)
+          return { created: 1, updated: 0, deletedDuplicates: 0 }
+        }),
       shutdown: Effect.void,
     }
     const fintualLayer = FintualPerformance.layer
@@ -119,7 +116,7 @@ it.effect("runs the assembled Fintual-to-Actual workflow once", () =>
     const job = yield* Effect.service(Job).pipe(Effect.provide(rootLayer))
     yield* job.synchronize()
 
-    expect(calls).toEqual(["create:2026-07-01"])
+    expect(calls).toEqual(["reconcile:1:account-id"])
     expect(script.requests).toHaveLength(5)
   }),
 )


### PR DESCRIPTION
## Summary

Deepen the Actual adapter (`ActualClient`) by consolidating 8 low-level SDK pass-through methods and 8 redundant error classes into a single high-leverage reconciliation operation (`reconcile`).

## Changes

- **Adapter Seam & Implementation** (`src/actual/actual-client.ts`):
  - Reshaped `ActualClient` interface from 8 granular SDK pass-through methods down to `reconcile` and `shutdown`.
  - Encapsulated budget downloading, transaction reading, row decoding, payee resolution, reconciliation planning, mutation batching, and syncing inside `ActualClientLive`.
- **Error Taxonomy Consolidation** (`src/actual/actual-error.ts`):
  - Collapsed the 8 redundant SDK operation failure classes into `ActualOperationFailure`, carrying `operation`, `cause`, and `retryable`.
  - Retained distinct error classes for health check, data directory reset, initialization, and starting date validation.
- **Simplified Orchestration** (`src/actual.ts`):
  - Simplified `ActualSynchronization` to manage the attempt lifecycle (health check probe, filesystem reset, starting date validation, scoped client acquisition, and retry schedule) while delegating reconciliation execution directly to `client.reconcile(...)`.
  - Removed private SDK sequencing helpers from orchestration.
- **Tests** (`src/actual.test.ts`, `src/actual/actual-client.test.ts`, `src/app.test.ts`):
  - Decoupled `ActualSynchronization` tests from internal SDK call sequences, testing attempt boundaries through `reconcile`.
  - Tested `ActualClientLive.reconcile` against mocked `@actual-app/api` for download, row decoding, payee resolution, mutation execution, and syncing.