### PR TITLE
chore: remove Ofelia container and references

### DIFF
--- a/.compose.env
+++ b/.compose.env
@@ -1,4 +1,3 @@
 # Intentionally separate from .runtime.env.
 # Use this file with `docker compose --env-file .compose.env ...` so Compose
 # does not try to interpolate secrets from your runtime env file.
-OFELIA_SYNC_SCHEDULE=@every 1m

--- a/README.md
+++ b/README.md
@@ -179,25 +179,12 @@ docker compose --env-file .compose.env up -d --build
 docker exec -it fintual-api-local pnpm once
 ```
 
-The compose stack also starts `ofelia`, so you can test the scheduled `job-exec` path and inspect scheduler logs:
-
-```bash
-docker logs -f fintual-api-ofelia
-```
-
-Set `OFELIA_SYNC_SCHEDULE` in `.compose.env` if you want a faster local test cadence, for example:
-
-```dotenv
-OFELIA_SYNC_SCHEDULE=@every 5m
-```
-
 If you keep runtime secrets in Secret Manager, fetch `GMAIL_APP_PASSWORD` at deploy time and inject it into the homelab runtime env instead of storing it in compose files.
 
 Useful commands while debugging:
 
 ```bash
 docker logs -f fintual-api-local
-docker logs -f fintual-api-ofelia
 docker exec -it fintual-api-local sh
 docker exec -it fintual-api-local pnpm once
 docker compose --env-file .compose.env down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,25 +12,4 @@ services:
     ports:
       - "3000:3000"
     command: ["sleep", "infinity"]
-    labels:
-      ofelia.enabled: "true"
-      ofelia.job-exec.fintual-sync.schedule: "${OFELIA_SYNC_SCHEDULE:-0 0 21 * * 1-5}"
-      ofelia.job-exec.fintual-sync.command: "pnpm once"
-      ofelia.job-exec.fintual-sync.no-overlap: "true"
-    restart: unless-stopped
-
-  ofelia:
-    image: mcuadros/ofelia:0.3.22@sha256:efcbe2c5cf658a25de6443c1462d653f9cc03791d642e01fc6c638a00f97e492
-    container_name: fintual-api-ofelia
-    depends_on:
-      - fintual-api
-    command:
-      - daemon
-      - --docker
-      - -f
-      - label=com.docker.compose.project=fintual-api
-    environment:
-      TZ: America/Santiago
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: unless-stopped

--- a/renovate.json
+++ b/renovate.json
@@ -18,12 +18,6 @@
 		},
 		{
 			"matchPackageNames": [
-				"mcuadros/ofelia"
-			],
-			"allowedVersions": "!/^v3\\.0\\.8$/"
-		},
-		{
-			"matchPackageNames": [
 				"@actual-app/api"
 			],
 			"minimumReleaseAge": "0 days",


### PR DESCRIPTION
## Summary

Remove the remaining references to Ofelia now that the in-process Effect scheduler (introduced in v3) replaces external container scheduling:

- Drop the `ofelia` container service and `ofelia.*` labels from `docker-compose.yml`
- Remove `OFELIA_SYNC_SCHEDULE` from `.compose.env`
- Remove Ofelia log instructions and configuration references from `README.md`
- Remove the `mcuadros/ofelia` package rule from `renovate.json`